### PR TITLE
fix(e2e): capacity lifecycle badge locator and gap assertion

### DIFF
--- a/apps/web-next/tests/capacity-lifecycle.spec.ts
+++ b/apps/web-next/tests/capacity-lifecycle.spec.ts
@@ -475,10 +475,11 @@ test.describe('Capacity Planner Lifecycle UI @pre-release', () => {
 
     await cards.first().click();
 
-    // Wait for the modal overlay to appear, then assert the badge inside it
+    // The Badge component renders <span class="px-2 py-0.5 rounded-full …">
+    // so match by the Tailwind classes it actually uses, scoped to the modal.
     const modal = page.locator('.fixed.inset-0');
     await expect(
-      modal.locator('[class*="badge"], [class*="Badge"]').first(),
+      modal.locator('span.rounded-full.text-xs').first(),
     ).toBeVisible({ timeout: 10_000 });
 
     await expect(page.getByText('Specifications')).toBeVisible({ timeout: 5_000 });
@@ -520,10 +521,10 @@ test.describe('Capacity Planner Lifecycle UI @pre-release', () => {
     test.skip(cardCount < 2, 'Need at least 2 cards to verify grid gap');
 
     const grid = cards.first().locator('..');
-    const gap = await grid.evaluate(
-      (el) => window.getComputedStyle(el).gap || window.getComputedStyle(el).columnGap,
-    );
-    const gapPx = parseFloat(gap);
+    const gapPx = await grid.evaluate((el) => {
+      const cs = window.getComputedStyle(el);
+      return parseFloat(cs.columnGap) || parseFloat(cs.rowGap) || parseFloat(cs.gap) || 0;
+    });
     expect(gapPx).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Badge locator mismatch**: The `Badge` component from `@naap/ui` renders `<span class="px-2 py-0.5 rounded-full text-xs font-semibold border ...">` with no class containing "badge". The test used `[class*="badge"], [class*="Badge"]` which never matches. Fixed to use `span.rounded-full.text-xs` scoped to the modal overlay.
- **Gap assertion NaN**: `getComputedStyle().gap` returns `"normal"` in headless Chromium when the gap is set via inline style or shorthand. `parseFloat("normal")` returns `NaN`. Fixed to check longhand properties `columnGap`/`rowGap` first, then fall back to `gap`.

Fixes 2 failures from [E2E Nightly #6](https://github.com/livepeer/naap/actions/runs/24247081824).

## Test plan

- [ ] `request detail modal shows status badge` passes in CI
- [ ] `card grid has non-zero gap on initial load` passes in CI
- [ ] No other test regressions

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability with more specific modal element selectors.
  * Enhanced grid gap assertion logic with defensive fallback handling for cross-browser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->