### PR TITLE
fix(middleware): restore plugin route map — /gateway returns 404

### DIFF
--- a/apps/web-next/src/middleware.ts
+++ b/apps/web-next/src/middleware.ts
@@ -1,14 +1,29 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-// Plugin route mapping: path prefix → plugin name
-// These routes are defined in the database seed and used by plugins
+// Plugin route mapping: path prefix → plugin name (camelCase DB name).
+// Maps custom route prefixes to their plugin so the middleware can rewrite
+// e.g. /gateway → /plugins/serviceGateway.
+// Keep in sync with WorkflowPlugin.routes / plugin.json.
+// Routes with their own page.tsx (/marketplace, /dashboard) are excluded.
+// /plugins/* paths are handled by the dynamic [pluginName] route automatically.
 const PLUGIN_ROUTE_MAP: Record<string, string> = {
+  '/wallet': 'myWallet',
+  '/gateway': 'serviceGateway',
+  '/gateways': 'gatewayManager',
+  '/orchestrators': 'orchestratorManager',
   '/capacity': 'capacityPlanner',
+  '/analytics': 'networkAnalytics',
+  '/leaderboard': 'networkAnalytics',
   '/forum': 'community',
   '/developers': 'developerApi',
   '/publish': 'pluginPublisher',
-  // Note: /marketplace and /dashboard have their own page.tsx files
+  '/daydream': 'daydreamVideo',
+  '/hello': 'helloWorld',
+  '/intelligent-dashboard': 'intelligentDashboard',
+  '/todos': 'todoList',
+  '/deployments': 'deploymentManager',
+  '/lightning-client': 'lightningClient',
 };
 
 // CSP configuration for plugin pages
@@ -190,6 +205,13 @@ export function middleware(request: NextRequest) {
       const loginUrl = new URL('/login', request.url);
       loginUrl.searchParams.set('redirect', pathname);
       return NextResponse.redirect(loginUrl);
+    }
+  }
+
+  // Redirect authenticated users away from auth pages (login/register)
+  if (authRoutes.some(route => pathname === route || pathname.startsWith(`${route}/`))) {
+    if (token) {
+      return NextResponse.redirect(new URL('/dashboard', request.url));
     }
   }
 

--- a/bin/sync-plugin-registry.ts
+++ b/bin/sync-plugin-registry.ts
@@ -28,6 +28,7 @@ import {
   toPluginPackageData,
   toPluginVersionData,
   getBundleUrl,
+  toCamelCase,
 } from '../packages/database/src/plugin-discovery.js';
 import { BILLING_PROVIDERS } from '@naap/database';
 import * as path from 'path';
@@ -331,18 +332,26 @@ async function main(): Promise<void> {
     }
 
     // ------------------------------------------------------------------
-    // Auto-generate plugin-routes.json for middleware consumption
+    // Generate plugin-routes.json for middleware consumption
     // ------------------------------------------------------------------
-    // Routes that already have dedicated page.tsx files and should NOT
-    // be rewritten by the middleware to the generic plugin loader.
-    const ROUTES_WITH_DEDICATED_PAGES = new Set(['/marketplace', '/dashboard']);
-
+    const routesWithOwnPage = new Set(['/marketplace', '/dashboard', '/plugins/my-dashboard']);
     const routeMap: Record<string, string> = {};
+
     for (const p of discovered) {
-      if (!p.routes || p.routes.length === 0) continue;
-      const primaryRoute = p.routes[0]; // e.g. "/gateway"
-      if (ROUTES_WITH_DEDICATED_PAGES.has(primaryRoute)) continue;
-      routeMap[primaryRoute] = p.name;
+      const camelName = toCamelCase(p.dirName);
+      const routes: string[] = p.routes || [];
+      for (const route of routes) {
+        const baseRoute = route.replace(/\/?\*$/, '');
+        if (!baseRoute || routesWithOwnPage.has(baseRoute)) continue;
+        const existing = routeMap[baseRoute];
+        if (existing && existing !== camelName) {
+          console.warn(
+            `[sync-plugin-registry] Route collision: "${baseRoute}" claimed by both "${existing}" and "${camelName}" — keeping "${existing}"`,
+          );
+          continue;
+        }
+        routeMap[baseRoute] = camelName;
+      }
     }
 
     const generatedDir = path.join(MONOREPO_ROOT, 'apps', 'web-next', 'src', 'generated');
@@ -352,7 +361,7 @@ async function main(): Promise<void> {
     const routesPath = path.join(generatedDir, 'plugin-routes.json');
     fs.writeFileSync(routesPath, JSON.stringify(routeMap, null, 2) + '\n', 'utf-8');
     console.log(
-      `[sync-plugin-registry] Generated ${routesPath} with ${Object.keys(routeMap).length} route(s): ${Object.keys(routeMap).join(', ')}`,
+      `[sync-plugin-registry] Generated plugin-routes.json with ${Object.keys(routeMap).length} route(s): ${Object.keys(routeMap).join(', ')}`,
     );
 
     console.log('[sync-plugin-registry] Done.');

--- a/bin/vercel-build.sh
+++ b/bin/vercel-build.sh
@@ -6,8 +6,9 @@
 #   1. Build plugin UMD bundles (source-hash cache skips unchanged)
 #   2. Copy bundles to public/cdn/plugins/ for static serving
 #   3. Push schema to database (skip generate — postinstall already did it)
-#   4. Build the Next.js app
-#   5. Sync plugin records in the database
+#   4. Sync plugin records + generate plugin-routes.json (before Next.js build)
+#   5. Build the Next.js app
+#   6. Optional one-time cleanup
 #
 # Optimizations:
 #   - Source-hash caching skips unchanged plugins (build-plugins.sh)
@@ -33,24 +34,24 @@ echo "Environment: ${VERCEL_ENV:-unknown}"
 # When CI restores a valid plugin cache (content-based key), skip plugin build to avoid stale output.
 # SKIP_PLUGIN_BUILD is set by .github/workflows/ci.yml when plugin cache hits.
 if [ "${SKIP_PLUGIN_BUILD}" = "true" ] && [ -d "dist/plugins" ] && [ -n "$(ls -A dist/plugins 2>/dev/null)" ]; then
-  echo "[0/5] Skipping plugin build (CI cache hit — dist/plugins restored)"
-  echo "[1/5] Skipping plugin bundles (using cached dist/plugins)"
+  echo "[0/6] Skipping plugin build (CI cache hit — dist/plugins restored)"
+  echo "[1/6] Skipping plugin bundles (using cached dist/plugins)"
 else
   # Build plugin-build (and plugin-utils) so plugin vite configs resolve to dist/.js
   # Plugin vite.config.ts imports @naap/plugin-build/vite; Node ESM cannot load .ts directly.
-  echo "[0/5] Building plugin-build package..."
+  echo "[0/6] Building plugin-build package..."
   npx tsc -p packages/plugin-build/tsconfig.json || { echo "ERROR: plugin-build build failed"; exit 1; }
   (cd packages/plugin-utils && npm run build --if-present) || true
 
   # Step 1: Build plugin UMD bundles
   # Production and preview: build all plugins. Source-hash caching in build-plugins.sh
   # skips unchanged plugins, so --parallel is efficient for both.
-  echo "[1/5] Building plugin bundles..."
+  echo "[1/6] Building plugin bundles..."
   ./bin/build-plugins.sh --parallel
 fi
 
 # Step 2: Copy built bundles to public/ for static serving
-echo "[2/5] Copying bundles to public/cdn/plugins/..."
+echo "[2/6] Copying bundles to public/cdn/plugins/..."
 mkdir -p apps/web-next/public/cdn/plugins
 if [ -d "dist/plugins" ]; then
   cp -r dist/plugins/* apps/web-next/public/cdn/plugins/
@@ -66,33 +67,31 @@ fi
 # Additive-only PRs are still safe, but we gate on production to enforce
 # the expand/contract migration discipline.
 if [ "${VERCEL_ENV}" = "production" ]; then
-  echo "[3/5] Prisma db push (production)..."
+  echo "[3/6] Prisma db push (production)..."
   cd packages/database || { echo "ERROR: Failed to cd to packages/database"; exit 1; }
   npx prisma db push --skip-generate --accept-data-loss 2>&1 || echo "WARN: prisma db push had issues (non-fatal)"
   cd ../.. || { echo "ERROR: Failed to cd back to root"; exit 1; }
 else
-  echo "[3/5] Skipping prisma db push (VERCEL_ENV=${VERCEL_ENV:-unset}, only runs on production)"
+  echo "[3/6] Skipping prisma db push (VERCEL_ENV=${VERCEL_ENV:-unset}, only runs on production)"
 fi
 
-# Step 4: Build Next.js app
-echo "[4/5] Building Next.js app..."
+# Step 4: Sync plugin registry in database (BEFORE build so generated files
+# like plugin-routes.json are available to the Next.js middleware bundler).
+# Always run — it's idempotent (upserts) and fast (~2-3s).
+echo "[4/6] Syncing plugin registry..."
+npx tsx bin/sync-plugin-registry.ts
+
+# Step 5: Build Next.js app
+echo "[5/6] Building Next.js app..."
 cd apps/web-next || { echo "ERROR: Failed to cd to apps/web-next"; exit 1; }
 npm run build
 cd ../.. || { echo "ERROR: Failed to cd back to root"; exit 1; }
 
-# Step 5: (Optional) One-time cleanup for PR 87 moved plugins
+# Step 6: (Optional) One-time cleanup for PR 87 moved plugins
 # Set RUN_PLUGIN_CLEANUP=1 in Vercel env to run once, then remove.
-# Cleans UserPluginPreference, TenantPluginInstall, TeamPluginInstall for moved plugins.
 if [ "${RUN_PLUGIN_CLEANUP}" = "1" ] && [ "${VERCEL_ENV}" = "production" ] && [ -n "$DATABASE_URL" ]; then
-  echo "[5a/5] Running plugin cleanup (PR 87)..."
+  echo "[6/6] Running plugin cleanup (PR 87)..."
   npx tsx bin/cleanup-moved-plugins.ts --force 2>&1 || echo "WARN: cleanup had issues (non-fatal)"
 fi
-
-# Step 5: Sync plugin registry in database
-# Always run — it's idempotent (upserts) and fast (~2-3s).
-# This ensures stale plugins are cleaned up when plugins are removed,
-# and new plugins are registered even if only the sync script changed.
-echo "[5/5] Syncing plugin registry..."
-npx tsx bin/sync-plugin-registry.ts
 
 echo "=== Vercel Build Pipeline Complete ==="


### PR DESCRIPTION
## Summary

- **Restore all 16 plugin route mappings** in `PLUGIN_ROUTE_MAP` (middleware.ts) — routes removed by PR #87 and never-added routes for newer plugins (`/gateway`, `/deployments`, `/lightning-client`, etc.)
- **Auto-generate `plugin-routes.json`** from plugin.json manifests in `sync-plugin-registry.ts` as a prevention mechanism
- **Reorder Vercel build pipeline** to run `sync-plugin-registry` before `npm run build` so generated files are available to the middleware bundler
- **Add auth-route redirect** so authenticated users on `/login` are sent to `/dashboard`
- **Fix connector templates directory** path (`templates/` → `connectors/`)

## Root Cause

PR #87 moved 6 plugins to `examples/` and removed their routes from the hardcoded `PLUGIN_ROUTE_MAP` in `middleware.ts`. The middleware uses this map to rewrite browser-facing URLs (e.g. `/gateway` → `/plugins/serviceGateway`). Without the mapping, Next.js has no matching page and returns 404.

The sidebar generates `<Link href="/gateway">` from `WorkflowPlugin.routes`, so users clicking any plugin in the sidebar hit the 404.

## Prevention Strategy

1. `sync-plugin-registry.ts` now generates `apps/web-next/src/generated/plugin-routes.json` from each plugin's `plugin.json` routes at build time
2. `vercel-build.sh` runs registry sync **before** the Next.js build (was Step 5, now Step 4) so the generated file is available at build time
3. Future improvement: middleware can import the generated JSON instead of hardcoding routes, making route additions fully automatic

## Relationship to Other PRs

- **Subsumes PR #161** — this PR includes the same route map restoration plus the prevention mechanism
- **Complementary to PR #164** — PR 164 adds a catch-all `[...slug]/page.tsx` as a defense-in-depth fallback; this PR fixes the middleware rewrite which is the primary routing mechanism

## Test plan

- [ ] `/gateway` loads Service Gateway plugin (was 404)
- [ ] `/wallet`, `/daydream`, `/orchestrators`, `/analytics`, `/leaderboard` load their plugins
- [ ] `/marketplace` and `/dashboard` still work (own page.tsx)
- [ ] Authenticated `/login` redirects to `/dashboard`
- [ ] Unauthenticated plugin route redirects to `/login`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated users are now automatically redirected to the dashboard when attempting to access login or registration pages.

* **Chores**
  * Optimized build pipeline sequence and plugin registry synchronization process for improved deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->