### PR TITLE
fix(start): align PLUGIN_SCHEMAS with schema.prisma and init-schemas (#95)

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -442,13 +442,18 @@ UNIFIED_DB_NAME="naap"
 UNIFIED_DB_URL="postgresql://postgres:postgres@localhost:5432/naap"
 
 # PostgreSQL schemas expected in the unified database.
-# If you add a new plugin schema, add it here AND in docker/init-schemas.sql
-# AND in packages/database/prisma/schema.prisma (schemas array).
+# Must match packages/database/prisma/schema.prisma (schemas array) and docker/init-schemas.sql.
+# Core plugins (plugins/): community, capacity, developer-api.
+# Example plugins (examples/): wallet, dashboard, daydream, gateway — kept for backward compat.
 PLUGIN_SCHEMAS=(
   "public"
   "plugin_community"
   "plugin_capacity"
   "plugin_developer_api"
+  "plugin_wallet"
+  "plugin_dashboard"
+  "plugin_daydream"
+  "plugin_gateway"
 )
 
 get_all_plugins() {


### PR DESCRIPTION
## Summary
Aligns `PLUGIN_SCHEMAS` in `bin/start.sh` with `packages/database/prisma/schema.prisma` and `docker/init-schemas.sql` per issue #95.

## Changes
- Add `plugin_wallet`, `plugin_dashboard`, `plugin_daydream`, `plugin_gateway` to PLUGIN_SCHEMAS
- These schemas are still used by example plugins (in examples/) when developers run them
- Ensures consistency across the three files

## Testing
- `./bin/start.sh validate` — all schema checks pass

Fixes #95

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new plugins: Wallet, Dashboard, Daydream, and Gateway. These plugins are now available for automatic discovery and health monitoring, expanding the platform's capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->