### PR TITLE
feat: add beta notice banner with Discord link

### DIFF
--- a/apps/web-next/src/app/layout.tsx
+++ b/apps/web-next/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
 import { Providers } from '@/components/providers';
+import { BetaBanner } from '@/components/ui/beta-banner';
 import './globals.css';
 
 const inter = Inter({
@@ -65,6 +66,7 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
+        <BetaBanner />
         <Providers>
           {children}
         </Providers>

--- a/apps/web-next/src/components/ui/beta-banner.tsx
+++ b/apps/web-next/src/components/ui/beta-banner.tsx
@@ -1,0 +1,24 @@
+import { ExternalLink } from 'lucide-react';
+
+const DISCORD_URL = 'https://discord.gg/livepeer';
+
+export function BetaBanner() {
+  return (
+    <div className="w-full bg-amber-500/10 border-b border-amber-500/20">
+      <div className="flex items-center justify-center gap-x-2 px-4 py-1.5 text-center">
+        <span className="text-xs text-amber-700 dark:text-amber-400">
+          This app is in beta &mdash; we&apos;re actively shaping it with community feedback.
+        </span>
+        <a
+          href={DISCORD_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs font-medium text-amber-800 dark:text-amber-300 underline underline-offset-2 decoration-amber-500/40 hover:decoration-amber-500 transition-colors whitespace-nowrap"
+        >
+          Join us on Discord
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a non-dismissible amber notice bar at the very top of every page (public overview, dashboard, auth, and docs) announcing that the app is in beta and linking to the Livepeer Discord (`discord.gg/livepeer`) for community feedback.
- Visually mirrors the notice bar pattern on `explorer.livepeer.org` so the two Foundation apps feel cohesive while the exact form of this app is still being shaped through community input.

## Changes

- **New**: `apps/web-next/src/components/ui/beta-banner.tsx` -- server component, compact amber bar with centered text + external Discord link
- **Edit**: `apps/web-next/src/app/layout.tsx` -- renders `BetaBanner` at the top of `<body>` above `<Providers>`, ensuring it appears on every route

## Test plan

- [ ] Verify banner appears on the public overview page (`/`)
- [ ] Verify banner appears on dashboard pages (`/dashboard`)
- [ ] Verify banner appears on auth pages (`/login`, `/register`)
- [ ] Verify banner appears on docs pages (`/docs`)
- [ ] Verify Discord link opens `https://discord.gg/livepeer` in a new tab
- [ ] Verify banner renders correctly in both light and dark mode
- [ ] Confirm banner is not dismissible (no close button)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global beta banner displayed across all pages to inform users the application is in beta.
  * Included a community link within the banner enabling users to connect and provide feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->