### PR TITLE
fix(ci): add lockfile sync validation to prevent stale package-lock.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
   lint-typecheck:
     name: Lint & TypeCheck
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: needs.paths-filter.outputs.docs_only != 'true'
     steps:
       - name: Checkout
@@ -185,7 +185,7 @@ jobs:
   shell-tests:
     name: Shell Tests
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: needs.paths-filter.outputs.shell == 'true'
     steps:
       - name: Checkout
@@ -217,7 +217,7 @@ jobs:
   sdk-tests:
     name: SDK Tests
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: needs.paths-filter.outputs.packages == 'true'
     steps:
       - name: Checkout
@@ -253,7 +253,7 @@ jobs:
   sdk-compat-matrix:
     name: SDK Compat — ${{ matrix.plugin }}
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: needs.paths-filter.outputs.sdk == 'true'
     strategy:
       fail-fast: false
@@ -303,7 +303,7 @@ jobs:
   plugin-tests:
     name: Plugin Tests — ${{ matrix.plugin }}
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: needs.paths-filter.outputs.plugins == 'true'
     strategy:
       fail-fast: false
@@ -375,7 +375,7 @@ jobs:
   lifecycle-tests:
     name: Lifecycle BDD Tests
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: >-
       needs.paths-filter.outputs.sdk == 'true' ||
       needs.paths-filter.outputs.plugins == 'true' ||
@@ -426,7 +426,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: paths-filter
+    needs: [paths-filter, lockfile-sync]
     if: needs.paths-filter.outputs.docs_only != 'true' && needs.paths-filter.outputs.build_relevant == 'true'
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Add a fast **Lockfile Sync** CI job that validates `package-lock.json` is in sync with `package.json` before any other job runs
- Audit job now depends on lockfile-sync (avoids redundant `npm ci` failure)
- Quality Gates tracks the new job with a clear error message

## Root cause of #174–#178

All 5 plugin health check failures were caused by the **same root issue**: `package-lock.json` was out of sync with `package.json` at the time the daily health cron ran (commit `c695058`). Specifically, `services/storage-svc` declared `@aws-sdk/lib-storage@^3.1000.0` but the lockfile had it resolved to `3.990.0`. `npm ci` correctly refused to install, failing all 5 health jobs before any plugin-specific code was reached.

The mismatch was later fixed by PR #151 which regenerated the lockfile. Current main passes `npm ci` cleanly. Issues #174–#178 have been closed with explanatory comments.

This PR adds a CI safeguard to catch this class of issue on every PR, preventing it from reaching main again.

## Test plan

- [ ] CI runs the new `Lockfile Sync` job and passes (current lockfile is in sync)
- [ ] Verify `Audit` job waits for `Lockfile Sync` to complete
- [ ] Quality Gates reports `lockfile-sync` status

Closes #174, #175, #176, #177, #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated package dependency validation to the CI pipeline. A new gating check ensures dependency configurations remain synchronized throughout the build process. The validation runs automatically and provides clear feedback if dependencies become misaligned, helping maintain build integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->