### PR TITLE
feat(auth): Use PasswordInput component in login, register, and reset password forms

### DIFF
--- a/apps/web-next/src/app/(auth)/login/login-form.tsx
+++ b/apps/web-next/src/app/(auth)/login/login-form.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/auth-context';
 import { Loader2, ArrowLeft } from 'lucide-react';
+import { PasswordInput } from '@/components/auth/PasswordInput';
 
 function formatOAuthError(errorCode: string): string {
   const errorMessages: Record<string, string> = {
@@ -101,13 +102,13 @@ export default function LoginForm() {
           <label htmlFor="password" className="block text-[13px] font-medium text-muted-foreground mb-1.5">
             Password
           </label>
-          <input
+          <PasswordInput
             id="password"
-            type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-3 py-2 text-sm bg-background border border-muted-foreground/25 rounded-lg text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-muted-foreground/50 focus:ring-1 focus:ring-muted-foreground/20 transition-colors"
+            inputClassName="w-full px-3 py-2 text-sm bg-background border border-muted-foreground/25 rounded-lg text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-muted-foreground/50 focus:ring-1 focus:ring-muted-foreground/20 transition-colors"
             placeholder="Enter your password"
+            autoComplete="current-password"
             required
           />
         </div>

--- a/apps/web-next/src/app/(auth)/register/register-form.tsx
+++ b/apps/web-next/src/app/(auth)/register/register-form.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Loader2, ArrowLeft } from 'lucide-react';
+import { PasswordInput } from '@/components/auth/PasswordInput';
 import { useAuth } from '@/contexts/auth-context';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';
@@ -151,14 +152,14 @@ export default function RegisterForm() {
           <label htmlFor="password" className="block text-[13px] font-medium text-muted-foreground mb-1.5">
             Password
           </label>
-          <input
+          <PasswordInput
             id="password"
             name="password"
-            type="password"
             value={formData.password}
             onChange={handleChange}
-            className={inputClass}
+            inputClassName={inputClass}
             placeholder="Min. 8 characters"
+            autoComplete="new-password"
             required
             minLength={8}
           />
@@ -168,14 +169,14 @@ export default function RegisterForm() {
           <label htmlFor="confirmPassword" className="block text-[13px] font-medium text-muted-foreground mb-1.5">
             Confirm password
           </label>
-          <input
+          <PasswordInput
             id="confirmPassword"
             name="confirmPassword"
-            type="password"
             value={formData.confirmPassword}
             onChange={handleChange}
-            className={inputClass}
+            inputClassName={inputClass}
             placeholder="Confirm your password"
+            autoComplete="new-password"
             required
           />
         </div>

--- a/apps/web-next/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/apps/web-next/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -4,6 +4,7 @@ import { useState, Suspense } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Loader2, CheckCircle, AlertCircle } from 'lucide-react';
+import { PasswordInput } from '@/components/auth/PasswordInput';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';
 
@@ -158,14 +159,14 @@ function ResetPasswordFormInner() {
           <label htmlFor="password" className="block text-[13px] font-medium text-muted-foreground mb-1.5">
             New password
           </label>
-          <input
+          <PasswordInput
             id="password"
             name="password"
-            type="password"
             value={formData.password}
             onChange={handleChange}
-            className={inputClass}
+            inputClassName={inputClass}
             placeholder="Min. 8 characters"
+            autoComplete="new-password"
             required
             minLength={8}
           />
@@ -175,14 +176,14 @@ function ResetPasswordFormInner() {
           <label htmlFor="confirmPassword" className="block text-[13px] font-medium text-muted-foreground mb-1.5">
             Confirm new password
           </label>
-          <input
+          <PasswordInput
             id="confirmPassword"
             name="confirmPassword"
-            type="password"
             value={formData.confirmPassword}
             onChange={handleChange}
-            className={inputClass}
+            inputClassName={inputClass}
             placeholder="Confirm your password"
+            autoComplete="new-password"
             required
           />
         </div>

--- a/apps/web-next/src/components/auth/PasswordInput.tsx
+++ b/apps/web-next/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+export type PasswordInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  /** Classes for the `<input>` (must leave room for the button — `pr-10` is applied automatically). */
+  inputClassName?: string;
+};
+
+/**
+ * Password field with show/hide toggle (eye icon).
+ */
+export function PasswordInput({ inputClassName, className, id, autoComplete, ...props }: PasswordInputProps) {
+  const [show, setShow] = useState(false);
+  const inputClasses = ['pr-10', inputClassName].filter(Boolean).join(' ');
+
+  return (
+    <div className={['relative', className].filter(Boolean).join(' ')}>
+      <input
+        id={id}
+        type={show ? 'text' : 'password'}
+        className={inputClasses}
+        autoComplete={autoComplete ?? 'current-password'}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setShow((v) => !v)}
+        className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-muted-foreground/30"
+        aria-label={show ? 'Hide password' : 'Show password'}
+        aria-pressed={show}
+      >
+        {show ? <EyeOff className="h-4 w-4" aria-hidden /> : <Eye className="h-4 w-4" aria-hidden />}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

<!-- 1-3 sentences. What does this PR do and why? -->
This change is intended to improve the UX of the password fields with a standard show/hide password icon. 

When a user is unable to login, this helps them verify the password they have typed is as expected.

## Changes
<!-- Bullet list of what changed. -->
- Updated the login, register, and reset password forms to use the new PasswordInput component for improved password handling.
- Added autoComplete attributes for better browser compatibility and user experience.
- Ensured consistent styling by passing inputClassName to the PasswordInput component.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Tooling
- [ ] Plugin (new or update)
- [ ] Dependencies

## Plugin(s) Affected

<!-- If this is a plugin PR, list the plugin name(s). Leave blank for core changes. -->

## Checklist

- [ ] Tests pass locally
- [ ] Lint passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] No new lint warnings introduced
- [ ] Breaking changes documented below
- [ ] Database migration included (if Prisma schema changed)

## Breaking Changes

<!-- If none, write "None". Otherwise describe what breaks and migration path. -->

None

## Screenshots / Recordings

<!-- For UI changes, attach screenshots or a short recording. Delete this section if not applicable. -->
<img width="426" height="255" alt="image" src="https://github.com/user-attachments/assets/c04b0ac6-3c5e-4939-92df-3af47a26be3c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added password visibility toggle feature across all authentication forms. Users can now show or hide their password input in login, registration, and password reset flows for improved usability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->