### PR TITLE
feat(postinstall): add bootstrap script for workspace packages

### DIFF
--- a/bin/bootstrap-workspace-packages.cjs
+++ b/bin/bootstrap-workspace-packages.cjs
@@ -1,0 +1,120 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+const REQUIRED_ARTIFACTS = [
+  {
+    name: '@naap/plugin-build',
+    files: [
+      'packages/plugin-build/dist/index.js',
+      'packages/plugin-build/dist/vite.js',
+    ],
+  },
+  {
+    name: '@naap/cache',
+    files: [
+      'packages/cache/dist/index.js',
+      'packages/cache/dist/index.d.ts',
+    ],
+  },
+];
+
+function exists(relPath) {
+  return fs.existsSync(path.join(ROOT_DIR, relPath));
+}
+
+function getMissingArtifacts() {
+  const missing = [];
+  for (const pkg of REQUIRED_ARTIFACTS) {
+    for (const file of pkg.files) {
+      if (!exists(file)) missing.push({ pkg: pkg.name, file });
+    }
+  }
+  return missing;
+}
+
+function writeLog(logPath, content) {
+  if (!logPath) return;
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  fs.writeFileSync(logPath, content, 'utf8');
+}
+
+function runBuild(logPath) {
+  const args = [
+    'run',
+    'build',
+    '--workspace=@naap/plugin-build',
+    '--workspace=@naap/cache',
+  ];
+
+  const res = spawnSync('npm', args, {
+    cwd: ROOT_DIR,
+    encoding: 'utf8',
+    env: process.env,
+  });
+
+  const output = `${res.stdout || ''}${res.stderr || ''}`;
+  writeLog(logPath, output);
+
+  return {
+    status: res.status ?? 1,
+    error: res.error,
+    output,
+  };
+}
+
+function formatMissing(missing) {
+  const grouped = new Map();
+  for (const m of missing) {
+    if (!grouped.has(m.pkg)) grouped.set(m.pkg, []);
+    grouped.get(m.pkg).push(m.file);
+  }
+  let out = '';
+  for (const [pkg, files] of grouped.entries()) {
+    out += `- ${pkg}:\n`;
+    for (const f of files) out += `  - ${f}\n`;
+  }
+  return out.trimEnd();
+}
+
+function main() {
+  const logPath = process.env.BOOTSTRAP_LOG_PATH
+    ? path.resolve(ROOT_DIR, process.env.BOOTSTRAP_LOG_PATH)
+    : '';
+
+  const missingBefore = getMissingArtifacts();
+  if (missingBefore.length === 0) {
+    process.exit(0);
+  }
+
+  console.log('[naap] Bootstrapping workspace package build artifacts...');
+  console.log(formatMissing(missingBefore));
+
+  const build = runBuild(logPath);
+  if (build.error) {
+    console.error('[naap] Failed to run npm to build workspace packages.');
+    console.error(build.error);
+    if (logPath) console.error(`[naap] Build output written to ${logPath}`);
+    process.exit(1);
+  }
+
+  const missingAfter = getMissingArtifacts();
+  if (missingAfter.length > 0) {
+    console.error('[naap] Workspace package bootstrap did not produce required artifacts:');
+    console.error(formatMissing(missingAfter));
+    if (logPath) console.error(`[naap] Build output written to ${logPath}`);
+    process.exit(1);
+  }
+
+  if (build.status !== 0) {
+    console.warn(
+      '[naap] Workspace build reported errors, but required artifacts were produced. Continuing.',
+    );
+    if (logPath) console.warn(`[naap] Build output written to ${logPath}`);
+  }
+}
+
+main();
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ci-check:full": "./bin/pre-push-validate.sh --full",
     "test": "nx run-many --target=test --all",
     "lint": "nx run-many --target=lint --all",
+    "postinstall": "node bin/bootstrap-workspace-packages.cjs",
     "smoke": "./bin/smoke.sh",
     "e2e:plugin-publisher": "./bin/e2e-plugin-publisher.sh",
     "e2e:plugin-publisher:cleanup": "npx tsx bin/cleanup-published-examples.ts",


### PR DESCRIPTION
## Summary

Introduce a new `postinstall` script in `package.json` that runs a bootstrap script to ensure required build artifacts for `@naap/plugin-build` and `@naap/cache` are present after installation. This script checks for missing artifacts and builds the necessary packages if they are not found, improving the setup process for fresh clones.

Additionally, updated `start.sh` to call this bootstrap script as a fallback during the preflight check, ensuring workspace packages are built even when `npm install` is run with `--ignore-scripts`.

<!-- 1-3 sentences. What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed. -->
- added postinstall
- added cjs script to build workspace
- updated package.json to include postinstall command

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Tooling
- [ ] Plugin (new or update)
- [ ] Dependencies

## Plugin(s) Affected

<!-- If this is a plugin PR, list the plugin name(s). Leave blank for core changes. -->

## Checklist

- [ ] Tests pass locally
- [ ] Lint passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] No new lint warnings introduced
- [ ] Breaking changes documented below
- [ ] Database migration included (if Prisma schema changed)

## Breaking Changes

<!-- If none, write "None". Otherwise describe what breaks and migration path. -->

None

## Screenshots / Recordings

<!-- For UI changes, attach screenshots or a short recording. Delete this section if not applicable. -->
