### PR TITLE
feat(billing): drop projectName + keyHash columns (contract part 2)

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1394,7 +1394,6 @@ model DevApiProject {
 model DevApiKey {
   id                String              @id @default(uuid())
   userId            String
-  projectName       String?
   projectId         String
   project           DevApiProject       @relation(fields: [projectId], references: [id], onDelete: Cascade)
   billingProviderId String
@@ -1403,7 +1402,6 @@ model DevApiKey {
   model             DevApiAIModel?      @relation(fields: [modelId], references: [id], onDelete: Cascade)
   gatewayOfferId    String?
   gatewayOffer      DevApiGatewayOffer? @relation(fields: [gatewayOfferId], references: [id], onDelete: SetNull)
-  keyHash           String?
   keyLookupId       String              @unique
   keyPrefix         String
   status            DevApiKeyStatus     @default(ACTIVE)

--- a/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
+++ b/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
@@ -21,9 +21,8 @@ interface AIModel {
 
 interface ApiKey {
   id: string;
-  project?: { id: string; name: string; isDefault: boolean };
-  billingProvider?: { id: string; slug: string; displayName: string };
-  projectName?: string;
+  project: { id: string; name: string; isDefault: boolean };
+  billingProvider: { id: string; slug: string; displayName: string };
   modelName: string;
   gatewayName: string;
   keyPrefix: string;
@@ -155,8 +154,8 @@ export const DeveloperView: React.FC = () => {
                           <Key size={20} className="text-accent-blue" />
                         </div>
                         <div>
-                          <p className="font-medium text-text-primary">{key.project?.name ?? key.projectName ?? 'Unknown'}</p>
-                          <p className="text-xs text-text-secondary">{key.keyPrefix} • {key.billingProvider?.displayName ?? 'Unknown'}</p>
+                          <p className="font-medium text-text-primary">{key.project.name}</p>
+                          <p className="text-xs text-text-secondary">{key.keyPrefix} • {key.billingProvider.displayName}</p>
                         </div>
                       </div>
                       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Final cleanup — drop legacy columns that are no longer used.

### Schema
- DROP \`projectName\` column from \`DevApiKey\`
- DROP \`keyHash\` column from \`DevApiKey\`

### Code
- Remove \`hashApiKey\` and \`generateApiKey\` utility functions
- Remove dual-write of \`projectName\`/\`keyHash\` from all create handlers
- Frontend \`ApiKey\` interface now requires \`project\`/\`billingProvider\` (no more optional fallbacks)
- In-memory fallback uses new data shape

### Safety
- No code references these columns after PR 3
- \`db push\` will DROP COLUMN — this is irreversible, hence gated behind the preview guard from PR 0

## Merge order

**PR 4 of 5 (final)** — merge only after PR 3 is deployed and stable.

**WARNING**: This PR drops columns. Ensure PR 0 (preview db push guard) is deployed first. Do not merge to a branch that runs \`prisma db push\` against production from preview deploys.

## Test plan

- [ ] Verify no code references \`projectName\` or \`keyHash\` on \`DevApiKey\`
- [ ] Key creation works without legacy fields
- [ ] Key list/detail responses use project/billingProvider objects exclusively
- [ ] \`prisma db push\` diff shows only DROP COLUMN (no other destructive changes)

Made with [Cursor](https://cursor.com)