### PR TITLE
fix(e2e): target request cards specifically instead of all glass-card elements

### DIFF
--- a/apps/web-next/tests/capacity-lifecycle.spec.ts
+++ b/apps/web-next/tests/capacity-lifecycle.spec.ts
@@ -469,15 +469,19 @@ test.describe('Capacity Planner Lifecycle UI @pre-release', () => {
       timeout: 45_000,
     });
 
-    const cards = page.locator('[class*="glass-card"]');
+    // Target only clickable request cards, not the SummaryPanel or filter
+    // panel which also use the glass-card class but lack click handlers.
+    const cards = page.locator(
+      '[data-testid="capacity-request-card"], [class*="glass-card"][class*="cursor-pointer"]',
+    );
     const cardCount = await cards.count();
     test.skip(cardCount === 0, 'No request cards available to test modal');
 
     await cards.first().click();
 
-    // Verify the modal opened and rendered content. "Specifications" is a
-    // section heading that only appears inside the detail modal, proving
-    // the full modal content (including the status badge) loaded.
+    // "Specifications" is a section heading that only appears inside the
+    // detail modal, proving the full modal content (including the status
+    // badge) loaded.
     await expect(page.getByText('Specifications')).toBeVisible({ timeout: 15_000 });
   });
 
@@ -512,7 +516,9 @@ test.describe('Capacity Planner Lifecycle UI @pre-release', () => {
       timeout: 45_000,
     });
 
-    const cards = page.locator('[class*="glass-card"]');
+    const cards = page.locator(
+      '[data-testid="capacity-request-card"], [class*="glass-card"][class*="cursor-pointer"]',
+    );
     const cardCount = await cards.count();
     test.skip(cardCount < 2, 'Need at least 2 cards to verify spacing');
 

--- a/plugins/capacity-planner/frontend/src/components/RequestCard.tsx
+++ b/plugins/capacity-planner/frontend/src/components/RequestCard.tsx
@@ -46,6 +46,7 @@ export const RequestCard: React.FC<RequestCardProps> = ({
 
   return (
     <motion.div
+      data-testid="capacity-request-card"
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}


### PR DESCRIPTION
## Summary

- **Root cause**: The E2E nightly has been failing for 5+ consecutive days on the `request detail modal shows status badge` test. The `[class*="glass-card"]` selector matches the **SummaryPanel** (which appears first in the DOM) instead of the actual clickable **RequestCard** components. Clicking SummaryPanel does nothing, so the detail modal never opens and `Specifications` is never found.
- **Fix**: Added `data-testid="capacity-request-card"` to `RequestCard.tsx` and updated both affected test selectors to use a combined locator: `data-testid` for future deploys + `cursor-pointer` CSS fallback for the currently deployed production bundle.
- PR #261 (already merged) addressed the wrong symptom (badge locator vs assertion text) but not the root cause.

## Files changed

| File | Change |
|------|--------|
| `plugins/capacity-planner/frontend/src/components/RequestCard.tsx` | Add `data-testid="capacity-request-card"` |
| `apps/web-next/tests/capacity-lifecycle.spec.ts` | Update card selectors in 2 tests |

## Test plan

- [x] Playwright runs locally (tests skip without E2E credentials but no compile/runtime errors)
- [ ] Trigger `E2E Nightly` workflow via `workflow_dispatch` against this branch to verify the fix passes in CI
- [ ] Confirm the `capacity-lifecycle` `request detail modal shows status badge` test passes after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced UI tests for capacity request cards to specifically target only interactive, clickable elements instead of all elements with matching styling patterns. This reduces unintended test interactions with non-interactive panels, improving test reliability, stability, and consistency for validating the capacity planning interface's card interaction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->