### PR TITLE
chore: add PR 87 plugin registry cleanup and migration

### DIFF
--- a/apps/web-next/prisma/seed.ts
+++ b/apps/web-next/prisma/seed.ts
@@ -617,8 +617,15 @@ async function main() {
   // ============================================
   console.log('⭐ Creating user plugin preferences for core plugins...');
 
-  // Core plugins that should be visible to all users
-  const corePluginNames = ['marketplace', 'pluginPublisher'];
+  // Core plugins that should be visible to all users (PR 87: 6 remaining in plugins/)
+  const corePluginNames = [
+    'marketplace',
+    'pluginPublisher',
+    'developerApi',
+    'community',
+    'capacityPlanner',
+    'dashboardProviderMock',
+  ];
   
   const allUsersForPrefs = await prisma.user.findMany({ select: { id: true } });
   let prefCount = 0;

--- a/bin/cleanup-moved-plugins.ts
+++ b/bin/cleanup-moved-plugins.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env npx tsx
+/**
+ * cleanup-moved-plugins.ts
+ *
+ * One-time cleanup script for PR 87: removes/deprecates the 6 plugins moved
+ * from plugins/ to examples/. Run against production (Vercel) or any database
+ * to align the plugin registry and user preferences with PR 87's changes.
+ *
+ * Plugins moved to examples/ (removed from registry):
+ *   - gateway-manager, orchestrator-manager, network-analytics
+ *   - my-wallet, daydream-video, my-dashboard
+ *
+ * Remaining plugins (6 in plugins/):
+ *   - capacity-planner, community, dashboard-provider-mock
+ *   - developer-api, marketplace, plugin-publisher
+ *
+ * Usage:
+ *   DATABASE_URL="postgresql://..." npx tsx bin/cleanup-moved-plugins.ts
+ *   # Or with Vercel Postgres:
+ *   POSTGRES_PRISMA_URL="..." npx tsx bin/cleanup-moved-plugins.ts
+ *
+ * Options:
+ *   --dry-run   Log actions without committing
+ *   --force     Skip confirmation prompt (for CI/automation)
+ */
+
+import { PrismaClient } from '../packages/database/src/generated/client/index.js';
+
+async function main(): Promise<void> {
+  const dbUrl =
+    process.env.DATABASE_URL ||
+    process.env.POSTGRES_PRISMA_URL ||
+    process.env.POSTGRES_URL ||
+    '';
+
+  if (!dbUrl) {
+    console.error(
+      '[cleanup-moved-plugins] No database URL. Set DATABASE_URL or POSTGRES_PRISMA_URL.',
+    );
+    process.exit(1);
+  }
+
+  const dryRun = process.argv.includes('--dry-run');
+  const force = process.argv.includes('--force');
+
+  if (!force && !dryRun) {
+    console.log('This will clean up 6 moved plugins from the registry and user preferences.');
+    console.log('Press Ctrl+C to cancel, or run with --force to skip confirmation.');
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+
+  const prisma = new PrismaClient({ datasources: { db: { url: dbUrl } } });
+
+  try {
+    console.log('[cleanup-moved-plugins] Starting cleanup...\n');
+
+    // 1. WorkflowPlugin: soft-disable (camelCase names from plugin-discovery)
+    const workflowPlugins = await prisma.workflowPlugin.findMany({
+      where: {
+        name: {
+          in: [
+            'gatewayManager',
+            'orchestratorManager',
+            'networkAnalytics',
+            'myWallet',
+            'daydreamVideo',
+            'myDashboard',
+          ],
+        },
+      },
+      select: { name: true, enabled: true },
+    });
+
+    for (const p of workflowPlugins) {
+      if (p.enabled) {
+        console.log(`  [WorkflowPlugin] Disabling ${p.name}`);
+        if (!dryRun) {
+          await prisma.workflowPlugin.update({
+            where: { name: p.name },
+            data: { enabled: false },
+          });
+        }
+      }
+    }
+
+    // 2. PluginPackage: unlist (find by name, handle both camel and kebab)
+    const packages = await prisma.pluginPackage.findMany({
+      where: { publishStatus: 'published' },
+      select: {
+        id: true,
+        name: true,
+        deployment: { select: { id: true } },
+      },
+    });
+
+    const toUnlist = packages.filter((p) => {
+      const norm = p.name.toLowerCase().replace(/[-_]/g, '');
+      return (
+        norm === 'gatewaymanager' ||
+        norm === 'orchestratormanager' ||
+        norm === 'networkanalytics' ||
+        norm === 'mywallet' ||
+        norm === 'daydreamvideo' ||
+        (norm === 'mydashboard' && !p.name.includes('Provider'))
+      );
+    });
+
+    for (const pkg of toUnlist) {
+      console.log(`  [PluginPackage] Unlisting ${pkg.name}`);
+      if (!dryRun) {
+        await prisma.pluginPackage.update({
+          where: { id: pkg.id },
+          data: { publishStatus: 'unlisted' },
+        });
+      }
+
+      // 3 & 4. TenantPluginInstall, TeamPluginInstall: delete for this package's deployment
+      const dep = pkg.deployment;
+      if (dep) {
+        const tenantCount = await prisma.tenantPluginInstall.count({
+          where: { deploymentId: dep.id },
+        });
+        if (tenantCount > 0) {
+          console.log(`    [TenantPluginInstall] Deleting ${tenantCount} for ${pkg.name}`);
+          if (!dryRun) {
+            await prisma.tenantPluginInstall.deleteMany({
+              where: { deploymentId: dep.id },
+            });
+          }
+        }
+
+        const teamCount = await prisma.teamPluginInstall.count({
+          where: { deploymentId: dep.id },
+        });
+        if (teamCount > 0) {
+          console.log(`    [TeamPluginInstall] Deleting ${teamCount} for ${pkg.name}`);
+          if (!dryRun) {
+            await prisma.teamPluginInstall.deleteMany({
+              where: { deploymentId: dep.id },
+            });
+          }
+        }
+      }
+    }
+
+    // 5. UserPluginPreference: delete for moved plugins (match any variant)
+    const prefs = await prisma.userPluginPreference.findMany({
+      select: { id: true, pluginName: true },
+    });
+
+    const prefToDelete = prefs.filter((p) => {
+      const norm = p.pluginName.toLowerCase().replace(/[-_]/g, '');
+      return (
+        norm === 'gatewaymanager' ||
+        norm === 'orchestratormanager' ||
+        norm === 'networkanalytics' ||
+        norm === 'mywallet' ||
+        norm === 'daydreamvideo' ||
+        (norm === 'mydashboard' && !p.pluginName.toLowerCase().includes('provider'))
+      );
+    });
+
+    for (const pref of prefToDelete) {
+        console.log(`  [UserPluginPreference] Deleting preference for ${pref.pluginName}`);
+      if (!dryRun) {
+        await prisma.userPluginPreference.delete({
+          where: { id: pref.id },
+        });
+      }
+    }
+
+    // 6. Ensure developerApi is core (per PR 87's 9d4e65a)
+    const devApi = await prisma.pluginPackage.findUnique({
+      where: { name: 'developerApi' },
+      select: { id: true, isCore: true },
+    });
+    if (devApi && !devApi.isCore) {
+      console.log('  [PluginPackage] Marking developerApi as core');
+      if (!dryRun) {
+        await prisma.pluginPackage.update({
+          where: { name: 'developerApi' },
+          data: { isCore: true },
+        });
+      }
+    }
+
+    if (dryRun) {
+      console.log('\n[cleanup-moved-plugins] Dry run complete. No changes applied.');
+    } else {
+      console.log('\n[cleanup-moved-plugins] Cleanup complete.');
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('[cleanup-moved-plugins] Fatal error:', err);
+  process.exit(1);
+});

--- a/bin/vercel-build.sh
+++ b/bin/vercel-build.sh
@@ -73,6 +73,14 @@ cd apps/web-next || { echo "ERROR: Failed to cd to apps/web-next"; exit 1; }
 npm run build
 cd ../.. || { echo "ERROR: Failed to cd back to root"; exit 1; }
 
+# Step 5: (Optional) One-time cleanup for PR 87 moved plugins
+# Set RUN_PLUGIN_CLEANUP=1 in Vercel env to run once, then remove.
+# Cleans UserPluginPreference, TenantPluginInstall, TeamPluginInstall for moved plugins.
+if [ "${RUN_PLUGIN_CLEANUP}" = "1" ] && [ "${VERCEL_ENV}" = "production" ] && [ -n "$DATABASE_URL" ]; then
+  echo "[5a/5] Running plugin cleanup (PR 87)..."
+  npx tsx bin/cleanup-moved-plugins.ts --force 2>&1 || echo "WARN: cleanup had issues (non-fatal)"
+fi
+
 # Step 5: Sync plugin registry in database
 # Always run — it's idempotent (upserts) and fast (~2-3s).
 # This ensures stale plugins are cleaned up when plugins are removed,

--- a/docs/MIGRATION_PR87.md
+++ b/docs/MIGRATION_PR87.md
@@ -1,0 +1,43 @@
+# Migration: PR 87 Plugin Registry Cleanup
+
+After PR 87 (refactor: move 6 non-essential plugins to examples/), the production database may contain stale plugin records. This migration cleans them up so only the 6 remaining plugins are registered and visible.
+
+## Option A: Automatic (Vercel Deploy)
+
+1. In Vercel Dashboard → Project → Settings → Environment Variables, add:
+   - `RUN_PLUGIN_CLEANUP` = `1`
+2. Trigger a production deploy (push to main or redeploy).
+3. After deploy succeeds, **remove** the `RUN_PLUGIN_CLEANUP` variable.
+4. The cleanup runs only when that env var is set.
+
+## Option B: Manual Run
+
+## What Gets Cleaned
+
+- **WorkflowPlugin**: Soft-disables gatewayManager, orchestratorManager, networkAnalytics, myWallet, daydreamVideo, myDashboard
+- **PluginPackage**: Unlists those 6 from the marketplace
+- **TenantPluginInstall** / **TeamPluginInstall**: Removes installs for the 6 moved plugins
+- **UserPluginPreference**: Removes user preferences for the 6 moved plugins
+- **PluginPackage.developerApi**: Ensures `isCore: true`
+
+## Manual Run Against Vercel Postgres
+
+1. Get your Vercel Postgres connection string:
+   - Vercel Dashboard → Storage → Your Postgres → .env.local tab
+   - Or: `vercel env pull` and use `POSTGRES_PRISMA_URL` or `DATABASE_URL`
+
+2. Dry run (no changes):
+   ```bash
+   POSTGRES_PRISMA_URL="postgresql://..." npx tsx bin/cleanup-moved-plugins.ts --dry-run
+   ```
+
+3. Apply changes:
+   ```bash
+   POSTGRES_PRISMA_URL="postgresql://..." npx tsx bin/cleanup-moved-plugins.ts --force
+   ```
+
+## Post-Cleanup
+
+- The next Vercel deploy runs `sync-plugin-registry` which registers/updates the 6 remaining plugins
+- User preferences for the 6 core plugins are created on first load via the personalized API (lazy auto-install)
+- Or run the seed locally/remotely to populate preferences: `npm run db:seed`

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "db:seed": "./bin/db-seed.sh",
     "db:reset": "./bin/db-reset.sh",
     "db:migrate": "./bin/db-migrate.sh",
+    "db:cleanup-moved-plugins": "npx tsx bin/cleanup-moved-plugins.ts",
     "infra:start": "./bin/start.sh --infra",
     "plugin:list": "./bin/start.sh list",
     "logs": "./bin/start.sh logs"


### PR DESCRIPTION
## Summary
Adds cleanup tooling to align the Vercel database with PR 87: only the 6 remaining plugins (capacity-planner, community, dashboard-provider-mock, developer-api, marketplace, plugin-publisher) should be registered and visible.

## Changes
- `bin/cleanup-moved-plugins.ts`: One-time cleanup script
  - Soft-disables WorkflowPlugin for the 6 moved plugins
  - Unlists PluginPackage, deletes TenantPluginInstall/TeamPluginInstall/UserPluginPreference
  - Ensures developerApi is core
- `bin/vercel-build.sh`: Optional `RUN_PLUGIN_CLEANUP=1` env var runs cleanup on prod deploy
- `apps/web-next/prisma/seed.ts`: corePluginNames includes all 6 remaining plugins
- `docs/MIGRATION_PR87.md`: Migration instructions

## To Run Cleanup on Vercel DB
**Option A (automatic):** Set `RUN_PLUGIN_CLEANUP=1` in Vercel env vars, trigger prod deploy, then remove the var.
**Option B (manual):** `POSTGRES_PRISMA_URL="..." npx tsx bin/cleanup-moved-plugins.ts --force`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new database cleanup command (`db:cleanup-moved-plugins`) for plugin registry management.

* **Documentation**
  * Added migration guide documenting plugin registry cleanup and expected behaviors post-migration.

* **Chores**
  * Updated default plugin configuration to expand core plugins visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->