### PR TITLE
fix: add missing registry package detail API route

### DIFF
--- a/apps/web-next/src/app/api/v1/registry/packages/[name]/route.ts
+++ b/apps/web-next/src/app/api/v1/registry/packages/[name]/route.ts
@@ -11,8 +11,33 @@ import { prisma } from '@/lib/db';
 import { success, errors, getAuthToken } from '@/lib/api/response';
 import { validateSession } from '@/lib/api/auth';
 
+/**
+ * In Next.js 15 App Router, route params are async (Promise-based).
+ * This is the standard pattern used across all route files in this project.
+ * See: https://nextjs.org/docs/app/api-reference/file-conventions/route#context-optional
+ */
 interface RouteParams {
   params: Promise<{ name: string }>;
+}
+
+/** Shared Prisma include for consistent response shape across GET and PUT. */
+const packageInclude = {
+  versions: {
+    where: { deprecated: false },
+    orderBy: { publishedAt: 'desc' as const },
+  },
+  _count: {
+    select: { installations: true },
+  },
+};
+
+/** Enrich a raw Prisma package with computed fields for the API response. */
+function enrichPackage(pkg: { versions: { version: string }[]; _count: { installations: number }; [key: string]: unknown }) {
+  return {
+    ...pkg,
+    latestVersion: pkg.versions[0]?.version ?? null,
+    installedCount: pkg._count.installations,
+  };
 }
 
 /**
@@ -29,28 +54,14 @@ export async function GET(
 
     const pkg = await prisma.pluginPackage.findUnique({
       where: { name },
-      include: {
-        versions: {
-          where: { deprecated: false },
-          orderBy: { publishedAt: 'desc' },
-        },
-        _count: {
-          select: { installations: true },
-        },
-      },
+      include: packageInclude,
     });
 
     if (!pkg) {
       return errors.notFound('Package');
     }
 
-    return success({
-      package: {
-        ...pkg,
-        latestVersion: pkg.versions[0]?.version ?? null,
-        installedCount: pkg._count.installations,
-      },
-    });
+    return success({ package: enrichPackage(pkg) });
   } catch (err) {
     console.error('Error fetching package details:', err);
     return errors.internal('Failed to fetch package details');
@@ -90,17 +101,20 @@ export async function PUT(
       return errors.notFound('Package');
     }
 
-    // Authorisation: admin or publisher owner
-    const isAdmin =
-      authUser.roles?.includes('system:admin') ||
-      authUser.email === 'admin@livepeer.org';
+    // Authorisation: role-based admin check only (no hard-coded emails)
+    const isAdmin = authUser.roles?.includes('system:admin') === true;
 
     let hasAccess = false;
-    if (!pkg.publisherId) hasAccess = true; // unowned package
-    else if (isAdmin) hasAccess = true;
-    else if (pkg.publisher && authUser.email && pkg.publisher.email === authUser.email) {
+    if (isAdmin) {
+      // Admins can update any package
+      hasAccess = true;
+    } else if (!pkg.publisherId) {
+      // Unowned packages can only be updated by admins
+      hasAccess = false;
+    } else if (pkg.publisher && authUser.email && pkg.publisher.email === authUser.email) {
       hasAccess = true;
     } else {
+      // Check if the user owns the publisher account linked to this package
       const userPublisher = await prisma.publisher.findFirst({
         where: { email: authUser.email || '' },
       });
@@ -111,8 +125,15 @@ export async function PUT(
       return errors.forbidden('You do not own this package');
     }
 
-    // Parse body — only allow safe fields
-    const body = await request.json();
+    // Parse body — catch malformed JSON explicitly
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return errors.badRequest('Invalid JSON in request body');
+    }
+
+    // Only allow safe, known fields
     const allowedFields: Record<string, unknown> = {};
     if (body.displayName !== undefined) allowedFields.displayName = body.displayName;
     if (body.description !== undefined) allowedFields.description = body.description;
@@ -128,15 +149,10 @@ export async function PUT(
     const updated = await prisma.pluginPackage.update({
       where: { name },
       data: allowedFields,
-      include: {
-        versions: {
-          where: { deprecated: false },
-          orderBy: { publishedAt: 'desc' },
-        },
-      },
+      include: packageInclude,
     });
 
-    return success({ package: updated });
+    return success({ package: enrichPackage(updated) });
   } catch (err) {
     console.error('Error updating package:', err);
     return errors.internal('Failed to update package');


### PR DESCRIPTION
## Summary

- Add the missing `GET /api/v1/registry/packages/:name` Next.js API route that was causing 404 errors when viewing plugin details in the Plugin Publisher
- Also add `PUT /api/v1/registry/packages/:name` for authenticated package metadata updates (owner/admin only)
- The route existed in `base-svc` (Express) but was never ported to the Next.js API layer

## Root Cause

The frontend's `getPackage()` and `getPluginStats()` functions in `plugins/plugin-publisher/frontend/src/lib/api.ts` call `/api/v1/registry/packages/${name}`, but in production `BASE_SVC_URL` is empty string (same-origin), routing to the Next.js app. The Next.js app had the list endpoint (`/api/v1/registry/packages`) and the reviews sub-route (`/api/v1/registry/packages/[name]/reviews`) but was missing the single-package detail endpoint.

## Changes

| File | Change |
|------|--------|
| `apps/web-next/src/app/api/v1/registry/packages/[name]/route.ts` | **New** — GET returns package with versions + install count; PUT allows owner/admin metadata updates |

## Test Plan

- [ ] Navigate to Plugin Publisher → My Plugins → click a plugin → detail page loads without 404
- [ ] Stats chart loads correctly on the detail page
- [ ] Plugin status changes (publish/unlist/deprecate) work from the detail page
- [ ] TypeScript compilation passes with no new errors

Closes #46

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to retrieve comprehensive package details, including non-deprecated versions sorted by publish date and a total installations count.
  * Added an API to update package metadata (display name, description, category, icon, keywords, repository) with authentication and role-based access control; rejects invalid or empty updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->