### PR TITLE
fix(gateway): fix TDZ error preventing connector detail page from rendering

### DIFF
--- a/plugins/service-gateway/frontend/src/pages/ConnectorDetailPage.tsx
+++ b/plugins/service-gateway/frontend/src/pages/ConnectorDetailPage.tsx
@@ -168,6 +168,9 @@ export const ConnectorDetailPage: React.FC = () => {
       .finally(() => setSpecLoading(false));
   }, [activeTab, id, api, openApiSpec]);
 
+  const connector = connectorRes?.data;
+  const keys = keysRes?.data || [];
+
   // Load secrets when Settings tab is active
   const loadSecrets = useCallback(() => {
     if (!id) return;
@@ -217,9 +220,6 @@ export const ConnectorDetailPage: React.FC = () => {
     if (activeTab !== 'Usage' || !id) return;
     loadUsage();
   }, [activeTab, id, loadUsage]);
-
-  const connector = connectorRes?.data;
-  const keys = keysRes?.data || [];
 
   const handleCreateKey = async () => {
     if (!newKeyName || !id) return;


### PR DESCRIPTION
## Summary
- Fixes a Temporal Dead Zone (TDZ) `ReferenceError: Cannot access 'L' before initialization` that prevented the connector detail page from rendering
- Root cause: `const connector = connectorRes?.data` was declared **after** a `useEffect` that referenced `connector?.endpoints` in its dependency array (line 190), causing a TDZ violation at runtime
- Fix: moved the `connector` and `keys` declarations above the `useEffect` that depends on them

## Test plan
- [ ] Verify connector detail page loads when clicking a connector from the list
- [ ] Verify all tabs render (Overview, API Spec, API Keys, Play, Usage, Settings)
- [ ] Verify upstream secret save works
- [ ] Verify Play tab sends requests and displays responses
- [ ] Verify connector archival works
- [ ] No console errors on page load


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal variable handling in the connector detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->