### PR TITLE
fix(quality/pr3): SDK package OCI removal + integration test runner

### DIFF
--- a/packages/plugin-sdk/cli/commands/__tests__/package.test.ts
+++ b/packages/plugin-sdk/cli/commands/__tests__/package.test.ts
@@ -383,9 +383,10 @@ describe('Package Command', () => {
 
   // Test 12: Invalid format error
   it('should reject unknown package formats', async () => {
-    const validFormats = ['tar', 'zip', 'oci'];
+    const validFormats = ['tar', 'zip'];
     const invalidFormat = 'rar';
     
     expect(validFormats.includes(invalidFormat)).toBe(false);
+    expect(validFormats.includes('oci')).toBe(false);
   });
 });

--- a/packages/plugin-sdk/cli/commands/package.ts
+++ b/packages/plugin-sdk/cli/commands/package.ts
@@ -5,7 +5,6 @@
  * Supports formats:
  * - tar: Traditional tar.gz archive
  * - zip: Standardized ZIP format for Plugin Publisher
- * - oci: OCI artifact (requires Docker)
  */
 
 import { Command } from 'commander';
@@ -85,7 +84,7 @@ async function copyDirectoryWithStats(
 export const packageCommand = new Command('package')
   .description('Create distributable plugin package')
   .option('-o, --output <dir>', 'Output directory', 'dist')
-  .option('--format <format>', 'Package format (tar, zip, oci)', 'zip')
+  .option('--format <format>', 'Package format (tar, zip)', 'zip')
   .option('--no-validate', 'Skip manifest validation')
   .option('--skip-bundle-validation', 'Skip UMD bundle validation')
   .action(async (options: {
@@ -299,13 +298,9 @@ export const packageCommand = new Command('package')
         
         // Cleanup package dir
         await fs.remove(packageDir);
-      } else if (options.format === 'oci') {
-        console.log(chalk.yellow('OCI format packaging requires Docker and registry access'));
-        archiveName = `${manifest.name}-${manifest.version}.oci`;
-        // TODO: Implement OCI artifact creation (archivePath and archiveSize unused until then)
       } else {
         console.error(chalk.red(`Unknown format: ${options.format}`));
-        console.log(chalk.yellow('Supported formats: zip, tar, oci'));
+        console.log(chalk.yellow('Supported formats: zip, tar'));
         process.exit(1);
       }
 


### PR DESCRIPTION
## Summary
- Remove unimplemented OCI packaging format from `package.ts` (was misleading TODO)
- Implement integration test runner in `test.ts`: health-check against shell, vitest execution
- Update package test to reject `oci` as invalid format

Supersedes #106 (rebuilt from `main` with clean scope).

## Files Changed (3)
- `packages/plugin-sdk/cli/commands/package.ts`
- `packages/plugin-sdk/cli/commands/test.ts`
- `packages/plugin-sdk/cli/commands/__tests__/package.test.ts`

## Test Evidence
- Package test updated to verify OCI rejection
- Integration runner implements deterministic failure modes (missing env, unreachable shell)

## Regression Impact
- OCI was never functional; removal is cleanup only
- Test runner is additive functionality

Made with [Cursor](https://cursor.com)