### PR TITLE
fix(vercel): revert npm ci to npm install — restore build speed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "framework": "nextjs",
   "buildCommand": "./bin/vercel-build.sh",
   "outputDirectory": "apps/web-next/.next",
-  "installCommand": "export DATABASE_URL=\"${DATABASE_URL:-$POSTGRES_PRISMA_URL}\" && npm ci --include=dev",
+  "installCommand": "export DATABASE_URL=\"${DATABASE_URL:-$POSTGRES_PRISMA_URL}\" && npm install --include=dev",
   "regions": ["iad1"],
   "git": {
     "deploymentEnabled": true


### PR DESCRIPTION
## Problem

Main branch Vercel builds exceeded 2 minutes after PR #86 switched installCommand from npm install to npm ci.

## Root cause

npm ci deletes node_modules before installing, which bypasses Vercel's automatic node_modules cache. Every build becomes a full reinstall instead of an incremental update when the cache is warm.

## Fix

Revert to npm install so Vercel can reuse cached dependencies between deploys.

Also update docs/VERCEL_BUILD_OPTIMIZATION.md to document this finding.

Made with [Cursor](https://cursor.com)