### PR TITLE
fix(community): resolve TDZ - votedPosts used before initialization

### DIFF
--- a/plugins/community/frontend/src/pages/Forum.tsx
+++ b/plugins/community/frontend/src/pages/Forum.tsx
@@ -57,8 +57,6 @@ export const ForumPage: React.FC = () => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const postsLengthRef = useRef(0);
   const votedPostsRef = useRef<Set<string>>(new Set());
-  postsLengthRef.current = posts.length;
-  votedPostsRef.current = votedPosts;
   const [searchQuery, setSearchQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'recent' | 'popular' | 'unanswered'>('recent');
@@ -66,6 +64,9 @@ export const ForumPage: React.FC = () => {
   const [votedPosts, setVotedPosts] = useState<Set<string>>(new Set());
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [tags, setTags] = useState<TagType[]>([]);
+
+  postsLengthRef.current = posts.length;
+  votedPostsRef.current = votedPosts;
 
   const LIMIT = 20;
 


### PR DESCRIPTION
Fixes Community Hub load error: `Cannot access 'k' before initialization` at Forum.tsx:61.

**Root cause:** `votedPostsRef.current = votedPosts` was executed before `votedPosts` was declared (useState on line 66), causing a temporal dead zone error.

**Fix:** Move ref sync assignments (`postsLengthRef.current`, `votedPostsRef.current`) to after all useState declarations.

Made with [Cursor](https://cursor.com)