### PR TITLE
feat: community moderation & capacity planner lifecycle management

### DIFF
--- a/apps/web-next/src/app/api/v1/capacity-planner/requests/[id]/route.ts
+++ b/apps/web-next/src/app/api/v1/capacity-planner/requests/[id]/route.ts
@@ -69,13 +69,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams): Prom
       return errors.notFound('Capacity request');
     }
 
-    // Closing requires ownership or admin role
-    if (body.status === 'CLOSED') {
-      const isOwner = existing.creatorId && existing.creatorId === user.id;
-      const isAdmin = user.roles.includes('system:admin');
-      if (!isOwner && !isAdmin) {
-        return errors.forbidden('Only the request creator or an admin can close a request');
-      }
+    const isOwner = existing.creatorId != null && existing.creatorId === user.id;
+    const isAdmin = user.roles.includes('system:admin');
+    if (!isOwner && !isAdmin) {
+      return errors.forbidden('Only the request creator or an admin can modify this request');
     }
 
     const updated = await prisma.capacityRequest.update({

--- a/apps/web-next/src/app/api/v1/capacity-planner/requests/[id]/route.ts
+++ b/apps/web-next/src/app/api/v1/capacity-planner/requests/[id]/route.ts
@@ -69,6 +69,15 @@ export async function PATCH(request: NextRequest, { params }: RouteParams): Prom
       return errors.notFound('Capacity request');
     }
 
+    // Closing requires ownership or admin role
+    if (body.status === 'CLOSED') {
+      const isOwner = existing.creatorId && existing.creatorId === user.id;
+      const isAdmin = user.roles.includes('system:admin');
+      if (!isOwner && !isAdmin) {
+        return errors.forbidden('Only the request creator or an admin can close a request');
+      }
+    }
+
     const updated = await prisma.capacityRequest.update({
       where: { id },
       data: {

--- a/apps/web-next/src/app/api/v1/capacity-planner/requests/route.ts
+++ b/apps/web-next/src/app/api/v1/capacity-planner/requests/route.ts
@@ -132,13 +132,16 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // Build Prisma where clause with proper types
     const where: Prisma.CapacityRequestWhereInput = {};
+    const andClauses: Prisma.CapacityRequestWhereInput[] = [];
 
     if (statusFilter === 'archived') {
       // Show non-active statuses OR active requests that have expired
-      where.OR = [
-        { status: { in: ['EXPIRED', 'CANCELLED', 'CLOSED', 'FULFILLED'] } },
-        { status: 'ACTIVE', validUntil: { lt: new Date() } },
-      ];
+      andClauses.push({
+        OR: [
+          { status: { in: ['EXPIRED', 'CANCELLED', 'CLOSED', 'FULFILLED'] } },
+          { status: 'ACTIVE', validUntil: { lt: new Date() } },
+        ],
+      });
     } else if (statusFilter === 'all') {
       // No status filter
     } else {
@@ -163,15 +166,21 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     if (search) {
-      where.OR = [
-        { requesterName: { contains: search, mode: 'insensitive' } },
-        { requesterAccount: { contains: search, mode: 'insensitive' } },
-        { gpuModel: { contains: search, mode: 'insensitive' } },
-        { pipeline: { contains: search, mode: 'insensitive' } },
-        { reason: { contains: search, mode: 'insensitive' } },
-        { osVersion: { contains: search, mode: 'insensitive' } },
-        { cudaVersion: { contains: search, mode: 'insensitive' } },
-      ];
+      andClauses.push({
+        OR: [
+          { requesterName: { contains: search, mode: 'insensitive' } },
+          { requesterAccount: { contains: search, mode: 'insensitive' } },
+          { gpuModel: { contains: search, mode: 'insensitive' } },
+          { pipeline: { contains: search, mode: 'insensitive' } },
+          { reason: { contains: search, mode: 'insensitive' } },
+          { osVersion: { contains: search, mode: 'insensitive' } },
+          { cudaVersion: { contains: search, mode: 'insensitive' } },
+        ],
+      });
+    }
+
+    if (andClauses.length > 0) {
+      where.AND = andClauses;
     }
 
     // Build orderBy with proper Prisma type

--- a/apps/web-next/src/app/api/v1/capacity-planner/requests/route.ts
+++ b/apps/web-next/src/app/api/v1/capacity-planner/requests/route.ts
@@ -41,6 +41,7 @@ function parseCapacityRequestsPagination(searchParams: URLSearchParams): {
  */
 function serialiseRequest(r: {
   id: string;
+  creatorId?: string | null;
   requesterName: string;
   requesterAccount: string;
   gpuModel: string;
@@ -81,6 +82,7 @@ function serialiseRequest(r: {
 
   return {
     id: r.id,
+    creatorId: r.creatorId ?? undefined,
     requesterName: r.requesterName,
     requesterAccount: r.requesterAccount,
     gpuModel: r.gpuModel,
@@ -126,11 +128,24 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const search = searchParams.get('search');
     const vramMin = searchParams.get('vramMin');
     const sort = searchParams.get('sort');
+    const statusFilter = searchParams.get('status') || 'active';
 
     // Build Prisma where clause with proper types
-    const where: Prisma.CapacityRequestWhereInput = {
-      status: 'ACTIVE',
-    };
+    const where: Prisma.CapacityRequestWhereInput = {};
+
+    if (statusFilter === 'archived') {
+      // Show non-active statuses OR active requests that have expired
+      where.OR = [
+        { status: { in: ['EXPIRED', 'CANCELLED', 'CLOSED', 'FULFILLED'] } },
+        { status: 'ACTIVE', validUntil: { lt: new Date() } },
+      ];
+    } else if (statusFilter === 'all') {
+      // No status filter
+    } else {
+      // Default: active and not yet expired
+      where.status = 'ACTIVE';
+      where.validUntil = { gte: new Date() };
+    }
 
     if (pipeline) {
       where.pipeline = pipeline;
@@ -273,6 +288,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const created = await prisma.capacityRequest.create({
       data: {
+        creatorId: user.id,
         requesterName: body.requesterName as string,
         requesterAccount: (body.requesterAccount as string) || '0x0000...0000',
         gpuModel: body.gpuModel as string,

--- a/apps/web-next/src/app/api/v1/community/posts/[id]/comments/route.ts
+++ b/apps/web-next/src/app/api/v1/community/posts/[id]/comments/route.ts
@@ -84,6 +84,10 @@ export async function POST(request: NextRequest, { params }: RouteParams): Promi
     // Get or create community profile
     const profile = await getOrCreateCommunityProfile(authUser.id);
 
+    if (profile.isBanned) {
+      return errors.forbidden('You are banned from posting in the community');
+    }
+
     const comment = await prisma.communityComment.create({
       data: {
         postId,

--- a/apps/web-next/src/app/api/v1/community/posts/[id]/moderate/route.ts
+++ b/apps/web-next/src/app/api/v1/community/posts/[id]/moderate/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Community Post Moderation API Route
+ * POST /api/v1/community/posts/:id/moderate - Admin moderation actions
+ *
+ * Actions: delete, close, archive
+ * Requires community:admin or system:admin role.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+const VALID_ACTIONS = ['delete', 'close', 'archive'] as const;
+type ModerateAction = (typeof VALID_ACTIONS)[number];
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+
+    const token = getAuthToken(request);
+    if (!token) {
+      return errors.unauthorized('No auth token provided');
+    }
+
+    const csrfError = validateCSRF(request, token);
+    if (csrfError) {
+      return csrfError;
+    }
+
+    const authUser = await validateSession(token);
+    if (!authUser) {
+      return errors.unauthorized('Invalid or expired session');
+    }
+
+    const isAdmin = authUser.roles.includes('community:admin') || authUser.roles.includes('system:admin');
+    if (!isAdmin) {
+      return errors.forbidden('Admin permission required');
+    }
+
+    const body = await request.json();
+    const action = body.action as ModerateAction;
+
+    if (!action || !VALID_ACTIONS.includes(action)) {
+      return errors.badRequest(`action must be one of: ${VALID_ACTIONS.join(', ')}`);
+    }
+
+    const post = await prisma.communityPost.findUnique({ where: { id } });
+    if (!post) {
+      return errors.notFound('Post');
+    }
+
+    if (action === 'delete') {
+      await prisma.communityPost.delete({ where: { id } });
+      return success({ deleted: true, postId: id });
+    }
+
+    const statusMap = { close: 'CLOSED', archive: 'ARCHIVED' } as const;
+    const newStatus = statusMap[action];
+
+    const updated = await prisma.communityPost.update({
+      where: { id },
+      data: { status: newStatus },
+    });
+
+    return success({ post: { id: updated.id, status: updated.status } });
+  } catch (err) {
+    console.error('Moderate post error:', err);
+    return errors.internal('Failed to moderate post');
+  }
+}

--- a/apps/web-next/src/app/api/v1/community/posts/[id]/moderate/route.ts
+++ b/apps/web-next/src/app/api/v1/community/posts/[id]/moderate/route.ts
@@ -43,10 +43,15 @@ export async function POST(request: NextRequest, { params }: RouteParams): Promi
       return errors.forbidden('Admin permission required');
     }
 
-    const body = await request.json();
-    const action = body.action as ModerateAction;
+    let body: { action?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return errors.badRequest('Invalid JSON in request body');
+    }
+    const action = body.action;
 
-    if (!action || !VALID_ACTIONS.includes(action)) {
+    if (typeof action !== 'string' || !VALID_ACTIONS.includes(action as ModerateAction)) {
       return errors.badRequest(`action must be one of: ${VALID_ACTIONS.join(', ')}`);
     }
 

--- a/apps/web-next/src/app/api/v1/community/posts/[id]/route.ts
+++ b/apps/web-next/src/app/api/v1/community/posts/[id]/route.ts
@@ -90,8 +90,8 @@ export async function PUT(request: NextRequest, { params }: RouteParams): Promis
       return errors.notFound('Post');
     }
 
-    // Check ownership
-    if (post.author.userId !== authUser.id) {
+    const isAdmin = authUser.roles.includes('community:admin') || authUser.roles.includes('system:admin');
+    if (post.author.userId !== authUser.id && !isAdmin) {
       return errors.forbidden('Not authorized to edit this post');
     }
 
@@ -147,8 +147,8 @@ export async function DELETE(request: NextRequest, { params }: RouteParams): Pro
       return errors.notFound('Post');
     }
 
-    // Check ownership
-    if (post.author.userId !== authUser.id) {
+    const isAdmin = authUser.roles.includes('community:admin') || authUser.roles.includes('system:admin');
+    if (post.author.userId !== authUser.id && !isAdmin) {
       return errors.forbidden('Not authorized to delete this post');
     }
 

--- a/apps/web-next/src/app/api/v1/community/posts/route.ts
+++ b/apps/web-next/src/app/api/v1/community/posts/route.ts
@@ -190,6 +190,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Get or create community profile
     const profile = await getOrCreateCommunityProfile(authUser.id);
 
+    if (profile.isBanned) {
+      return errors.forbidden('You are banned from posting in the community');
+    }
+
     // Create post
     const post = await prisma.communityPost.create({
       data: {

--- a/apps/web-next/src/app/api/v1/community/users/[id]/ban/route.ts
+++ b/apps/web-next/src/app/api/v1/community/users/[id]/ban/route.ts
@@ -1,0 +1,81 @@
+/**
+ * Community User Ban API Route
+ * POST /api/v1/community/users/:id/ban - Ban or unban a user from the community
+ *
+ * Requires community:admin or system:admin role.
+ * The :id param is the User.id (not CommunityProfile.id).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id: targetUserId } = await params;
+
+    const token = getAuthToken(request);
+    if (!token) {
+      return errors.unauthorized('No auth token provided');
+    }
+
+    const csrfError = validateCSRF(request, token);
+    if (csrfError) {
+      return csrfError;
+    }
+
+    const authUser = await validateSession(token);
+    if (!authUser) {
+      return errors.unauthorized('Invalid or expired session');
+    }
+
+    const isAdmin = authUser.roles.includes('community:admin') || authUser.roles.includes('system:admin');
+    if (!isAdmin) {
+      return errors.forbidden('Admin permission required');
+    }
+
+    if (targetUserId === authUser.id) {
+      return errors.badRequest('Cannot ban yourself');
+    }
+
+    const body = await request.json();
+    const { banned, reason } = body;
+
+    if (typeof banned !== 'boolean') {
+      return errors.badRequest('banned must be a boolean');
+    }
+
+    const profile = await prisma.communityProfile.findUnique({
+      where: { userId: targetUserId },
+    });
+
+    if (!profile) {
+      return errors.notFound('Community profile');
+    }
+
+    const updated = await prisma.communityProfile.update({
+      where: { userId: targetUserId },
+      data: {
+        isBanned: banned,
+        bannedAt: banned ? new Date() : null,
+        bannedReason: banned ? (reason || null) : null,
+      },
+    });
+
+    return success({
+      userId: targetUserId,
+      isBanned: updated.isBanned,
+      bannedAt: updated.bannedAt?.toISOString() ?? null,
+      bannedReason: updated.bannedReason,
+    });
+  } catch (err) {
+    console.error('Ban user error:', err);
+    return errors.internal('Failed to update ban status');
+  }
+}

--- a/apps/web-next/src/app/api/v1/community/users/[id]/ban/route.ts
+++ b/apps/web-next/src/app/api/v1/community/users/[id]/ban/route.ts
@@ -44,11 +44,20 @@ export async function POST(request: NextRequest, { params }: RouteParams): Promi
       return errors.badRequest('Cannot ban yourself');
     }
 
-    const body = await request.json();
+    let body: { banned?: unknown; reason?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return errors.badRequest('Invalid JSON in request body');
+    }
     const { banned, reason } = body;
 
     if (typeof banned !== 'boolean') {
       return errors.badRequest('banned must be a boolean');
+    }
+
+    if (reason != null && typeof reason !== 'string') {
+      return errors.badRequest('reason must be a string');
     }
 
     const profile = await prisma.communityProfile.findUnique({
@@ -64,7 +73,7 @@ export async function POST(request: NextRequest, { params }: RouteParams): Promi
       data: {
         isBanned: banned,
         bannedAt: banned ? new Date() : null,
-        bannedReason: banned ? (reason || null) : null,
+        bannedReason: banned ? ((reason as string)?.trim() || null) : null,
       },
     });
 

--- a/apps/web-next/tests/capacity-lifecycle.spec.ts
+++ b/apps/web-next/tests/capacity-lifecycle.spec.ts
@@ -262,36 +262,87 @@ test.describe('Capacity Planner Lifecycle Authenticated API', () => {
   });
 
   test('non-creator cannot close another user\'s request', async ({ request }) => {
+    // This test needs two separate user identities
     const email = process.env.E2E_USER_EMAIL?.trim();
     const password = process.env.E2E_USER_PASSWORD;
-    if (!email || !password) {
-      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+    const adminEmail = process.env.ADMIN_EMAIL?.trim();
+    const adminPassword = process.env.ADMIN_PASSWORD;
+    if (!email || !password || !adminEmail || !adminPassword) {
+      test.skip(true, 'Set E2E_USER_EMAIL/E2E_USER_PASSWORD and ADMIN_EMAIL/ADMIN_PASSWORD');
       return;
     }
 
-    // Login
-    const loginRes = await request.post(`${base()}/api/v1/auth/login`, {
+    // Login as admin (user A — will create the request)
+    const loginARes = await request.post(`${base()}/api/v1/auth/login`, {
+      data: { email: adminEmail, password: adminPassword },
+    });
+    if (!loginARes.ok()) {
+      test.skip(true, 'Admin login failed');
+      return;
+    }
+    const tokenA = (await loginARes.json()).data?.token;
+    if (!tokenA) {
+      test.skip(true, 'No admin token');
+      return;
+    }
+
+    // Create a request as admin
+    const futureDate = new Date();
+    futureDate.setMonth(futureDate.getMonth() + 1);
+    const validUntilDate = new Date();
+    validUntilDate.setDate(validUntilDate.getDate() + 14);
+    const createRes = await request.post(`${base()}/api/v1/capacity-planner/requests`, {
+      headers: { 'Authorization': `Bearer ${tokenA}`, 'Content-Type': 'application/json' },
+      data: {
+        requesterName: 'E2E Ownership Test',
+        requesterAccount: '0xOWNERSHIP',
+        gpuModel: 'RTX 4090',
+        vram: 24,
+        count: 1,
+        pipeline: 'text-to-image',
+        startDate: new Date().toISOString().split('T')[0],
+        endDate: futureDate.toISOString().split('T')[0],
+        validUntil: validUntilDate.toISOString().split('T')[0],
+        hourlyRate: 1.0,
+        reason: 'E2E ownership test',
+        riskLevel: 1,
+      },
+    });
+    if (!createRes.ok()) {
+      test.skip(true, `Create request failed: ${createRes.status()}`);
+      return;
+    }
+    const createdId = (await createRes.json()).data?.id;
+    expect(createdId).toBeTruthy();
+
+    // Login as regular user (user B)
+    const loginBRes = await request.post(`${base()}/api/v1/auth/login`, {
       data: { email, password },
     });
-    if (!loginRes.ok()) {
-      test.skip(true, 'Login failed');
+    if (!loginBRes.ok()) {
+      test.skip(true, 'Regular user login failed');
       return;
     }
-    const token = (await loginRes.json()).data?.token;
-    if (!token) {
-      test.skip(true, 'No token');
+    const tokenB = (await loginBRes.json()).data?.token;
+    if (!tokenB) {
+      test.skip(true, 'No regular user token');
       return;
     }
 
-    // Try to close a non-existent request (should get 404, not 500)
+    // User B tries to close user A's request — should be 403
     const closeRes = await request.patch(
-      `${base()}/api/v1/capacity-planner/requests/00000000-0000-0000-0000-000000000000`,
+      `${base()}/api/v1/capacity-planner/requests/${createdId}`,
       {
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Authorization': `Bearer ${tokenB}`, 'Content-Type': 'application/json' },
         data: { status: 'CLOSED' },
       }
     );
-    expect(closeRes.status()).toBe(404);
+    expect(closeRes.status()).toBe(403);
+
+    // Cleanup: delete the test request as admin
+    await request.delete(`${base()}/api/v1/capacity-planner/requests/${createdId}`, {
+      headers: { 'Authorization': `Bearer ${tokenA}`, 'Content-Type': 'application/json' },
+    });
   });
 });
 
@@ -339,13 +390,17 @@ test.describe('Capacity Planner Lifecycle UI @pre-release', () => {
     const archivedBtn = page.getByRole('button', { name: /Archived/i });
     await archivedBtn.click();
 
-    // Wait for reload — either the count changes or we get "No archived requests"
-    await page.waitForTimeout(2000);
-    const countTextAfter = await page.locator('text=/Showing \\d+ of \\d+/').textContent({ timeout: 5_000 }).catch(() => '');
-    const noArchived = await page.getByText(/No archived requests/i).isVisible().catch(() => false);
-
-    // Either the count text changed or the empty state is shown
-    expect(countTextAfter !== countTextBefore || noArchived).toBeTruthy();
+    // Poll until the listing changes or the empty state appears
+    await expect
+      .poll(async () => {
+        const countTextAfter = await page
+          .locator('text=/Showing \\d+ of \\d+/')
+          .textContent({ timeout: 5_000 })
+          .catch(() => '');
+        const noArchived = await page.getByText(/No archived requests/i).isVisible().catch(() => false);
+        return countTextAfter !== countTextBefore || noArchived;
+      }, { timeout: 15_000 })
+      .toBeTruthy();
   });
 
   test('New Request button still works', async ({ page }) => {

--- a/apps/web-next/tests/capacity-lifecycle.spec.ts
+++ b/apps/web-next/tests/capacity-lifecycle.spec.ts
@@ -1,0 +1,417 @@
+import { test, expect } from '@playwright/test';
+import { assertCapacityPlannerApiHealthy } from './helpers/plugin-preflight';
+import { e2eBaseUrl } from './helpers/e2e-base';
+
+/**
+ * E2E tests for Capacity Planner lifecycle features.
+ *
+ * Tests the following capabilities:
+ * - Creator can close their own request
+ * - Expired requests are hidden from default listing
+ * - Archived filter shows closed/expired/cancelled requests
+ * - creatorId is stored on new requests
+ * - Ownership check prevents non-creators from closing
+ *
+ * Requires:
+ *   E2E_USER_EMAIL + E2E_USER_PASSWORD for authenticated tests
+ */
+
+// ── API-level tests ──
+
+test.describe('Capacity Planner Lifecycle API @pre-release', () => {
+  const base = () => e2eBaseUrl();
+
+  test.beforeAll(async ({ request }) => {
+    const baseURL = base();
+    test.skip(!baseURL, 'baseURL required');
+    await assertCapacityPlannerApiHealthy(request, baseURL);
+  }, { timeout: 120_000 });
+
+  test.describe('GET /capacity-planner/requests (status filter)', () => {
+    test('default listing returns only active, non-expired requests', async ({ request }) => {
+      const res = await request.get(`${base()}/api/v1/capacity-planner/requests?limit=5`);
+      expect(res.ok()).toBeTruthy();
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      const data = json.data;
+      expect(Array.isArray(data)).toBeTruthy();
+
+      // All returned requests should be active status
+      for (const req of data) {
+        expect(req.status).toBe('active');
+        // validUntil should be in the future (or at least today)
+        const validUntil = new Date(req.validUntil);
+        const now = new Date();
+        // Allow 1 day buffer for timezone edge cases
+        now.setDate(now.getDate() - 1);
+        expect(validUntil.getTime()).toBeGreaterThanOrEqual(now.getTime());
+      }
+    });
+
+    test('archived filter returns non-active requests', async ({ request }) => {
+      const res = await request.get(`${base()}/api/v1/capacity-planner/requests?status=archived&limit=5`);
+      expect(res.ok()).toBeTruthy();
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      expect(Array.isArray(json.data)).toBeTruthy();
+
+      // All returned should be non-active or expired-active
+      for (const req of json.data) {
+        const isNonActive = ['expired', 'cancelled', 'closed', 'fulfilled'].includes(req.status);
+        const isExpiredActive = req.status === 'active' && new Date(req.validUntil) < new Date();
+        expect(isNonActive || isExpiredActive).toBeTruthy();
+      }
+    });
+
+    test('all filter returns everything', async ({ request }) => {
+      const res = await request.get(`${base()}/api/v1/capacity-planner/requests?status=all&limit=5`);
+      expect(res.ok()).toBeTruthy();
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      expect(Array.isArray(json.data)).toBeTruthy();
+    });
+
+    test('invalid status falls through to default (active)', async ({ request }) => {
+      const res = await request.get(`${base()}/api/v1/capacity-planner/requests?status=bogus&limit=5`);
+      expect(res.ok()).toBeTruthy();
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      // Should behave like default active filter
+      for (const req of json.data) {
+        expect(req.status).toBe('active');
+      }
+    });
+  });
+
+  test.describe('GET /capacity-planner/requests/:id', () => {
+    test('returns 404 for non-existent request', async ({ request }) => {
+      const res = await request.get(
+        `${base()}/api/v1/capacity-planner/requests/00000000-0000-0000-0000-000000000000`
+      );
+      expect(res.status()).toBe(404);
+    });
+  });
+
+  test.describe('PATCH /capacity-planner/requests/:id (close)', () => {
+    test('rejects unauthenticated close', async ({ request }) => {
+      const res = await request.patch(
+        `${base()}/api/v1/capacity-planner/requests/00000000-0000-0000-0000-000000000000`,
+        { data: { status: 'CLOSED' } }
+      );
+      expect(res.status()).toBe(401);
+    });
+  });
+
+  test.describe('POST /capacity-planner/requests (creatorId)', () => {
+    test('rejects unauthenticated create', async ({ request }) => {
+      const res = await request.post(`${base()}/api/v1/capacity-planner/requests`, {
+        data: {
+          requesterName: 'Test',
+          gpuModel: 'RTX 4090',
+          vram: 24,
+          count: 1,
+          pipeline: 'text-to-image',
+          startDate: '2026-05-01',
+          endDate: '2026-06-01',
+          validUntil: '2026-05-15',
+          hourlyRate: 1.5,
+          reason: 'Test request',
+        },
+      });
+      expect(res.status()).toBe(401);
+    });
+  });
+
+  test.describe('Summary endpoint', () => {
+    test('summary still works with new status filter', async ({ request }) => {
+      const res = await request.get(`${base()}/api/v1/capacity-planner/summary`);
+      expect(res.ok()).toBeTruthy();
+      const json = await res.json();
+      expect(json.success).toBe(true);
+    });
+  });
+});
+
+// ── Authenticated API tests (create + close flow) ──
+
+test.describe('Capacity Planner Lifecycle Authenticated API', () => {
+  const base = () => e2eBaseUrl();
+
+  test.beforeAll(async ({ request }) => {
+    const baseURL = base();
+    test.skip(!baseURL, 'baseURL required');
+    await assertCapacityPlannerApiHealthy(request, baseURL);
+  }, { timeout: 120_000 });
+
+  test('full create → close → appears in archive flow', async ({ request }) => {
+    // This test requires auth - skip if no credentials
+    const email = process.env.E2E_USER_EMAIL?.trim();
+    const password = process.env.E2E_USER_PASSWORD;
+    if (!email || !password) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD for authenticated tests');
+      return;
+    }
+
+    // Step 1: Login to get auth token
+    const loginRes = await request.post(`${base()}/api/v1/auth/login`, {
+      data: { email, password },
+    });
+    if (!loginRes.ok()) {
+      test.skip(true, 'Login failed — skipping authenticated lifecycle test');
+      return;
+    }
+    const loginData = await loginRes.json();
+    const token = loginData.data?.token;
+    if (!token) {
+      test.skip(true, 'No token in login response');
+      return;
+    }
+
+    const authHeaders = {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+
+    // Step 2: Get CSRF token
+    const meRes = await request.get(`${base()}/api/v1/auth/me`, { headers: authHeaders });
+    const csrfToken = meRes.headers()['x-csrf-token'] || '';
+    if (csrfToken) {
+      (authHeaders as Record<string, string>)['X-CSRF-Token'] = csrfToken;
+    }
+
+    // Step 3: Create a new request
+    const futureDate = new Date();
+    futureDate.setMonth(futureDate.getMonth() + 1);
+    const futureDateStr = futureDate.toISOString().split('T')[0];
+    const validUntilDate = new Date();
+    validUntilDate.setDate(validUntilDate.getDate() + 14);
+    const validUntilStr = validUntilDate.toISOString().split('T')[0];
+
+    const createRes = await request.post(`${base()}/api/v1/capacity-planner/requests`, {
+      headers: authHeaders,
+      data: {
+        requesterName: 'E2E Lifecycle Test',
+        requesterAccount: '0xE2ETEST',
+        gpuModel: 'RTX 4090',
+        vram: 24,
+        count: 1,
+        pipeline: 'text-to-image',
+        startDate: new Date().toISOString().split('T')[0],
+        endDate: futureDateStr,
+        validUntil: validUntilStr,
+        hourlyRate: 1.0,
+        reason: 'E2E test — will be closed immediately',
+        riskLevel: 1,
+      },
+    });
+
+    if (!createRes.ok()) {
+      const body = await createRes.text();
+      console.log('[capacity-lifecycle] Create failed:', createRes.status(), body);
+      test.skip(true, `Create request failed: ${createRes.status()}`);
+      return;
+    }
+
+    const created = await createRes.json();
+    const requestId = created.data?.id;
+    expect(requestId).toBeTruthy();
+
+    // Verify creatorId is set
+    expect(created.data?.creatorId).toBeTruthy();
+
+    // Step 4: Verify it appears in active listing
+    const activeListRes = await request.get(
+      `${base()}/api/v1/capacity-planner/requests?search=E2E+Lifecycle+Test&limit=5`
+    );
+    expect(activeListRes.ok()).toBeTruthy();
+    const activeList = await activeListRes.json();
+    const inActiveList = activeList.data?.some((r: { id: string }) => r.id === requestId);
+    expect(inActiveList).toBeTruthy();
+
+    // Step 5: Close the request
+    const closeRes = await request.patch(
+      `${base()}/api/v1/capacity-planner/requests/${requestId}`,
+      {
+        headers: authHeaders,
+        data: { status: 'CLOSED' },
+      }
+    );
+    expect(closeRes.ok()).toBeTruthy();
+
+    // Step 6: Verify it's gone from active listing
+    const activeList2Res = await request.get(
+      `${base()}/api/v1/capacity-planner/requests?limit=50`
+    );
+    const activeList2 = await activeList2Res.json();
+    const stillInActive = activeList2.data?.some((r: { id: string }) => r.id === requestId);
+    expect(stillInActive).toBeFalsy();
+
+    // Step 7: Verify it appears in archived listing
+    const archivedRes = await request.get(
+      `${base()}/api/v1/capacity-planner/requests?status=archived&limit=50`
+    );
+    expect(archivedRes.ok()).toBeTruthy();
+    const archivedList = await archivedRes.json();
+    const inArchived = archivedList.data?.some((r: { id: string }) => r.id === requestId);
+    expect(inArchived).toBeTruthy();
+
+    // Step 8: Clean up — delete the test request
+    await request.delete(`${base()}/api/v1/capacity-planner/requests/${requestId}`, {
+      headers: authHeaders,
+    });
+  });
+
+  test('non-creator cannot close another user\'s request', async ({ request }) => {
+    const email = process.env.E2E_USER_EMAIL?.trim();
+    const password = process.env.E2E_USER_PASSWORD;
+    if (!email || !password) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    // Login
+    const loginRes = await request.post(`${base()}/api/v1/auth/login`, {
+      data: { email, password },
+    });
+    if (!loginRes.ok()) {
+      test.skip(true, 'Login failed');
+      return;
+    }
+    const token = (await loginRes.json()).data?.token;
+    if (!token) {
+      test.skip(true, 'No token');
+      return;
+    }
+
+    // Try to close a non-existent request (should get 404, not 500)
+    const closeRes = await request.patch(
+      `${base()}/api/v1/capacity-planner/requests/00000000-0000-0000-0000-000000000000`,
+      {
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        data: { status: 'CLOSED' },
+      }
+    );
+    expect(closeRes.status()).toBe(404);
+  });
+});
+
+// ── Browser-based UI tests ──
+
+test.describe('Capacity Planner Lifecycle UI @pre-release', () => {
+  test.beforeAll(async ({ request, baseURL }) => {
+    test.skip(!baseURL, 'baseURL required');
+    await assertCapacityPlannerApiHealthy(request, baseURL!);
+  }, { timeout: 120_000 });
+
+  test('archived toggle button is visible', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    await page.goto('/capacity');
+    await expect(page.getByRole('heading', { name: 'Capacity Requests' })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // The Archived toggle button should be visible
+    const archivedBtn = page.getByRole('button', { name: /Archived/i });
+    await expect(archivedBtn).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('clicking Archived toggle changes listing', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    await page.goto('/capacity');
+    await expect(page.getByRole('heading', { name: 'Capacity Requests' })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Record current request count text
+    const countTextBefore = await page.locator('text=/Showing \\d+ of \\d+/').textContent({ timeout: 10_000 }).catch(() => '');
+
+    // Click the Archived button
+    const archivedBtn = page.getByRole('button', { name: /Archived/i });
+    await archivedBtn.click();
+
+    // Wait for reload — either the count changes or we get "No archived requests"
+    await page.waitForTimeout(2000);
+    const countTextAfter = await page.locator('text=/Showing \\d+ of \\d+/').textContent({ timeout: 5_000 }).catch(() => '');
+    const noArchived = await page.getByText(/No archived requests/i).isVisible().catch(() => false);
+
+    // Either the count text changed or the empty state is shown
+    expect(countTextAfter !== countTextBefore || noArchived).toBeTruthy();
+  });
+
+  test('New Request button still works', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    await page.goto('/capacity');
+    await expect(page.getByRole('heading', { name: 'Capacity Requests' })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    const newReqBtn = page.getByRole('button', { name: /New Request/i });
+    await expect(newReqBtn).toBeVisible({ timeout: 15_000 });
+    await newReqBtn.click();
+
+    // Modal should appear
+    await expect(page.getByText(/GPU Model/i)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('request detail modal shows status badge', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    await page.goto('/capacity');
+    await expect(page.getByRole('heading', { name: 'Capacity Requests' })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Click on the first request card if any exist
+    const cards = page.locator('[class*="glass-card"]');
+    const cardCount = await cards.count();
+    if (cardCount > 0) {
+      await cards.first().click();
+
+      // Modal should open with status badge
+      await expect(page.locator('text=/active|closed|expired|fulfilled|cancelled/i')).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Specifications section should be visible
+      await expect(page.getByText('Specifications')).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test('filters and sort bar include Archived button', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    await page.goto('/capacity');
+    await expect(page.getByRole('heading', { name: 'Capacity Requests' })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Verify the filter bar layout
+    await expect(page.getByRole('button', { name: /Filters/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Archived/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /New Request/i })).toBeVisible();
+    await expect(page.getByPlaceholder(/Search by name/i)).toBeVisible();
+  });
+});

--- a/apps/web-next/tests/community-moderation.spec.ts
+++ b/apps/web-next/tests/community-moderation.spec.ts
@@ -114,20 +114,16 @@ test.describe('Community Moderation Admin UI', () => {
       timeout: 45_000,
     });
 
-    // If there are any posts, check that the admin menu (MoreVertical) is visible
+    // Verify posts exist — skip explicitly if none available
     const postCards = page.locator('[class*="cursor-pointer"]').filter({ has: page.locator('h3') });
     const postCount = await postCards.count();
-    if (postCount > 0) {
-      // Hover over the first post to reveal actions area
-      await postCards.first().hover();
-      // The three-dot menu button should be in the post card
-      const moreButton = postCards.first().locator('button[title="Moderate"]');
-      if (await moreButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await moreButton.click();
-        // Should show Delete, Close, Archive, Ban User options
-        await expect(page.getByText('Delete', { exact: false })).toBeVisible({ timeout: 3000 });
-      }
-    }
+    test.skip(postCount === 0, 'No posts available to validate admin moderation controls');
+
+    await postCards.first().hover();
+    const moreButton = postCards.first().locator('button[title="Moderate"]');
+    await expect(moreButton).toBeVisible({ timeout: 3000 });
+    await moreButton.click();
+    await expect(page.getByText('Delete', { exact: false })).toBeVisible({ timeout: 3000 });
   });
 
   test('admin sees moderation controls on post detail page', async ({ page }) => {
@@ -142,21 +138,17 @@ test.describe('Community Moderation Admin UI', () => {
       timeout: 45_000,
     });
 
-    // Click on the first post to go to detail
+    // Verify posts exist — skip explicitly if none available
     const postCards = page.locator('[class*="cursor-pointer"]').filter({ has: page.locator('h3') });
     const postCount = await postCards.count();
-    if (postCount > 0) {
-      await postCards.first().click();
-      // Wait for detail page to load
-      await expect(page.getByText('Back to Forum')).toBeVisible({ timeout: 15_000 });
+    test.skip(postCount === 0, 'No posts available to validate admin post detail controls');
 
-      // Admin badge should be visible
-      const adminBadge = page.getByText('Admin', { exact: true });
-      if (await adminBadge.isVisible({ timeout: 3000 }).catch(() => false)) {
-        // Admin action buttons should be present
-        await expect(page.getByRole('button', { name: /Delete/i })).toBeVisible();
-      }
-    }
+    await postCards.first().click();
+    await expect(page.getByText('Back to Forum')).toBeVisible({ timeout: 15_000 });
+
+    const adminBadge = page.getByText('Admin', { exact: true });
+    await expect(adminBadge).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole('button', { name: /Delete/i })).toBeVisible();
   });
 });
 

--- a/apps/web-next/tests/community-moderation.spec.ts
+++ b/apps/web-next/tests/community-moderation.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test';
+import { assertCommunityApiHealthy } from './helpers/plugin-preflight';
+import { e2eBaseUrl } from './helpers/e2e-base';
+
+/**
+ * E2E tests for Community Hub admin moderation features.
+ *
+ * Tests the following capabilities:
+ * - Admin can delete any post (not just author)
+ * - Admin can moderate posts (close/archive)
+ * - Admin can ban/unban users from the community
+ * - Banned users are prevented from posting and commenting
+ * - Moderation UI elements are visible only to admins
+ *
+ * Requires:
+ *   ADMIN_EMAIL + ADMIN_PASSWORD for admin-authenticated tests
+ *   E2E_USER_EMAIL + E2E_USER_PASSWORD for regular user tests
+ */
+
+// ── API-level tests (no browser required, use APIRequestContext) ──
+
+test.describe('Community Moderation API @pre-release', () => {
+  const base = () => e2eBaseUrl();
+
+  test.beforeAll(async ({ request }) => {
+    const baseURL = base();
+    test.skip(!baseURL, 'baseURL required');
+    await assertCommunityApiHealthy(request, baseURL);
+  }, { timeout: 120_000 });
+
+  test.describe('POST /community/posts/:id/moderate', () => {
+    test('rejects unauthenticated requests', async ({ request }) => {
+      const res = await request.post(`${base()}/api/v1/community/posts/nonexistent/moderate`, {
+        data: { action: 'close' },
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    test('rejects invalid action values', async ({ request }) => {
+      const res = await request.post(`${base()}/api/v1/community/posts/nonexistent/moderate`, {
+        data: { action: 'invalid_action' },
+        headers: { 'Authorization': 'Bearer test-token' },
+      });
+      // Should get 401 (bad token) or 400 (bad action) — not 500
+      expect(res.status()).toBeLessThan(500);
+    });
+
+    test('returns 404 for non-existent post', async ({ request }) => {
+      // Without valid admin auth this will return 401, which is acceptable
+      const res = await request.post(
+        `${base()}/api/v1/community/posts/00000000-0000-0000-0000-000000000000/moderate`,
+        { data: { action: 'close' } }
+      );
+      expect(res.status()).toBeLessThan(500);
+      expect([401, 403, 404]).toContain(res.status());
+    });
+  });
+
+  test.describe('POST /community/users/:id/ban', () => {
+    test('rejects unauthenticated requests', async ({ request }) => {
+      const res = await request.post(`${base()}/api/v1/community/users/some-user-id/ban`, {
+        data: { banned: true, reason: 'test' },
+      });
+      expect(res.status()).toBe(401);
+    });
+
+    test('rejects requests without banned boolean', async ({ request }) => {
+      const res = await request.post(`${base()}/api/v1/community/users/some-user-id/ban`, {
+        data: { reason: 'missing banned field' },
+        headers: { 'Authorization': 'Bearer test-token' },
+      });
+      expect(res.status()).toBeLessThan(500);
+    });
+  });
+
+  test.describe('GET /community/posts (ban enforcement)', () => {
+    test('posts endpoint remains healthy', async ({ request }) => {
+      const res = await request.get(`${base()}/api/v1/community/posts?limit=1`);
+      expect(res.ok()).toBeTruthy();
+      const json = await res.json();
+      expect(json.success).toBe(true);
+    });
+  });
+
+  test.describe('DELETE /community/posts/:id (admin override)', () => {
+    test('rejects unauthenticated delete', async ({ request }) => {
+      const res = await request.delete(
+        `${base()}/api/v1/community/posts/00000000-0000-0000-0000-000000000000`
+      );
+      expect(res.status()).toBe(401);
+    });
+  });
+});
+
+// ── Admin UI tests (browser-based, require admin auth) ──
+
+test.describe('Community Moderation Admin UI', () => {
+  test.use({ storageState: 'playwright/.auth/admin.json' });
+
+  test.beforeAll(async ({ request, baseURL }) => {
+    test.skip(!baseURL, 'baseURL required');
+    await assertCommunityApiHealthy(request, baseURL!);
+  }, { timeout: 120_000 });
+
+  test('admin sees moderation controls on forum page', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set ADMIN_EMAIL / ADMIN_PASSWORD for admin tests');
+      return;
+    }
+
+    await page.goto('/forum');
+    await expect(page.getByRole('heading', { name: 'Community Hub', exact: true })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // If there are any posts, check that the admin menu (MoreVertical) is visible
+    const postCards = page.locator('[class*="cursor-pointer"]').filter({ has: page.locator('h3') });
+    const postCount = await postCards.count();
+    if (postCount > 0) {
+      // Hover over the first post to reveal actions area
+      await postCards.first().hover();
+      // The three-dot menu button should be in the post card
+      const moreButton = postCards.first().locator('button[title="Moderate"]');
+      if (await moreButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await moreButton.click();
+        // Should show Delete, Close, Archive, Ban User options
+        await expect(page.getByText('Delete', { exact: false })).toBeVisible({ timeout: 3000 });
+      }
+    }
+  });
+
+  test('admin sees moderation controls on post detail page', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set ADMIN_EMAIL / ADMIN_PASSWORD for admin tests');
+      return;
+    }
+
+    await page.goto('/forum');
+    await expect(page.getByRole('heading', { name: 'Community Hub', exact: true })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Click on the first post to go to detail
+    const postCards = page.locator('[class*="cursor-pointer"]').filter({ has: page.locator('h3') });
+    const postCount = await postCards.count();
+    if (postCount > 0) {
+      await postCards.first().click();
+      // Wait for detail page to load
+      await expect(page.getByText('Back to Forum')).toBeVisible({ timeout: 15_000 });
+
+      // Admin badge should be visible
+      const adminBadge = page.getByText('Admin', { exact: true });
+      if (await adminBadge.isVisible({ timeout: 3000 }).catch(() => false)) {
+        // Admin action buttons should be present
+        await expect(page.getByRole('button', { name: /Delete/i })).toBeVisible();
+      }
+    }
+  });
+});
+
+// ── Regular user tests (should NOT see admin controls) ──
+
+test.describe('Community Moderation Regular User', () => {
+  test.beforeAll(async ({ request, baseURL }) => {
+    test.skip(!baseURL, 'baseURL required');
+    await assertCommunityApiHealthy(request, baseURL!);
+  }, { timeout: 120_000 });
+
+  test('regular user does not see moderation menu on forum', async ({ page }) => {
+    await page.goto('/dashboard');
+    if (page.url().includes('/login')) {
+      test.skip(true, 'Set E2E_USER_EMAIL / E2E_USER_PASSWORD');
+      return;
+    }
+
+    await page.goto('/forum');
+    await expect(page.getByRole('heading', { name: 'Community Hub', exact: true })).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Regular users should NOT have the Moderate menu button
+    const moderateButtons = page.locator('button[title="Moderate"]');
+    expect(await moderateButtons.count()).toBe(0);
+  });
+});

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -799,14 +799,17 @@ model AuditLog {
 // Note: CommunityProfile links to User via userId, NOT a separate User table
 
 model CommunityProfile {
-  id         String   @id @default(uuid())
-  userId     String   @unique
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  bio        String?
-  reputation Int      @default(0)
-  level      Int      @default(1)
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id           String    @id @default(uuid())
+  userId       String    @unique
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  bio          String?
+  reputation   Int       @default(0)
+  level        Int       @default(1)
+  isBanned     Boolean   @default(false)
+  bannedAt     DateTime?
+  bannedReason String?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   posts          CommunityPost[]
   comments       CommunityComment[]
@@ -1536,6 +1539,7 @@ model GatewayConfig {
 
 model CapacityRequest {
   id               String                @id @default(uuid())
+  creatorId        String?
   requesterName    String
   requesterAccount String
   gpuModel         String
@@ -1563,6 +1567,7 @@ model CapacityRequest {
   @@index([validUntil])
   @@index([createdAt])
   @@index([riskLevel])
+  @@index([creatorId])
   @@schema("plugin_capacity")
 }
 
@@ -1571,6 +1576,7 @@ enum CapacityRequestStatus {
   EXPIRED
   FULFILLED
   CANCELLED
+  CLOSED
 
   @@schema("plugin_capacity")
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -102,6 +102,8 @@ export interface Capability {
 
 export interface CapacityRequest {
   id: string;
+  /** User ID of the creator (set on creation from authenticated session) */
+  creatorId?: string;
   /** Who initiated - user description input (displayed as title) */
   requesterName: string;
   /** Account/wallet name (displayed below title) */
@@ -137,7 +139,7 @@ export interface CapacityRequest {
   /** ISO timestamp of creation */
   createdAt: string;
   /** Request status */
-  status: 'active' | 'expired' | 'fulfilled';
+  status: 'active' | 'expired' | 'fulfilled' | 'cancelled' | 'closed';
 
   // Legacy compat fields (optional)
   gatewayName?: string;

--- a/plugins/capacity-planner/frontend/src/components/RequestCard.tsx
+++ b/plugins/capacity-planner/frontend/src/components/RequestCard.tsx
@@ -49,20 +49,28 @@ export const RequestCard: React.FC<RequestCardProps> = ({
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="glass-card p-5 hover:border-accent-blue/30 transition-all cursor-pointer group flex flex-col"
+      className={`glass-card p-5 hover:border-accent-blue/30 transition-all cursor-pointer group flex flex-col ${
+        request.status !== 'active' ? 'opacity-60' : ''
+      }`}
       onClick={() => onSelect(request)}
     >
       {/* Header: Requester info */}
       <div className="flex items-start justify-between mb-3">
         <div className="min-w-0 flex-1 mr-3">
-          <h3 className="font-bold text-text-primary text-sm leading-tight truncate group-hover:text-accent-blue transition-colors">
+          <h3 className={`font-bold text-sm leading-tight truncate transition-colors ${
+            request.status !== 'active' ? 'text-text-secondary' : 'text-text-primary group-hover:text-accent-blue'
+          }`}>
             {request.requesterName}
           </h3>
           <p className="text-xs text-text-secondary font-mono mt-0.5 truncate">
             {request.requesterAccount}
           </p>
         </div>
-        <Badge variant={request.status === 'active' ? 'emerald' : 'secondary'}>
+        <Badge variant={
+          request.status === 'active' ? 'emerald' :
+          request.status === 'fulfilled' ? 'blue' :
+          'secondary'
+        }>
           {request.status}
         </Badge>
       </div>

--- a/plugins/capacity-planner/frontend/src/components/RequestDetailModal.tsx
+++ b/plugins/capacity-planner/frontend/src/components/RequestDetailModal.tsx
@@ -77,6 +77,8 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
     }
   };
 
+  const isActionable = request.status === 'active';
+
   const totalCommittedGpus = request.softCommits.reduce(
     (sum, sc) => sum + (sc.gpuCount ?? 1),
     0
@@ -196,9 +198,12 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
                 <div className="relative">
                   <button
                     ref={commitBtnRef}
-                    onClick={() => setShowCommitDialog(true)}
+                    onClick={() => isActionable && setShowCommitDialog(true)}
+                    disabled={!isActionable}
                     className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all ${
-                      hasCommitted
+                      !isActionable
+                        ? 'opacity-40 cursor-not-allowed bg-bg-tertiary text-text-secondary border border-[var(--border-color)]'
+                        : hasCommitted
                         ? 'bg-accent-emerald/20 text-accent-emerald border border-accent-emerald/30'
                         : 'bg-accent-emerald text-white shadow-lg shadow-accent-emerald/20 hover:bg-accent-emerald/90'
                     }`}
@@ -315,14 +320,15 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
                     value={commentText}
                     onChange={(e) => setCommentText(e.target.value)}
                     onKeyDown={handleKeyDown}
-                    placeholder="Ask a question or leave a comment..."
+                    disabled={!isActionable}
+                    placeholder={isActionable ? "Ask a question or leave a comment..." : "This request is no longer active"}
                     rows={2}
-                    className="w-full bg-bg-tertiary border border-[var(--border-color)] rounded-xl px-3 py-2.5 text-sm text-text-primary focus:outline-none focus:border-accent-blue transition-colors resize-none placeholder:text-text-secondary/50"
+                    className="w-full bg-bg-tertiary border border-[var(--border-color)] rounded-xl px-3 py-2.5 text-sm text-text-primary focus:outline-none focus:border-accent-blue transition-colors resize-none placeholder:text-text-secondary/50 disabled:opacity-40 disabled:cursor-not-allowed"
                   />
                 </div>
                 <button
                   onClick={handleSubmitComment}
-                  disabled={!commentText.trim()}
+                  disabled={!isActionable || !commentText.trim()}
                   className="self-end px-4 py-2.5 bg-accent-blue text-white rounded-xl font-medium text-sm hover:bg-accent-blue/90 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
                 >
                   <Send size={16} />

--- a/plugins/capacity-planner/frontend/src/components/RequestDetailModal.tsx
+++ b/plugins/capacity-planner/frontend/src/components/RequestDetailModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   X,
+  XCircle,
   ThumbsUp,
   MessageSquare,
   Send,
@@ -27,9 +28,11 @@ interface RequestDetailModalProps {
   onCommit: (request: CapacityRequest, gpuCount: number) => void;
   onWithdraw: (request: CapacityRequest) => void;
   onAddComment: (requestId: string, comment: RequestComment) => void;
+  onCloseRequest?: (requestId: string) => void;
   hasCommitted: boolean;
   userCommitCount?: number;
   currentUserName: string;
+  currentUserId?: string;
 }
 
 export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
@@ -39,9 +42,11 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
   onCommit,
   onWithdraw,
   onAddComment,
+  onCloseRequest,
   hasCommitted,
   userCommitCount,
   currentUserName,
+  currentUserId,
 }) => {
   const [commentText, setCommentText] = useState('');
   const [showCommitDialog, setShowCommitDialog] = useState(false);
@@ -119,19 +124,39 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
                 {request.requesterAccount}
               </p>
               <div className="flex items-center gap-2 mt-2">
-                <Badge variant={request.status === 'active' ? 'emerald' : 'secondary'}>
+                <Badge variant={
+                  request.status === 'active' ? 'emerald' :
+                  request.status === 'closed' ? 'secondary' :
+                  request.status === 'expired' ? 'secondary' :
+                  request.status === 'fulfilled' ? 'blue' :
+                  'secondary'
+                }>
                   {request.status}
                 </Badge>
                 <Badge variant="blue">{request.gpuModel} x {request.count}</Badge>
                 <RiskIndicator level={request.riskLevel} size="md" />
               </div>
             </div>
-            <button
-              onClick={onClose}
-              className="p-2 rounded-lg hover:bg-white/5 text-text-secondary hover:text-text-primary transition-colors flex-shrink-0"
-            >
-              <X size={20} />
-            </button>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              {onCloseRequest && request.status === 'active' && currentUserId && request.creatorId === currentUserId && (
+                <button
+                  onClick={() => {
+                    if (window.confirm('Close this request? It will be moved to the archive.')) {
+                      onCloseRequest(request.id);
+                    }
+                  }}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-accent-rose hover:bg-accent-rose/10 rounded-lg transition-colors border border-accent-rose/20"
+                >
+                  <XCircle size={14} /> Close Request
+                </button>
+              )}
+              <button
+                onClick={onClose}
+                className="p-2 rounded-lg hover:bg-white/5 text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <X size={20} />
+              </button>
+            </div>
           </div>
 
           {/* Scrollable content */}

--- a/plugins/capacity-planner/frontend/src/lib/api.ts
+++ b/plugins/capacity-planner/frontend/src/lib/api.ts
@@ -113,6 +113,8 @@ export interface FetchRequestsParams {
   sort?: string;
   limit?: number;
   offset?: number;
+  /** Filter by status: 'active' (default), 'archived', or 'all' */
+  status?: 'active' | 'archived' | 'all';
 }
 
 export interface FetchRequestsResult {
@@ -130,6 +132,7 @@ export async function fetchRequests(params: FetchRequestsParams = {}): Promise<F
   if (params.sort) searchParams.set('sort', params.sort);
   if (params.limit != null) searchParams.set('limit', String(params.limit));
   if (params.offset != null) searchParams.set('offset', String(params.offset));
+  if (params.status) searchParams.set('status', params.status);
 
   const query = searchParams.toString();
   const url = `${getCapacityApiBaseUrl()}/requests${query ? `?${query}` : ''}`;
@@ -227,6 +230,14 @@ export async function addComment(
   return apiRequest<RequestComment>(`/requests/${requestId}/comments`, {
     method: 'POST',
     body: JSON.stringify({ author, text }),
+  });
+}
+
+// Close a capacity request (creator or admin only)
+export async function closeRequest(requestId: string): Promise<CapacityRequest> {
+  return apiRequest<CapacityRequest>(`/requests/${requestId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'CLOSED' }),
   });
 }
 

--- a/plugins/capacity-planner/frontend/src/pages/Capacity.tsx
+++ b/plugins/capacity-planner/frontend/src/pages/Capacity.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   AlertCircle,
   RefreshCw,
+  Archive,
 } from 'lucide-react';
 import { Card } from '@naap/ui';
 import type { CapacityRequest, FilterState, SortField, RequestComment, SummaryData } from '../types';
@@ -24,6 +25,7 @@ import {
   commitCapacity as apiCommitCapacity,
   withdrawCommit as apiWithdrawCommit,
   addComment as apiAddComment,
+  closeRequest as apiCloseRequest,
   fetchCurrentUser,
   fetchSummary,
   type FetchRequestsParams,
@@ -62,6 +64,7 @@ export const CapacityPage: React.FC = () => {
     pipeline: '',
   });
   const [sortField, setSortField] = useState<SortField>('newest');
+  const [showArchived, setShowArchived] = useState(false);
 
   const [debouncedSearch, setDebouncedSearch] = useState('');
   useEffect(() => {
@@ -106,6 +109,7 @@ export const CapacityPage: React.FC = () => {
         const params: FetchRequestsParams = {
           limit: PAGE_SIZE,
           offset: 0,
+          status: showArchived ? 'archived' : 'active',
         };
         if (filters.gpuModel) params.gpuModel = filters.gpuModel;
         if (filters.pipeline) params.pipeline = filters.pipeline;
@@ -128,7 +132,7 @@ export const CapacityPage: React.FC = () => {
         }
       }
     },
-    [filters.gpuModel, filters.pipeline, filters.vramMin, debouncedSearch, sortField, mergeCommittedFromRequests]
+    [filters.gpuModel, filters.pipeline, filters.vramMin, debouncedSearch, sortField, showArchived, mergeCommittedFromRequests]
   );
 
   const loadMore = useCallback(
@@ -142,6 +146,7 @@ export const CapacityPage: React.FC = () => {
         const params: FetchRequestsParams = {
           limit: PAGE_SIZE,
           offset,
+          status: showArchived ? 'archived' : 'active',
         };
         if (filters.gpuModel) params.gpuModel = filters.gpuModel;
         if (filters.pipeline) params.pipeline = filters.pipeline;
@@ -181,6 +186,7 @@ export const CapacityPage: React.FC = () => {
       filters.vramMin,
       debouncedSearch,
       sortField,
+      showArchived,
     ]
   );
 
@@ -230,7 +236,22 @@ export const CapacityPage: React.FC = () => {
       : PIPELINE_OPTIONS;
 
   const hasActiveFilters = filters.gpuModel || filters.vramMin || filters.pipeline;
-  const hasAnyListFilter = hasActiveFilters || Boolean(filters.search.trim());
+  const hasAnyListFilter = hasActiveFilters || Boolean(filters.search.trim()) || showArchived;
+
+  const handleCloseRequest = useCallback(
+    async (requestId: string) => {
+      try {
+        await apiCloseRequest(requestId);
+        setSelectedRequest(null);
+        refreshSummary();
+        await loadRequests(currentUser.id);
+      } catch (err) {
+        console.error('[Capacity] Failed to close request:', err);
+        alert('Failed to close request: ' + (err instanceof Error ? err.message : 'Unknown error'));
+      }
+    },
+    [currentUser.id, loadRequests, refreshSummary]
+  );
 
   const getUserCommit = useCallback(
     (request: CapacityRequest) => {
@@ -394,6 +415,7 @@ export const CapacityPage: React.FC = () => {
 
   const clearFilters = () => {
     setFilters({ search: '', gpuModel: '', vramMin: '', pipeline: '' });
+    setShowArchived(false);
   };
 
   const sortOptions: { value: SortField; label: string }[] = [
@@ -513,6 +535,18 @@ export const CapacityPage: React.FC = () => {
               ))}
             </select>
           </div>
+
+          <button
+            onClick={() => setShowArchived(!showArchived)}
+            className={`flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium transition-all border ${
+              showArchived
+                ? 'bg-accent-amber/10 text-accent-amber border-accent-amber/30'
+                : 'bg-bg-secondary text-text-secondary border-[var(--border-color)] hover:text-text-primary'
+            }`}
+          >
+            <Archive size={15} />
+            Archived
+          </button>
 
           <button
             onClick={() => setShowNewRequestModal(true)}
@@ -642,10 +676,12 @@ export const CapacityPage: React.FC = () => {
         <Card className="text-center py-16">
           <Zap size={48} className="mx-auto mb-4 text-text-secondary opacity-30" />
           <h3 className="text-lg font-bold text-text-primary mb-2">
-            {hasAnyListFilter ? 'No matching requests' : 'No active requests'}
+            {showArchived ? 'No archived requests' : hasAnyListFilter ? 'No matching requests' : 'No active requests'}
           </h3>
           <p className="text-text-secondary mb-4">
-            {hasAnyListFilter
+            {showArchived
+              ? 'No closed, expired, or cancelled requests found'
+              : hasAnyListFilter
               ? 'Try adjusting your filters or search terms'
               : 'Create a new capacity request to get started'}
           </p>
@@ -675,9 +711,11 @@ export const CapacityPage: React.FC = () => {
           onCommit={handleCommit}
           onWithdraw={handleWithdraw}
           onAddComment={handleAddComment}
+          onCloseRequest={handleCloseRequest}
           hasCommitted={committedIds.has(selectedRequest.id)}
           userCommitCount={getUserCommit(selectedRequest)?.gpuCount}
           currentUserName={currentUser.name}
+          currentUserId={currentUser.id}
         />
       )}
     </div>

--- a/plugins/community/frontend/src/App.tsx
+++ b/plugins/community/frontend/src/App.tsx
@@ -16,9 +16,11 @@ const UserSync: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   useEffect(() => {
     if (user) {
+      const isAdmin = user.roles?.includes('community:admin') || user.roles?.includes('system:admin') || false;
       setCurrentUser({
         userId: user.id || 'anonymous',
         displayName: user.displayName || user.address?.slice(0, 10) || 'Anonymous',
+        isAdmin,
       });
     } else {
       setCurrentUser(null);

--- a/plugins/community/frontend/src/api/client.ts
+++ b/plugins/community/frontend/src/api/client.ts
@@ -18,19 +18,19 @@ const API_BASE = getPluginBackendUrl('community', {
 });
 
 // Module-level user state, set by React components via setCurrentUser()
-let _currentUser: { userId: string; displayName: string } | null = null;
+let _currentUser: { userId: string; displayName: string; isAdmin?: boolean } | null = null;
 
 /**
  * Set the current user from a React component (call from useEffect with useAuth/useUser hooks).
  */
-export function setCurrentUser(user: { userId: string; displayName: string } | null) {
+export function setCurrentUser(user: { userId: string; displayName: string; isAdmin?: boolean } | null) {
   _currentUser = user;
 }
 
 /**
  * Get the current user. Returns null if not set.
  */
-export function getCurrentUser(): { userId: string; displayName: string } | null {
+export function getCurrentUser(): { userId: string; displayName: string; isAdmin?: boolean } | null {
   return _currentUser;
 }
 
@@ -473,4 +473,41 @@ export async function searchPosts(query: string, params?: {
   const json = await res.json();
   const payload = json.data ?? json;
   return { posts: Array.isArray(payload?.posts) ? payload.posts : [], total: payload?.total ?? 0, query };
+}
+
+// --- Admin Moderation ---
+
+export async function moderatePost(
+  postId: string,
+  action: 'delete' | 'close' | 'archive'
+): Promise<{ deleted?: boolean; post?: { id: string; status: string } }> {
+  const res = await fetch(`${API_BASE}/posts/${postId}/moderate`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: JSON.stringify({ action }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to moderate post');
+  }
+  const json = await res.json();
+  return json.data ?? json;
+}
+
+export async function banUser(
+  userId: string,
+  banned: boolean,
+  reason?: string
+): Promise<{ userId: string; isBanned: boolean }> {
+  const res = await fetch(`${API_BASE}/users/${userId}/ban`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: JSON.stringify({ banned, reason }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to update ban status');
+  }
+  const json = await res.json();
+  return json.data ?? json;
 }

--- a/plugins/community/frontend/src/pages/Forum.tsx
+++ b/plugins/community/frontend/src/pages/Forum.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Users, Plus, Search, MessageSquare, ThumbsUp, Clock, CheckCircle, TrendingUp, HelpCircle, Megaphone, Sparkles, Trophy, Tag, Loader2 } from 'lucide-react';
+import { Users, Plus, Search, MessageSquare, ThumbsUp, Clock, CheckCircle, TrendingUp, HelpCircle, Megaphone, Sparkles, Trophy, Tag, Loader2, MoreVertical, Trash2, XCircle, Archive, Ban } from 'lucide-react';
 import { Card, Badge } from '@naap/ui';
-import { fetchPosts, fetchLeaderboard, fetchTags, votePost, removeVote, checkVoted, isUserLoggedIn, getCurrentUser, type Post, type LeaderboardEntry, type Tag as TagType } from '../api/client';
+import { fetchPosts, fetchLeaderboard, fetchTags, votePost, removeVote, checkVoted, moderatePost, banUser, isUserLoggedIn, getCurrentUser, type Post, type LeaderboardEntry, type Tag as TagType } from '../api/client';
 import { CreatePostModal } from '../components/CreatePostModal';
 
 const CATEGORIES = [
@@ -232,6 +232,32 @@ export const ForumPage: React.FC = () => {
   };
 
   const currentUser = getCurrentUser();
+  const isAdmin = currentUser?.isAdmin ?? false;
+  const [adminMenuPostId, setAdminMenuPostId] = useState<string | null>(null);
+
+  const handleAdminAction = async (postId: string, action: 'delete' | 'close' | 'archive') => {
+    setAdminMenuPostId(null);
+    const labels = { delete: 'delete', close: 'close', archive: 'archive' };
+    if (!window.confirm(`Are you sure you want to ${labels[action]} this post?`)) return;
+    try {
+      await moderatePost(postId, action);
+      loadPosts();
+    } catch (err) {
+      alert('Failed to moderate post: ' + (err as Error).message);
+    }
+  };
+
+  const handleBanPostAuthor = async (post: Post) => {
+    setAdminMenuPostId(null);
+    const reason = window.prompt('Reason for banning this user (optional):');
+    if (reason === null) return;
+    try {
+      await banUser(post.author.userId, true, reason || undefined);
+      alert('User has been banned from the community.');
+    } catch (err) {
+      alert('Failed to ban user: ' + (err as Error).message);
+    }
+  };
 
   return (
     <div className="flex gap-4 h-full min-h-0">
@@ -428,6 +454,55 @@ export const ForumPage: React.FC = () => {
                           </span>
                         ))}
                       </div>
+                      {isAdmin && (
+                        <div className="relative ml-auto">
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setAdminMenuPostId(adminMenuPostId === post.id ? null : post.id);
+                            }}
+                            className="p-1 rounded hover:bg-white/10 text-text-secondary hover:text-text-primary transition-colors"
+                            title="Moderate"
+                          >
+                            <MoreVertical size={14} />
+                          </button>
+                          {adminMenuPostId === post.id && (
+                            <div
+                              className="absolute right-0 top-full mt-1 w-36 bg-bg-secondary border border-white/10 rounded-lg shadow-xl z-20 py-1"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <button
+                                onClick={() => handleAdminAction(post.id, 'delete')}
+                                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-accent-rose hover:bg-white/5 transition-colors"
+                              >
+                                <Trash2 size={12} /> Delete
+                              </button>
+                              {post.status === 'OPEN' && (
+                                <button
+                                  onClick={() => handleAdminAction(post.id, 'close')}
+                                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-accent-amber hover:bg-white/5 transition-colors"
+                                >
+                                  <XCircle size={12} /> Close
+                                </button>
+                              )}
+                              {post.status === 'OPEN' && (
+                                <button
+                                  onClick={() => handleAdminAction(post.id, 'archive')}
+                                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-text-secondary hover:bg-white/5 transition-colors"
+                                >
+                                  <Archive size={12} /> Archive
+                                </button>
+                              )}
+                              <button
+                                onClick={() => handleBanPostAuthor(post)}
+                                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-accent-rose hover:bg-white/5 transition-colors"
+                              >
+                                <Ban size={12} /> Ban User
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/plugins/community/frontend/src/pages/PostDetail.tsx
+++ b/plugins/community/frontend/src/pages/PostDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, ThumbsUp, Clock, CheckCircle, MessageSquare, Send, Loader2, Eye } from 'lucide-react';
+import { ArrowLeft, ThumbsUp, Clock, CheckCircle, MessageSquare, Send, Loader2, Eye, Shield, Trash2, Ban, Archive, XCircle } from 'lucide-react';
 import DOMPurify from 'dompurify';
 import { Card, Badge } from '@naap/ui';
 import {
@@ -11,6 +11,9 @@ import {
   createComment,
   voteComment,
   acceptAnswer,
+  moderatePost,
+  banUser,
+  deletePost,
   isUserLoggedIn,
   getCurrentUser,
   type Post,
@@ -211,6 +214,47 @@ export const PostDetailPage: React.FC = () => {
 
   const currentUser = getCurrentUser();
   const isAuthor = post && currentUser && currentUser.userId === post.author.userId;
+  const isAdmin = currentUser?.isAdmin ?? false;
+
+  const handleModerate = async (action: 'delete' | 'close' | 'archive') => {
+    if (!post) return;
+    const labels = { delete: 'delete', close: 'close', archive: 'archive' };
+    if (!window.confirm(`Are you sure you want to ${labels[action]} this post?`)) return;
+    try {
+      await moderatePost(post.id, action);
+      if (action === 'delete') {
+        navigate('/');
+      } else {
+        const updated = await fetchPost(post.id);
+        setPost(updated);
+      }
+    } catch (err) {
+      alert('Failed to moderate post: ' + (err as Error).message);
+    }
+  };
+
+  const handleDeletePost = async () => {
+    if (!post) return;
+    if (!window.confirm('Are you sure you want to delete this post? This cannot be undone.')) return;
+    try {
+      await deletePost(post.id);
+      navigate('/');
+    } catch (err) {
+      alert('Failed to delete post: ' + (err as Error).message);
+    }
+  };
+
+  const handleBanUser = async () => {
+    if (!post) return;
+    const reason = window.prompt('Reason for banning this user (optional):');
+    if (reason === null) return; // cancelled
+    try {
+      await banUser(post.author.userId, true, reason || undefined);
+      alert('User has been banned from the community.');
+    } catch (err) {
+      alert('Failed to ban user: ' + (err as Error).message);
+    }
+  };
 
   if (loading) {
     return (
@@ -337,6 +381,50 @@ export const PostDetailPage: React.FC = () => {
                 </span>
               ))}
             </div>
+
+            {/* Author / Admin actions */}
+            {(isAuthor || isAdmin) && (
+              <div className="flex items-center gap-2 mt-4 pt-4 border-t border-white/10">
+                {isAdmin && (
+                  <div className="flex items-center gap-1 mr-2">
+                    <Shield size={14} className="text-accent-amber" />
+                    <span className="text-xs font-medium text-accent-amber">Admin</span>
+                  </div>
+                )}
+                {(isAuthor || isAdmin) && (
+                  <button
+                    onClick={handleDeletePost}
+                    className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-accent-rose hover:bg-accent-rose/10 rounded-md transition-colors"
+                  >
+                    <Trash2 size={12} /> Delete
+                  </button>
+                )}
+                {isAdmin && post.status === 'OPEN' && (
+                  <button
+                    onClick={() => handleModerate('close')}
+                    className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-accent-amber hover:bg-accent-amber/10 rounded-md transition-colors"
+                  >
+                    <XCircle size={12} /> Close
+                  </button>
+                )}
+                {isAdmin && post.status === 'OPEN' && (
+                  <button
+                    onClick={() => handleModerate('archive')}
+                    className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-text-secondary hover:bg-white/5 rounded-md transition-colors"
+                  >
+                    <Archive size={12} /> Archive
+                  </button>
+                )}
+                {isAdmin && !isAuthor && (
+                  <button
+                    onClick={handleBanUser}
+                    className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-accent-rose hover:bg-accent-rose/10 rounded-md transition-colors"
+                  >
+                    <Ban size={12} /> Ban User
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary

- **Community Hub admin moderation**: admins can delete, close, or archive any post, and ban/unban users from posting and commenting. Ban enforcement is applied at the API level on both post and comment creation endpoints.
- **Capacity Planner lifecycle**: new requests track `creatorId`; request creators can close their own requests via ownership-enforced PATCH. Expired requests (past `validUntil`) are hidden from the default listing. A new `status=archived|all` query parameter reveals closed/expired/cancelled/fulfilled requests.
- **Frontend**: admin moderation dropdown on forum list, action bar on post detail, Archived toggle button on capacity page, Close Request button in request detail modal, and status badges for all states.
- **E2E tests**: comprehensive Playwright tests covering community moderation API endpoints (auth, moderate, ban, delete), capacity planner lifecycle API (status filters, create→close→archive flow, ownership enforcement), and UI tests for both features.

## Changes

### Backend (API)
- `schema.prisma`: `CommunityProfile.isBanned/bannedAt/bannedReason`, `CapacityRequest.creatorId`, `CLOSED` status enum
- `POST /community/posts/[id]/moderate` — admin moderation actions
- `POST /community/users/[id]/ban` — admin user ban/unban
- `DELETE/PUT /community/posts/[id]` — extended with admin role check
- `POST /community/posts`, `POST /community/posts/[id]/comments` — ban enforcement
- `GET /capacity-planner/requests` — default excludes expired; supports `?status=active|archived|all`
- `POST /capacity-planner/requests` — stores `creatorId`
- `PATCH /capacity-planner/requests/[id]` — ownership check for `CLOSED` status

### Frontend
- Community Forum: three-dot admin menu (delete/close/archive/ban) on post cards and detail page
- Capacity Planner: Archived toggle, Close Request button, status badges, dimmed non-active cards

### E2E Tests
- `community-moderation.spec.ts` — API auth/403 tests, admin UI visibility, regular user exclusion
- `capacity-lifecycle.spec.ts` — status filter validation, create→close→archive API flow, UI toggle and modal tests

## Test plan
- [ ] Verify Prisma migration generates cleanly
- [ ] Run `npx playwright test community-moderation` — all tests pass
- [ ] Run `npx playwright test capacity-lifecycle` — all tests pass
- [ ] Manual: login as admin, verify moderation menu appears on forum
- [ ] Manual: ban a user, verify they cannot create posts/comments
- [ ] Manual: create a capacity request, close it, verify it moves to archived
- [ ] Manual: toggle Archived filter, verify only non-active requests appear


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Close request action for creators and admins; UI supports closing a request and toggling archived view
  - Status filter for capacity requests (active, archived, all) and creator attribution on requests
  - Admin moderation tools: post moderation actions and user ban/unban with reasons; admin UI controls added

* **Bug Fixes**
  - Blocked banned users from creating posts/comments
  - Strengthened authorization for editing/closing/deleting posts and requests

* **Tests**
  - Added E2E suites for capacity planner lifecycle and community moderation (API + UI)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->