### PR TITLE
fix(vercel): add @aws-sdk/client-s3 to web-next for unzipper resolution

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -47,7 +47,8 @@
     "shiki": "^3.22.0",
     "unzipper": "^0.12.3",
     "zod": "^3.23.8",
-    "zustand": "^5.0.0"
+    "zustand": "^5.0.0",
+    "@aws-sdk/client-s3": "^3.989.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "name": "@naap/web-next",
       "version": "0.0.1",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.989.0",
         "@naap/config": "*",
         "@naap/database": "*",
         "@naap/plugin-sdk": "*",
@@ -668,6 +669,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.990.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.990.0.tgz",
+      "integrity": "sha512-XnsM8RgB35Atn2+aYSocitCybDG82x9yYf/s2D23ytpyHCupmuZN3LzK2a0WxmKO6Zf7EtEIYy0mHGY4tLp9YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.10",
+        "@aws-sdk/credential-provider-node": "^3.972.9",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.3",
+        "@aws-sdk/middleware-expect-continue": "^3.972.3",
+        "@aws-sdk/middleware-flexible-checksums": "^3.972.8",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-location-constraint": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.10",
+        "@aws-sdk/middleware-ssec": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.10",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/signature-v4-multi-region": "3.990.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.990.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.8",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.23.0",
+        "@smithy/eventstream-serde-browser": "^4.2.8",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
+        "@smithy/eventstream-serde-node": "^4.2.8",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-blob-browser": "^4.2.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/hash-stream-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/md5-js": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.14",
+        "@smithy/middleware-retry": "^4.4.31",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.30",
+        "@smithy/util-defaults-mode-node": "^4.2.33",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.990.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.990.0.tgz",
@@ -711,22 +778,6 @@
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
         "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
-      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1102,22 +1153,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
-      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/nested-clients": {
       "version": "3.990.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.990.0.tgz",
@@ -1167,22 +1202,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
-      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.972.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
@@ -1192,6 +1211,23 @@
         "@aws-sdk/types": "^3.973.1",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.990.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.990.0.tgz",
+      "integrity": "sha512-O55s1eFmKi+2Ko5T1hbdxL6tFVONGscSVe9VRxS4m91Tlbo9iG2Q2HvKWq1DuKQAuUWSUfMmjrRt07JNzizr2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.10",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -1236,6 +1272,22 @@
       "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.990.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
+      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -34227,72 +34279,6 @@
         "typescript": "^5.9.3"
       }
     },
-    "services/storage-svc/node_modules/@aws-sdk/client-s3": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.990.0.tgz",
-      "integrity": "sha512-XnsM8RgB35Atn2+aYSocitCybDG82x9yYf/s2D23ytpyHCupmuZN3LzK2a0WxmKO6Zf7EtEIYy0mHGY4tLp9YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.10",
-        "@aws-sdk/credential-provider-node": "^3.972.9",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.3",
-        "@aws-sdk/middleware-expect-continue": "^3.972.3",
-        "@aws-sdk/middleware-flexible-checksums": "^3.972.8",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-location-constraint": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.10",
-        "@aws-sdk/middleware-ssec": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.10",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/signature-v4-multi-region": "3.990.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.990.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.8",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.0",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-        "@smithy/eventstream-serde-node": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-blob-browser": "^4.2.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/hash-stream-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/md5-js": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.14",
-        "@smithy/middleware-retry": "^4.4.31",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.30",
-        "@smithy/util-defaults-mode-node": "^4.2.33",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.12",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "services/storage-svc/node_modules/@aws-sdk/lib-storage": {
       "version": "3.990.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.990.0.tgz",
@@ -34312,39 +34298,6 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3.990.0"
-      }
-    },
-    "services/storage-svc/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.990.0.tgz",
-      "integrity": "sha512-O55s1eFmKi+2Ko5T1hbdxL6tFVONGscSVe9VRxS4m91Tlbo9iG2Q2HvKWq1DuKQAuUWSUfMmjrRt07JNzizr2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.10",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "services/storage-svc/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
-      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "services/storage-svc/node_modules/@types/uuid": {


### PR DESCRIPTION
## Problem
Vercel builds fail on main and PRs with:
```
Module not found: Can't resolve '@aws-sdk/client-s3'
Import trace: unzipper/unzip.js -> ./src/app/api/v1/plugin-publisher/upload/route.ts
```

## Cause
`unzipper` declares `@aws-sdk/client-s3` as an optional dependency but imports it unconditionally in `Open/index.js`. When webpack bundles the plugin-publisher upload route, it resolves unzipper and fails because `@aws-sdk/client-s3` is not in web-next's dependency tree.

## Fix
Add `@aws-sdk/client-s3` to `apps/web-next/package.json` dependencies. Version `^3.989.0` matches `storage-svc`.

## Verification
- `./bin/vercel-build.sh` passes locally

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to support enhanced backend infrastructure and storage capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->