### PR TITLE
fix(middleware): remove redirect on stale token so login page can load

### DIFF
--- a/apps/web-next/src/middleware.ts
+++ b/apps/web-next/src/middleware.ts
@@ -202,13 +202,6 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  // Check if authenticated user is trying to access auth routes
-  if (authRoutes.some(route => pathname.startsWith(route))) {
-    if (token) {
-      return NextResponse.redirect(new URL('/dashboard', request.url));
-    }
-  }
-
   const response = NextResponse.next();
   response.headers.set('x-request-id', requestId);
   response.headers.set('x-trace-id', traceId);


### PR DESCRIPTION
## Summary

Fixes a bug where users with a stale or invalid auth token were unable to reach the login page. Middleware redirected them to the dashboard, which would then fail auth and could leave the app stuck. This PR lets the login page load for auth routes regardless of token presence, and validates the token client-side so valid sessions still redirect to the dashboard.

## Changes

- **middleware.ts**: Removed the redirect that sent users with a token from `/login` and `/register` to `/dashboard`. Auth routes are now allowed through; `AuthProvider` handles validation and redirects.
- **login/page.tsx**: Added a `useEffect` that redirects authenticated users to `/dashboard` when `AuthProvider` confirms a valid session.
- **login/page.tsx**: Imported `useRouter` for the redirect logic.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Tooling
- [ ] Plugin (new or update)
- [ ] Dependencies

## Plugin(s) Affected

<!-- If this is a plugin PR, list the plugin name(s). Leave blank for core changes. -->

## Checklist

- [x] Tests pass locally
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] No new lint warnings introduced
- [ ] Breaking changes documented below
- [ ] Database migration included (if Prisma schema changed)

## Breaking Changes

None

## Screenshots / Recordings

<!-- For UI changes, attach screenshots or a short recording. Delete this section if not applicable. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login page now performs a safe client-side redirect to the dashboard (or a provided return path) when users are already authenticated, preventing unnecessary access to the login form.

* **Chores**
  * Removed the automatic server-side redirect that previously blocked authenticated users from visiting auth pages, allowing direct access when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->