### PR TITLE
feat(web-next): add site-wide beta banner pointing to Livepeer Discord

### DIFF
--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
 import { Providers } from '@/components/providers';
+import { BetaBanner } from '@/components/layout/beta-banner';
 import './globals.css';
 
 const inter = Inter({
@@ -66,6 +67,7 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
         <Providers>
+          <BetaBanner />
           {children}
         </Providers>
       </body>

--- a/apps/web-next/src/components/layout/beta-banner.tsx
+++ b/apps/web-next/src/components/layout/beta-banner.tsx
@@ -1,0 +1,24 @@
+import { AlertTriangle } from 'lucide-react';
+
+const DISCORD_URL = 'https://discord.com/channels/423160867534929930/1470881817291915538';
+
+export function BetaBanner() {
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-2 text-center text-[13px] text-amber-600 dark:text-amber-400 bg-amber-500/10 border-b border-amber-500/30">
+      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden />
+      <p className="min-w-0">
+        <span className="font-semibold">This app is currently in beta.</span>{' '}
+        We&apos;re actively looking for feedback — join the{' '}
+        <a
+          href={DISCORD_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold underline underline-offset-2 hover:opacity-80"
+        >
+          Livepeer Discord
+        </a>{' '}
+        to share yours.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a small, non-dismissible amber notice bar at the very top of every page (public overview and authenticated dashboard alike) announcing that the app is in beta and linking to the Livepeer Discord for feedback. Visually mirrors the notice bar on explorer.livepeer.org so the two Foundation apps feel cohesive while the exact form of this app is still being defined through community feedback.

<!-- 1-3 sentences. What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed. -->

- Added a beta banner at the very top of every page.
 
## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Tooling
- [ ] Plugin (new or update)
- [ ] Dependencies

## Plugin(s) Affected

<!-- If this is a plugin PR, list the plugin name(s). Leave blank for core changes. -->

## Checklist

- [x] Tests pass locally
- [ ] Lint passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] No new lint warnings introduced
- [x] Breaking changes documented below
- [ ] Database migration included (if Prisma schema changed)

## Breaking Changes

<!-- If none, write "None". Otherwise describe what breaks and migration path. -->

None

## Screenshots / Recordings

<!-- For UI changes, attach screenshots or a short recording. Delete this section if not applicable. -->

<img width="5122" height="487" alt="image" src="https://github.com/user-attachments/assets/4f9fa80f-fef5-4a48-a2c0-1ec2c3aa5295" />
