### PR TITLE
feat(api): add orchestrator discovery endpoint using cached NaaP data

### DIFF
--- a/apps/web-next/src/app/api/v1/network/discover-orchestrators/route.ts
+++ b/apps/web-next/src/app/api/v1/network/discover-orchestrators/route.ts
@@ -6,6 +6,7 @@
  * the latest `LastSeen` and `capabilities_prices` per `pipeline/model` capability.
  *
  * Query: repeated `caps` — OR match (row kept if `capabilities` includes any listed value).
+ * Rows are ordered by `score` descending, then `last_seen_ms` descending, then `address`.
  *
  * @see https://github.com/livepeer/go-livepeer/blob/master/doc/remote-signer.md (Remote discovery)
  */

--- a/apps/web-next/src/app/api/v1/network/discover-orchestrators/route.ts
+++ b/apps/web-next/src/app/api/v1/network/discover-orchestrators/route.ts
@@ -1,87 +1,57 @@
 /**
  * GET /api/v1/network/discover-orchestrators
  *
- * Public, remote-signer-compatible orchestrator discovery (JSON array).
- * Query: repeated `caps` — OR match (orchestrator included if it advertises any listed capability).
+ * Public discovery JSON derived from NAAP BFF `GET /v1/net/orchestrators` (same cached bundle
+ * as KPI / orchestrator overview). One row per **on-chain orchestrator address**, grouped with
+ * the latest `LastSeen` and `capabilities_prices` per `pipeline/model` capability.
+ *
+ * Query: repeated `caps` — OR match (row kept if `capabilities` includes any listed value).
  *
  * @see https://github.com/livepeer/go-livepeer/blob/master/doc/remote-signer.md (Remote discovery)
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import discoverOrchestrators from '@/data/discover-orchestrators.json';
 import { jsonWithOverviewCache, OverviewHttpCacheSec } from '@/lib/api/overview-http-cache';
+import {
+  getOrchestratorDiscoveryList,
+  type OrchestratorDiscoveryEntry,
+} from '@/lib/facade/resolvers/net-orchestrators';
 
 export const runtime = 'nodejs';
-export const maxDuration = 30;
+export const maxDuration = 60;
 // Literal required for Next segment config; matches OVERVIEW_HTTP_CACHE_SEC (30m).
 export const revalidate = 1800;
 
-type DiscoverOrchestratorRow = {
-  address: string;
-  score: number;
-  capabilities: string[];
-};
-
-function isDiscoverRow(x: unknown): x is DiscoverOrchestratorRow {
-  if (x == null || typeof x !== 'object') {
-    return false;
-  }
-  const o = x as Record<string, unknown>;
-  return (
-    typeof o.address === 'string'
-    && o.address.trim().length > 0
-    && typeof o.score === 'number'
-    && Number.isFinite(o.score)
-    && Array.isArray(o.capabilities)
-    && o.capabilities.every((c) => typeof c === 'string')
-  );
-}
-
-function normalizeRows(raw: unknown): DiscoverOrchestratorRow[] {
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  const out: DiscoverOrchestratorRow[] = [];
-  for (const item of raw) {
-    if (isDiscoverRow(item)) {
-      out.push({
-        address: item.address.trim(),
-        score: item.score,
-        capabilities: item.capabilities.map((c) => c.trim()).filter(Boolean),
-      });
-    }
-  }
-  return out;
-}
-
-/** OR semantics: keep rows that advertise at least one requested capability. */
-function filterByCaps(rows: DiscoverOrchestratorRow[], caps: string[]): DiscoverOrchestratorRow[] {
+function filterByCaps(rows: OrchestratorDiscoveryEntry[], caps: string[]): OrchestratorDiscoveryEntry[] {
   if (caps.length === 0) {
     return rows;
   }
   return rows.filter((row) => caps.some((wanted) => row.capabilities.includes(wanted)));
 }
 
-const BASE_ROWS = normalizeRows(discoverOrchestrators);
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  if (BASE_ROWS.length === 0) {
-    console.error('[network/discover-orchestrators] empty or invalid curated list');
+  try {
+    const baseRows = await getOrchestratorDiscoveryList();
+    const caps = Array.from(
+      new Set(
+        request.nextUrl.searchParams
+          .getAll('caps')
+          .map((c) => c.trim())
+          .filter((c) => c.length > 0),
+      ),
+    );
+    const filtered = filterByCaps(baseRows, caps);
+    return jsonWithOverviewCache(filtered, OverviewHttpCacheSec.discoverOrchestrators);
+  } catch (err) {
+    console.error('[network/discover-orchestrators]', err);
     return NextResponse.json(
-      { error: { code: 'SERVICE_UNAVAILABLE', message: 'Orchestrator discovery data is unavailable' } },
-      { status: 503 },
+      {
+        error: {
+          code: 'SERVICE_UNAVAILABLE',
+          message: 'Orchestrator discovery data is unavailable',
+        },
+      },
+      { status: 503, headers: { 'Cache-Control': 'public, max-age=0, s-maxage=5, stale-while-revalidate=0' } },
     );
   }
-
-  const caps = Array.from(
-    new Set(
-      request.nextUrl.searchParams
-        .getAll('caps')
-        .map((c) => c.trim())
-        .filter((c) => c.length > 0),
-    ),
-  );
-
-  const filtered = filterByCaps(BASE_ROWS, caps);
-  return jsonWithOverviewCache(filtered, OverviewHttpCacheSec.discoverOrchestrators);
 }

--- a/apps/web-next/src/app/api/v1/network/discover-orchestrators/route.ts
+++ b/apps/web-next/src/app/api/v1/network/discover-orchestrators/route.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /api/v1/network/discover-orchestrators
+ *
+ * Public, remote-signer-compatible orchestrator discovery (JSON array).
+ * Query: repeated `caps` — OR match (orchestrator included if it advertises any listed capability).
+ *
+ * @see https://github.com/livepeer/go-livepeer/blob/master/doc/remote-signer.md (Remote discovery)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import discoverOrchestrators from '@/data/discover-orchestrators.json';
+import { jsonWithOverviewCache, OverviewHttpCacheSec } from '@/lib/api/overview-http-cache';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+// Literal required for Next segment config; matches OVERVIEW_HTTP_CACHE_SEC (30m).
+export const revalidate = 1800;
+
+type DiscoverOrchestratorRow = {
+  address: string;
+  score: number;
+  capabilities: string[];
+};
+
+function isDiscoverRow(x: unknown): x is DiscoverOrchestratorRow {
+  if (x == null || typeof x !== 'object') {
+    return false;
+  }
+  const o = x as Record<string, unknown>;
+  return (
+    typeof o.address === 'string'
+    && o.address.trim().length > 0
+    && typeof o.score === 'number'
+    && Number.isFinite(o.score)
+    && Array.isArray(o.capabilities)
+    && o.capabilities.every((c) => typeof c === 'string')
+  );
+}
+
+function normalizeRows(raw: unknown): DiscoverOrchestratorRow[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const out: DiscoverOrchestratorRow[] = [];
+  for (const item of raw) {
+    if (isDiscoverRow(item)) {
+      out.push({
+        address: item.address.trim(),
+        score: item.score,
+        capabilities: item.capabilities.map((c) => c.trim()).filter(Boolean),
+      });
+    }
+  }
+  return out;
+}
+
+/** OR semantics: keep rows that advertise at least one requested capability. */
+function filterByCaps(rows: DiscoverOrchestratorRow[], caps: string[]): DiscoverOrchestratorRow[] {
+  if (caps.length === 0) {
+    return rows;
+  }
+  return rows.filter((row) => caps.some((wanted) => row.capabilities.includes(wanted)));
+}
+
+const BASE_ROWS = normalizeRows(discoverOrchestrators);
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (BASE_ROWS.length === 0) {
+    console.error('[network/discover-orchestrators] empty or invalid curated list');
+    return NextResponse.json(
+      { error: { code: 'SERVICE_UNAVAILABLE', message: 'Orchestrator discovery data is unavailable' } },
+      { status: 503 },
+    );
+  }
+
+  const caps = Array.from(
+    new Set(
+      request.nextUrl.searchParams
+        .getAll('caps')
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0),
+    ),
+  );
+
+  const filtered = filterByCaps(BASE_ROWS, caps);
+  return jsonWithOverviewCache(filtered, OverviewHttpCacheSec.discoverOrchestrators);
+}

--- a/apps/web-next/src/lib/api/overview-http-cache.ts
+++ b/apps/web-next/src/lib/api/overview-http-cache.ts
@@ -32,6 +32,8 @@ export const OverviewHttpCacheSec = {
   perfByModel: OVERVIEW_HTTP_CACHE_SEC,
   protocol: OVERVIEW_HTTP_CACHE_SEC,
   fees: OVERVIEW_HTTP_CACHE_SEC,
+  /** Curated LV2V / remote-signer-style orchestrator discovery list */
+  discoverOrchestrators: OVERVIEW_HTTP_CACHE_SEC,
 } as const;
 
 /**

--- a/apps/web-next/src/lib/facade/resolvers/net-orchestrators.ts
+++ b/apps/web-next/src/lib/facade/resolvers/net-orchestrators.ts
@@ -12,6 +12,71 @@ import { naapGet } from '../naap-get.js';
 /** Single-request `limit` for net/orchestrators. */
 export const NET_ORCHESTRATORS_PAGE_SIZE = '1000';
 
+/**
+ * Orchestrator `hardware[].pipeline` values should already be Livepeer-style slugs.
+ * Reject unexpected shapes so registry blobs cannot inject odd capability path segments.
+ */
+const REGISTRY_PIPELINE_SLUG_RE = /^[a-z][a-z0-9-]{0,63}$/;
+
+function sanitizeRegistryPipelineSlug(raw: string): string | null {
+  const s = raw.trim();
+  return REGISTRY_PIPELINE_SLUG_RE.test(s) ? s : null;
+}
+
+/**
+ * Fallback: Livepeer `net.Capability` / protobuf enum **names** (SCREAMING_SNAKE), aligned with
+ * go-livepeer generated code — not user-controlled strings. Slugs are derived with
+ * {@link livepeerCapabilityEnumNameToPipelineSlug}.
+ *
+ * Prefer resolving pipeline from `hardware` on the same `RawCapabilities` object (model_id ↔
+ * constraint); this table is only used when a price row has no matching hardware entry.
+ *
+ * @see https://github.com/livepeer/go-livepeer/blob/master/net/capabilities.go (Capability enum)
+ */
+const LIVEPEER_CAPABILITY_ENUM_NAME_BY_ID: Partial<Record<number, string>> = {
+  27: 'TEXT_TO_IMAGE',
+  28: 'IMAGE_TO_IMAGE',
+  29: 'IMAGE_TO_VIDEO',
+  30: 'UPSCALE',
+  31: 'AUDIO_TO_TEXT',
+  32: 'SEGMENT_ANYTHING_2',
+  33: 'LLM',
+  34: 'IMAGE_TO_TEXT',
+  35: 'LIVE_VIDEO_TO_VIDEO',
+  36: 'TEXT_TO_SPEECH',
+  37: 'BYOC',
+};
+
+const LIVEPEER_ENUM_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+
+function livepeerCapabilityEnumNameToPipelineSlug(enumName: string): string | null {
+  if (!LIVEPEER_ENUM_NAME_RE.test(enumName)) {
+    return null;
+  }
+  return enumName.toLowerCase().replaceAll('_', '-');
+}
+
+function pipelineSlugFromCapabilityId(capId: number): string | null {
+  const name = LIVEPEER_CAPABILITY_ENUM_NAME_BY_ID[capId];
+  return name !== undefined ? livepeerCapabilityEnumNameToPipelineSlug(name) : null;
+}
+
+/** model_id / price constraint → pipeline slug from the same registry JSON (dynamic, no ID table). */
+function pipelineSlugByModelFromHardware(reg: RegistryRawCapabilities): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const h of reg.hardware ?? []) {
+    const model = h.model_id?.trim();
+    const pipe = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
+    if (!model || !pipe) {
+      continue;
+    }
+    if (!m.has(model)) {
+      m.set(model, pipe);
+    }
+  }
+  return m;
+}
+
 interface NaapNetOrchestrator {
   Address: string;
   URI: string;
@@ -22,8 +87,14 @@ interface NaapNetOrchestrator {
   RawCapabilities?: string;
 }
 
-interface RawCapabilitiesJson {
+interface RegistryRawCapabilities {
   hardware?: Array<{ pipeline?: string; model_id?: string }>;
+  capabilities_prices?: Array<{
+    pricePerUnit: number;
+    pixelsPerUnit: number;
+    capability: number;
+    constraint: string;
+  }>;
 }
 
 interface DashboardPipelineModelOffer {
@@ -31,29 +102,52 @@ interface DashboardPipelineModelOffer {
   modelIds: string[];
 }
 
-function parseRawCapabilities(raw: string | undefined): DashboardPipelineModelOffer[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw) as RawCapabilitiesJson;
-    const byPipeline = new Map<string, Set<string>>();
-    for (const h of parsed.hardware ?? []) {
-      const pipeline = h.pipeline?.trim();
-      const model = h.model_id?.trim();
-      if (!pipeline || !model) continue;
-      let models = byPipeline.get(pipeline);
-      if (!models) {
-        models = new Set();
-        byPipeline.set(pipeline, models);
-      }
-      models.add(model);
-    }
-    return [...byPipeline.entries()].map(([pipelineId, modelSet]) => ({
-      pipelineId,
-      modelIds: [...modelSet].sort((a, b) => a.localeCompare(b)),
-    }));
-  } catch {
-    return [];
+interface CapabilityFreshnessEntry {
+  lastSeenMs: number;
+  pricePerUnit?: number;
+  pixelsPerUnit?: number;
+}
+
+interface DiscoveryAggRow {
+  displayAddress: string;
+  uris: string[];
+  active: boolean;
+  caps: Map<string, CapabilityFreshnessEntry>;
+  bestLastSeenMs: number;
+  canonicalUri: string;
+}
+
+function parseRegistryRawCapabilities(raw: string | undefined): RegistryRawCapabilities {
+  if (!raw) {
+    return {};
   }
+  try {
+    return JSON.parse(raw) as RegistryRawCapabilities;
+  } catch {
+    return {};
+  }
+}
+
+function parseRawCapabilities(raw: string | undefined): DashboardPipelineModelOffer[] {
+  const parsed = parseRegistryRawCapabilities(raw);
+  const byPipeline = new Map<string, Set<string>>();
+  for (const h of parsed.hardware ?? []) {
+    const pipeline = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
+    const model = h.model_id?.trim();
+    if (!pipeline || !model) {
+      continue;
+    }
+    let models = byPipeline.get(pipeline);
+    if (!models) {
+      models = new Set();
+      byPipeline.set(pipeline, models);
+    }
+    models.add(model);
+  }
+  return [...byPipeline.entries()].map(([pipelineId, modelSet]) => ({
+    pipelineId,
+    modelIds: [...modelSet].sort((a, b) => a.localeCompare(b)),
+  }));
 }
 
 function mergePipelineModelOffers(
@@ -98,8 +192,9 @@ function parseOrchestratorLastSeenMs(row: NaapNetOrchestrator): number | undefin
     return undefined;
   }
   if (typeof raw === 'number' && Number.isFinite(raw)) {
-    if (raw <= 0) return undefined;
-    // Unix ms (e.g. 1.7e12) vs seconds (e.g. 1.7e9)
+    if (raw <= 0) {
+      return undefined;
+    }
     return raw >= 1e12 ? raw : raw * 1000;
   }
   if (typeof raw !== 'string') {
@@ -109,7 +204,6 @@ function parseOrchestratorLastSeenMs(row: NaapNetOrchestrator): number | undefin
   if (/^\d+$/.test(trimmed)) {
     const epoch = Number(trimmed);
     if (Number.isFinite(epoch) && epoch > 0) {
-      // Unix ms (e.g. 1.7e12) vs seconds (e.g. 1.7e9)
       return epoch >= 1e12 ? epoch : epoch * 1000;
     }
   }
@@ -117,27 +211,75 @@ function parseOrchestratorLastSeenMs(row: NaapNetOrchestrator): number | undefin
   return Number.isFinite(t) ? t : undefined;
 }
 
+/** Row-level merge: keep the entry tied to the greatest LastSeen; tie-break merges price. */
+function mergeCapFreshness(
+  existing: CapabilityFreshnessEntry | undefined,
+  ls: number,
+  price: { pricePerUnit: number; pixelsPerUnit: number } | undefined,
+): CapabilityFreshnessEntry {
+  if (existing === undefined) {
+    return {
+      lastSeenMs: ls,
+      pricePerUnit: price?.pricePerUnit,
+      pixelsPerUnit: price?.pixelsPerUnit,
+    };
+  }
+  if (ls > existing.lastSeenMs) {
+    return {
+      lastSeenMs: ls,
+      pricePerUnit: price?.pricePerUnit,
+      pixelsPerUnit: price?.pixelsPerUnit,
+    };
+  }
+  if (ls < existing.lastSeenMs) {
+    return {
+      lastSeenMs: existing.lastSeenMs,
+      pricePerUnit: existing.pricePerUnit ?? price?.pricePerUnit,
+      pixelsPerUnit: existing.pixelsPerUnit ?? price?.pixelsPerUnit,
+    };
+  }
+  return {
+    lastSeenMs: ls,
+    pricePerUnit: existing.pricePerUnit ?? price?.pricePerUnit,
+    pixelsPerUnit: existing.pixelsPerUnit ?? price?.pixelsPerUnit,
+  };
+}
+
 export interface NetOrchestratorData {
-  /** Distinct addresses where at least one entry has IsActive === true. */
   activeCount: number;
-  /**
-   * Distinct addresses with at least one non-blank service URI — same inclusion rule as
-   * the orchestrator table (`resolveOrchestrators` after `rowHasNonBlankServiceUri`).
-   */
+  /** Lower-cased on-chain addresses with at least one `IsActive` registry row. */
+  activeAddresses: Set<string>;
   listedCount: number;
-  /** Address (lower-cased) → deduplicated list of service URIs. */
   urisByAddress: Map<string, string[]>;
-  /** First-seen casing of each address (for display / merge rows). */
   displayAddressByLower: Map<string, string>;
-  /**
-   * True when the upstream registry returned at least one parseable `LastSeen` timestamp.
-   * Used by the KPI panel to scope orchestrator counts to the overview timeframe.
-   */
   hasLastSeenData: boolean;
-  /** Per-address max `LastSeen` (ms) across URI rows; only addresses with a seen timestamp appear. */
   lastSeenMsByAddress: Map<string, number>;
-  /** Per-address pipeline/model offers parsed from RawCapabilities.hardware. */
   pipelineModelsByAddress: Map<string, DashboardPipelineModelOffer[]>;
+}
+
+/** Remote-signer-style discovery row; extra fields are NAAP extensions (ignored by strict clients). */
+export interface OrchestratorDiscoveryEntry {
+  /** Canonical service URI (row with latest LastSeen for this orchestrator). */
+  address: string;
+  /** On-chain orchestrator address (mixed-case from registry). */
+  orchestrator_address: string;
+  score: number;
+  /** `pipeline-id/model` strings for `caps=` filtering (OR semantics). */
+  capabilities: string[];
+  /** All distinct service URIs seen for this orchestrator. */
+  service_uris: string[];
+  capability_details: Array<{
+    capability: string;
+    last_seen: string;
+    last_seen_ms: number;
+    price_per_unit?: number;
+    pixels_per_unit?: number;
+  }>;
+}
+
+export interface NetOrchestratorBundle {
+  data: NetOrchestratorData;
+  discoveryList: OrchestratorDiscoveryEntry[];
 }
 
 /** True if this URI list would produce a row in the overview orchestrator table. */
@@ -145,8 +287,38 @@ export function hasNonBlankServiceUri(uris: string[]): boolean {
   return uris.some((u) => typeof u === 'string' && u.trim().length > 0);
 }
 
+function discoveryEntryFromAgg(agg: DiscoveryAggRow): OrchestratorDiscoveryEntry | null {
+  if (!hasNonBlankServiceUri(agg.uris)) {
+    return null;
+  }
+  const address =
+    (agg.canonicalUri.trim().length > 0 ? agg.canonicalUri : agg.uris.find((u) => u.trim().length > 0) ?? '').trim();
+  if (!address) {
+    return null;
+  }
+  const capability_details = [...agg.caps.entries()]
+    .map(([capability, e]) => ({
+      capability,
+      last_seen: e.lastSeenMs > 0 ? new Date(e.lastSeenMs).toISOString() : '',
+      last_seen_ms: e.lastSeenMs,
+      ...(e.pricePerUnit !== undefined ? { price_per_unit: e.pricePerUnit } : {}),
+      ...(e.pixelsPerUnit !== undefined ? { pixels_per_unit: e.pixelsPerUnit } : {}),
+    }))
+    .sort((a, b) => a.capability.localeCompare(b.capability));
+  const capabilities = capability_details.map((d) => d.capability);
+  return {
+    address,
+    orchestrator_address: agg.displayAddress,
+    score: agg.active ? 1 : 0,
+    capabilities,
+    service_uris: [...agg.uris].sort((a, b) => a.localeCompare(b)),
+    capability_details,
+  };
+}
+
 const EMPTY: NetOrchestratorData = {
   activeCount: 0,
+  activeAddresses: new Set(),
   listedCount: 0,
   urisByAddress: new Map(),
   displayAddressByLower: new Map(),
@@ -154,6 +326,8 @@ const EMPTY: NetOrchestratorData = {
   lastSeenMsByAddress: new Map(),
   pipelineModelsByAddress: new Map(),
 };
+
+const EMPTY_DISCOVERY: OrchestratorDiscoveryEntry[] = [];
 
 async function fetchAllNetOrchestratorRows(): Promise<NaapNetOrchestrator[]> {
   const revalidateSec = Math.floor(TTL.NET_MODELS / 1000);
@@ -168,72 +342,177 @@ async function fetchAllNetOrchestratorRows(): Promise<NaapNetOrchestrator[]> {
   }, fetchOptions);
 }
 
-export function getNetOrchestratorData(): Promise<NetOrchestratorData> {
-  const cacheKey = `facade:net-orchestrators:single-request&limit=${NET_ORCHESTRATORS_PAGE_SIZE}`;
-  return cachedFetch(cacheKey, TTL.NET_MODELS, async () => {
+function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): NetOrchestratorBundle {
+  const urisByAddress = new Map<string, string[]>();
+  const displayAddressByLower = new Map<string, string>();
+  const activeAddresses = new Set<string>();
+  const lastSeenMsByAddress = new Map<string, number>();
+  const pipelineModelsByAddress = new Map<string, DashboardPipelineModelOffer[]>();
+  const discoveryByAddress = new Map<string, DiscoveryAggRow>();
+  let hasLastSeenData = false;
+
+  for (const r of rows) {
+    const addr = r.Address.trim().toLowerCase();
+    const lsRaw = parseOrchestratorLastSeenMs(r);
+    const ls = lsRaw ?? 0;
+    if (lsRaw !== undefined) {
+      hasLastSeenData = true;
+    }
+
+    if (!displayAddressByLower.has(addr)) {
+      displayAddressByLower.set(addr, r.Address.trim());
+    }
+
+    let disc = discoveryByAddress.get(addr);
+    if (!disc) {
+      disc = {
+        displayAddress: r.Address.trim(),
+        uris: [],
+        active: false,
+        caps: new Map(),
+        bestLastSeenMs: -1,
+        canonicalUri: '',
+      };
+      discoveryByAddress.set(addr, disc);
+    }
+
+    const uri = typeof r.URI === 'string' ? r.URI.trim() : '';
+    if (uri.length > 0 && !disc.uris.includes(uri)) {
+      disc.uris.push(uri);
+    }
+    if (r.IsActive) {
+      activeAddresses.add(addr);
+      disc.active = true;
+    }
+    if (lsRaw !== undefined) {
+      const prevAddrLs = lastSeenMsByAddress.get(addr);
+      if (prevAddrLs === undefined || lsRaw > prevAddrLs) {
+        lastSeenMsByAddress.set(addr, lsRaw);
+      }
+    }
+    if (lsRaw !== undefined && uri.length > 0) {
+      if (lsRaw > disc.bestLastSeenMs) {
+        disc.bestLastSeenMs = lsRaw;
+        disc.canonicalUri = uri;
+      } else if (lsRaw === disc.bestLastSeenMs && disc.canonicalUri.length === 0) {
+        disc.canonicalUri = uri;
+      }
+    }
+
+    const offers = parseRawCapabilities(r.RawCapabilities);
+    if (offers.length > 0) {
+      pipelineModelsByAddress.set(
+        addr,
+        mergePipelineModelOffers(pipelineModelsByAddress.get(addr), offers),
+      );
+    }
+
+    let uris = urisByAddress.get(addr);
+    if (!uris) {
+      uris = [];
+      urisByAddress.set(addr, uris);
+    }
+    if (uri.length > 0 && !uris.includes(uri)) {
+      uris.push(uri);
+    }
+
+    const reg = parseRegistryRawCapabilities(r.RawCapabilities);
+    const pipelineByModel = pipelineSlugByModelFromHardware(reg);
+    const priceByCapKey = new Map<string, { pricePerUnit: number; pixelsPerUnit: number }>();
+    for (const pr of reg.capabilities_prices ?? []) {
+      const constraint = pr.constraint?.trim();
+      if (!constraint) {
+        continue;
+      }
+      const slug =
+        pipelineByModel.get(constraint) ?? pipelineSlugFromCapabilityId(pr.capability);
+      if (!slug) {
+        continue;
+      }
+      const k = `${slug}/${constraint}`;
+      priceByCapKey.set(k, { pricePerUnit: pr.pricePerUnit, pixelsPerUnit: pr.pixelsPerUnit });
+    }
+
+    const keysThisRow = new Set<string>();
+    for (const h of reg.hardware ?? []) {
+      const p = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
+      const m = h.model_id?.trim();
+      if (!p || !m) {
+        continue;
+      }
+      keysThisRow.add(`${p}/${m}`);
+    }
+    for (const k of priceByCapKey.keys()) {
+      keysThisRow.add(k);
+    }
+
+    for (const key of keysThisRow) {
+      const price = priceByCapKey.get(key);
+      const cur = disc.caps.get(key);
+      disc.caps.set(key, mergeCapFreshness(cur, ls, price));
+    }
+  }
+
+  let listedCount = 0;
+  for (const uris of urisByAddress.values()) {
+    if (hasNonBlankServiceUri(uris)) {
+      listedCount++;
+    }
+  }
+
+  const data: NetOrchestratorData = {
+    activeCount: activeAddresses.size,
+    activeAddresses,
+    listedCount,
+    urisByAddress,
+    displayAddressByLower,
+    hasLastSeenData,
+    lastSeenMsByAddress,
+    pipelineModelsByAddress,
+  };
+
+  const discoveryList: OrchestratorDiscoveryEntry[] = [];
+  for (const agg of discoveryByAddress.values()) {
+    if (!hasNonBlankServiceUri(agg.uris)) {
+      continue;
+    }
+    if (agg.canonicalUri.length === 0) {
+      const first = agg.uris.find((u) => u.trim().length > 0);
+      if (first) {
+        agg.canonicalUri = first.trim();
+      }
+    }
+    const entry = discoveryEntryFromAgg(agg);
+    if (entry) {
+      discoveryList.push(entry);
+    }
+  }
+  discoveryList.sort((a, b) => a.address.localeCompare(b.address));
+
+  return { data, discoveryList };
+}
+
+const NET_ORCHESTRATORS_CACHE_KEY = `facade:net-orchestrators:single-request&limit=${NET_ORCHESTRATORS_PAGE_SIZE}`;
+
+export function getNetOrchestratorBundle(): Promise<NetOrchestratorBundle> {
+  return cachedFetch(NET_ORCHESTRATORS_CACHE_KEY, TTL.NET_MODELS, async () => {
     const rows = await fetchAllNetOrchestratorRows();
-
-    const urisByAddress = new Map<string, string[]>();
-    const displayAddressByLower = new Map<string, string>();
-    const activeAddresses = new Set<string>();
-    const lastSeenMsByAddress = new Map<string, number>();
-    const pipelineModelsByAddress = new Map<string, DashboardPipelineModelOffer[]>();
-    let hasLastSeenData = false;
-
-    for (const r of rows) {
-      const addr = r.Address.trim().toLowerCase();
-      if (!displayAddressByLower.has(addr)) {
-        displayAddressByLower.set(addr, r.Address.trim());
-      }
-      const offers = parseRawCapabilities(r.RawCapabilities);
-      if (offers.length > 0) {
-        pipelineModelsByAddress.set(
-          addr,
-          mergePipelineModelOffers(pipelineModelsByAddress.get(addr), offers),
-        );
-      }
-      let uris = urisByAddress.get(addr);
-      if (!uris) {
-        uris = [];
-        urisByAddress.set(addr, uris);
-      }
-      const uri =
-        typeof r.URI === 'string' ? r.URI.trim() : '';
-      if (uri.length > 0 && !uris.includes(uri)) {
-        uris.push(uri);
-      }
-      if (r.IsActive) {
-        activeAddresses.add(addr);
-      }
-      const ls = parseOrchestratorLastSeenMs(r);
-      if (ls !== undefined) {
-        hasLastSeenData = true;
-        const prev = lastSeenMsByAddress.get(addr);
-        if (prev === undefined || ls > prev) {
-          lastSeenMsByAddress.set(addr, ls);
-        }
-      }
-    }
-
-    let listedCount = 0;
-    for (const uris of urisByAddress.values()) {
-      if (hasNonBlankServiceUri(uris)) {
-        listedCount++;
-      }
-    }
-
-    return {
-      activeCount: activeAddresses.size,
-      listedCount,
-      urisByAddress,
-      displayAddressByLower,
-      hasLastSeenData,
-      lastSeenMsByAddress,
-      pipelineModelsByAddress,
-    };
+    return aggregateNetOrchestratorBundleFromRows(rows);
   });
+}
+
+export function getNetOrchestratorData(): Promise<NetOrchestratorData> {
+  return getNetOrchestratorBundle().then((b) => b.data);
+}
+
+export function getOrchestratorDiscoveryList(): Promise<OrchestratorDiscoveryEntry[]> {
+  return getNetOrchestratorBundle().then((b) => b.discoveryList);
 }
 
 export function getNetOrchestratorDataSafe(): Promise<NetOrchestratorData> {
   return getNetOrchestratorData().catch(() => EMPTY);
+}
+
+export function getOrchestratorDiscoveryListSafe(): Promise<OrchestratorDiscoveryEntry[]> {
+  return getOrchestratorDiscoveryList().catch(() => EMPTY_DISCOVERY);
 }

--- a/apps/web-next/src/lib/facade/resolvers/net-orchestrators.ts
+++ b/apps/web-next/src/lib/facade/resolvers/net-orchestrators.ts
@@ -24,41 +24,28 @@ function sanitizeRegistryPipelineSlug(raw: string): string | null {
 }
 
 /**
- * Fallback: Livepeer `net.Capability` / protobuf enum **names** (SCREAMING_SNAKE), aligned with
- * go-livepeer generated code — not user-controlled strings. Slugs are derived with
- * {@link livepeerCapabilityEnumNameToPipelineSlug}.
- *
- * Prefer resolving pipeline from `hardware` on the same `RawCapabilities` object (model_id ↔
- * constraint); this table is only used when a price row has no matching hardware entry.
+ * Fallback: Livepeer `net.Capability` protobuf enum IDs → pipeline slugs.
+ * Prefer resolving pipeline from `hardware` on the same `RawCapabilities` object;
+ * this table is only used when a price row has no matching hardware entry.
  *
  * @see https://github.com/livepeer/go-livepeer/blob/master/net/capabilities.go (Capability enum)
  */
-const LIVEPEER_CAPABILITY_ENUM_NAME_BY_ID: Partial<Record<number, string>> = {
-  27: 'TEXT_TO_IMAGE',
-  28: 'IMAGE_TO_IMAGE',
-  29: 'IMAGE_TO_VIDEO',
-  30: 'UPSCALE',
-  31: 'AUDIO_TO_TEXT',
-  32: 'SEGMENT_ANYTHING_2',
-  33: 'LLM',
-  34: 'IMAGE_TO_TEXT',
-  35: 'LIVE_VIDEO_TO_VIDEO',
-  36: 'TEXT_TO_SPEECH',
-  37: 'BYOC',
+const LIVEPEER_CAPABILITY_SLUG_BY_ID: Partial<Record<number, string>> = {
+  27: 'text-to-image',
+  28: 'image-to-image',
+  29: 'image-to-video',
+  30: 'upscale',
+  31: 'audio-to-text',
+  32: 'segment-anything-2',
+  33: 'llm',
+  34: 'image-to-text',
+  35: 'live-video-to-video',
+  36: 'text-to-speech',
+  37: 'byoc',
 };
 
-const LIVEPEER_ENUM_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
-
-function livepeerCapabilityEnumNameToPipelineSlug(enumName: string): string | null {
-  if (!LIVEPEER_ENUM_NAME_RE.test(enumName)) {
-    return null;
-  }
-  return enumName.toLowerCase().replaceAll('_', '-');
-}
-
 function pipelineSlugFromCapabilityId(capId: number): string | null {
-  const name = LIVEPEER_CAPABILITY_ENUM_NAME_BY_ID[capId];
-  return name !== undefined ? livepeerCapabilityEnumNameToPipelineSlug(name) : null;
+  return LIVEPEER_CAPABILITY_SLUG_BY_ID[capId] ?? null;
 }
 
 /** model_id / price constraint → pipeline slug from the same registry JSON (dynamic, no ID table). */
@@ -102,17 +89,11 @@ interface DashboardPipelineModelOffer {
   modelIds: string[];
 }
 
-interface CapabilityFreshnessEntry {
-  lastSeenMs: number;
-  pricePerUnit?: number;
-  pixelsPerUnit?: number;
-}
-
 interface DiscoveryAggRow {
   displayAddress: string;
   uris: string[];
   active: boolean;
-  caps: Map<string, CapabilityFreshnessEntry>;
+  caps: Set<string>;
   bestLastSeenMs: number;
   canonicalUri: string;
 }
@@ -128,10 +109,9 @@ function parseRegistryRawCapabilities(raw: string | undefined): RegistryRawCapab
   }
 }
 
-function parseRawCapabilities(raw: string | undefined): DashboardPipelineModelOffer[] {
-  const parsed = parseRegistryRawCapabilities(raw);
+function pipelineModelOffersFromRegistry(reg: RegistryRawCapabilities): DashboardPipelineModelOffer[] {
   const byPipeline = new Map<string, Set<string>>();
-  for (const h of parsed.hardware ?? []) {
+  for (const h of reg.hardware ?? []) {
     const pipeline = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
     const model = h.model_id?.trim();
     if (!pipeline || !model) {
@@ -211,40 +191,6 @@ function parseOrchestratorLastSeenMs(row: NaapNetOrchestrator): number | undefin
   return Number.isFinite(t) ? t : undefined;
 }
 
-/** Row-level merge: keep the entry tied to the greatest LastSeen; tie-break merges price. */
-function mergeCapFreshness(
-  existing: CapabilityFreshnessEntry | undefined,
-  ls: number,
-  price: { pricePerUnit: number; pixelsPerUnit: number } | undefined,
-): CapabilityFreshnessEntry {
-  if (existing === undefined) {
-    return {
-      lastSeenMs: ls,
-      pricePerUnit: price?.pricePerUnit,
-      pixelsPerUnit: price?.pixelsPerUnit,
-    };
-  }
-  if (ls > existing.lastSeenMs) {
-    return {
-      lastSeenMs: ls,
-      pricePerUnit: price?.pricePerUnit,
-      pixelsPerUnit: price?.pixelsPerUnit,
-    };
-  }
-  if (ls < existing.lastSeenMs) {
-    return {
-      lastSeenMs: existing.lastSeenMs,
-      pricePerUnit: existing.pricePerUnit ?? price?.pricePerUnit,
-      pixelsPerUnit: existing.pixelsPerUnit ?? price?.pixelsPerUnit,
-    };
-  }
-  return {
-    lastSeenMs: ls,
-    pricePerUnit: existing.pricePerUnit ?? price?.pricePerUnit,
-    pixelsPerUnit: existing.pixelsPerUnit ?? price?.pixelsPerUnit,
-  };
-}
-
 export interface NetOrchestratorData {
   activeCount: number;
   /** Lower-cased on-chain addresses with at least one `IsActive` registry row. */
@@ -257,24 +203,20 @@ export interface NetOrchestratorData {
   pipelineModelsByAddress: Map<string, DashboardPipelineModelOffer[]>;
 }
 
-/** Remote-signer-style discovery row; extra fields are NAAP extensions (ignored by strict clients). */
+/** Remote-signer-style discovery row. */
 export interface OrchestratorDiscoveryEntry {
   /** Canonical service URI (row with latest LastSeen for this orchestrator). */
   address: string;
-  /** On-chain orchestrator address (mixed-case from registry). */
-  orchestrator_address: string;
   score: number;
   /** `pipeline-id/model` strings for `caps=` filtering (OR semantics). */
   capabilities: string[];
-  /** All distinct service URIs seen for this orchestrator. */
-  service_uris: string[];
-  capability_details: Array<{
-    capability: string;
-    last_seen: string;
-    last_seen_ms: number;
-    price_per_unit?: number;
-    pixels_per_unit?: number;
-  }>;
+  /**
+   * Latest registry `LastSeen` for this orchestrator (max across its URI rows), ms since epoch.
+   * Response list is sorted by this field descending (newest first); `0` means unknown/missing.
+   */
+  last_seen_ms: number;
+  /** Present when {@link last_seen_ms} &gt; 0. */
+  last_seen?: string;
 }
 
 export interface NetOrchestratorBundle {
@@ -287,7 +229,11 @@ export function hasNonBlankServiceUri(uris: string[]): boolean {
   return uris.some((u) => typeof u === 'string' && u.trim().length > 0);
 }
 
-function discoveryEntryFromAgg(agg: DiscoveryAggRow): OrchestratorDiscoveryEntry | null {
+function discoveryEntryFromAgg(
+  addrLower: string,
+  agg: DiscoveryAggRow,
+  lastSeenMsByAddress: Map<string, number>,
+): OrchestratorDiscoveryEntry | null {
   if (!hasNonBlankServiceUri(agg.uris)) {
     return null;
   }
@@ -296,23 +242,18 @@ function discoveryEntryFromAgg(agg: DiscoveryAggRow): OrchestratorDiscoveryEntry
   if (!address) {
     return null;
   }
-  const capability_details = [...agg.caps.entries()]
-    .map(([capability, e]) => ({
-      capability,
-      last_seen: e.lastSeenMs > 0 ? new Date(e.lastSeenMs).toISOString() : '',
-      last_seen_ms: e.lastSeenMs,
-      ...(e.pricePerUnit !== undefined ? { price_per_unit: e.pricePerUnit } : {}),
-      ...(e.pixelsPerUnit !== undefined ? { pixels_per_unit: e.pixelsPerUnit } : {}),
-    }))
-    .sort((a, b) => a.capability.localeCompare(b.capability));
-  const capabilities = capability_details.map((d) => d.capability);
+  const fromMap = lastSeenMsByAddress.get(addrLower);
+  const rawMs = Math.max(
+    agg.bestLastSeenMs,
+    fromMap ?? -1,
+  );
+  const last_seen_ms = rawMs < 0 ? 0 : rawMs;
   return {
     address,
-    orchestrator_address: agg.displayAddress,
     score: agg.active ? 1 : 0,
-    capabilities,
-    service_uris: [...agg.uris].sort((a, b) => a.localeCompare(b)),
-    capability_details,
+    capabilities: [...agg.caps].sort((a, b) => a.localeCompare(b)),
+    last_seen_ms,
+    ...(last_seen_ms > 0 ? { last_seen: new Date(last_seen_ms).toISOString() } : {}),
   };
 }
 
@@ -343,7 +284,6 @@ async function fetchAllNetOrchestratorRows(): Promise<NaapNetOrchestrator[]> {
 }
 
 function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): NetOrchestratorBundle {
-  const urisByAddress = new Map<string, string[]>();
   const displayAddressByLower = new Map<string, string>();
   const activeAddresses = new Set<string>();
   const lastSeenMsByAddress = new Map<string, number>();
@@ -354,7 +294,6 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
   for (const r of rows) {
     const addr = r.Address.trim().toLowerCase();
     const lsRaw = parseOrchestratorLastSeenMs(r);
-    const ls = lsRaw ?? 0;
     if (lsRaw !== undefined) {
       hasLastSeenData = true;
     }
@@ -369,7 +308,7 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
         displayAddress: r.Address.trim(),
         uris: [],
         active: false,
-        caps: new Map(),
+        caps: new Set(),
         bestLastSeenMs: -1,
         canonicalUri: '',
       };
@@ -399,7 +338,9 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
       }
     }
 
-    const offers = parseRawCapabilities(r.RawCapabilities);
+    const reg = parseRegistryRawCapabilities(r.RawCapabilities);
+
+    const offers = pipelineModelOffersFromRegistry(reg);
     if (offers.length > 0) {
       pipelineModelsByAddress.set(
         addr,
@@ -407,18 +348,18 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
       );
     }
 
-    let uris = urisByAddress.get(addr);
-    if (!uris) {
-      uris = [];
-      urisByAddress.set(addr, uris);
-    }
-    if (uri.length > 0 && !uris.includes(uri)) {
-      uris.push(uri);
+    const pipelineByModel = pipelineSlugByModelFromHardware(reg);
+
+    // Collect capability keys from hardware entries.
+    for (const h of reg.hardware ?? []) {
+      const p = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
+      const m = h.model_id?.trim();
+      if (p && m) {
+        disc.caps.add(`${p}/${m}`);
+      }
     }
 
-    const reg = parseRegistryRawCapabilities(r.RawCapabilities);
-    const pipelineByModel = pipelineSlugByModelFromHardware(reg);
-    const priceByCapKey = new Map<string, { pricePerUnit: number; pixelsPerUnit: number }>();
+    // Collect capability keys from price entries (fallback via capability ID when no hardware match).
     for (const pr of reg.capabilities_prices ?? []) {
       const constraint = pr.constraint?.trim();
       if (!constraint) {
@@ -426,36 +367,18 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
       }
       const slug =
         pipelineByModel.get(constraint) ?? pipelineSlugFromCapabilityId(pr.capability);
-      if (!slug) {
-        continue;
+      if (slug) {
+        disc.caps.add(`${slug}/${constraint}`);
       }
-      const k = `${slug}/${constraint}`;
-      priceByCapKey.set(k, { pricePerUnit: pr.pricePerUnit, pixelsPerUnit: pr.pixelsPerUnit });
-    }
-
-    const keysThisRow = new Set<string>();
-    for (const h of reg.hardware ?? []) {
-      const p = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
-      const m = h.model_id?.trim();
-      if (!p || !m) {
-        continue;
-      }
-      keysThisRow.add(`${p}/${m}`);
-    }
-    for (const k of priceByCapKey.keys()) {
-      keysThisRow.add(k);
-    }
-
-    for (const key of keysThisRow) {
-      const price = priceByCapKey.get(key);
-      const cur = disc.caps.get(key);
-      disc.caps.set(key, mergeCapFreshness(cur, ls, price));
     }
   }
 
+  // Derive urisByAddress from the single-source discoveryByAddress map.
+  const urisByAddress = new Map<string, string[]>();
   let listedCount = 0;
-  for (const uris of urisByAddress.values()) {
-    if (hasNonBlankServiceUri(uris)) {
+  for (const [addr, disc] of discoveryByAddress) {
+    urisByAddress.set(addr, disc.uris);
+    if (hasNonBlankServiceUri(disc.uris)) {
       listedCount++;
     }
   }
@@ -472,7 +395,7 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
   };
 
   const discoveryList: OrchestratorDiscoveryEntry[] = [];
-  for (const agg of discoveryByAddress.values()) {
+  for (const [addrLower, agg] of discoveryByAddress) {
     if (!hasNonBlankServiceUri(agg.uris)) {
       continue;
     }
@@ -482,12 +405,22 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
         agg.canonicalUri = first.trim();
       }
     }
-    const entry = discoveryEntryFromAgg(agg);
+    const entry = discoveryEntryFromAgg(addrLower, agg, lastSeenMsByAddress);
     if (entry) {
       discoveryList.push(entry);
     }
   }
-  discoveryList.sort((a, b) => a.address.localeCompare(b.address));
+  discoveryList.sort((a, b) => {
+    const byScore = b.score - a.score;
+    if (byScore !== 0) {
+      return byScore;
+    }
+    const bySeen = b.last_seen_ms - a.last_seen_ms;
+    if (bySeen !== 0) {
+      return bySeen;
+    }
+    return a.address.localeCompare(b.address);
+  });
 
   return { data, discoveryList };
 }

--- a/apps/web-next/src/lib/facade/resolvers/net-orchestrators.ts
+++ b/apps/web-next/src/lib/facade/resolvers/net-orchestrators.ts
@@ -48,18 +48,21 @@ function pipelineSlugFromCapabilityId(capId: number): string | null {
   return LIVEPEER_CAPABILITY_SLUG_BY_ID[capId] ?? null;
 }
 
-/** model_id / price constraint → pipeline slug from the same registry JSON (dynamic, no ID table). */
-function pipelineSlugByModelFromHardware(reg: RegistryRawCapabilities): Map<string, string> {
-  const m = new Map<string, string>();
+/** model_id / price constraint → pipeline slugs from the same registry JSON (dynamic, no ID table). */
+function pipelineSlugByModelFromHardware(reg: RegistryRawCapabilities): Map<string, Set<string>> {
+  const m = new Map<string, Set<string>>();
   for (const h of reg.hardware ?? []) {
     const model = h.model_id?.trim();
     const pipe = sanitizeRegistryPipelineSlug(h.pipeline ?? '');
     if (!model || !pipe) {
       continue;
     }
-    if (!m.has(model)) {
-      m.set(model, pipe);
+    let set = m.get(model);
+    if (!set) {
+      set = new Set();
+      m.set(model, set);
     }
+    set.add(pipe);
   }
   return m;
 }
@@ -243,10 +246,10 @@ function discoveryEntryFromAgg(
     return null;
   }
   const fromMap = lastSeenMsByAddress.get(addrLower);
-  const rawMs = Math.max(
-    agg.bestLastSeenMs,
-    fromMap ?? -1,
-  );
+  const rawMs =
+    agg.canonicalUri.length > 0 && agg.bestLastSeenMs >= 0
+      ? agg.bestLastSeenMs
+      : (fromMap ?? 0);
   const last_seen_ms = rawMs < 0 ? 0 : rawMs;
   return {
     address,
@@ -365,10 +368,15 @@ function aggregateNetOrchestratorBundleFromRows(rows: NaapNetOrchestrator[]): Ne
       if (!constraint) {
         continue;
       }
-      const slug =
-        pipelineByModel.get(constraint) ?? pipelineSlugFromCapabilityId(pr.capability);
-      if (slug) {
-        disc.caps.add(`${slug}/${constraint}`);
+      const slugsFromHw = pipelineByModel.get(constraint);
+      if (slugsFromHw) {
+        for (const slug of slugsFromHw) {
+          disc.caps.add(`${slug}/${constraint}`);
+        }
+      }
+      const capSlug = pipelineSlugFromCapabilityId(pr.capability);
+      if (capSlug) {
+        disc.caps.add(`${capSlug}/${constraint}`);
       }
     }
   }


### PR DESCRIPTION
## Summary
<!-- 1-3 sentences. What does this PR do and why? -->
This change adds a discovery endpoint to NaaP's public data API, following same response format as the remote signer's combined `-remoteDiscovery` and `-orchWebhookUrl` flags. This endpoint can be used by developers via the SDK by passing `discovery_url` parameter to the [start_lv2v class](https://github.com/livepeer/livepeer-python-gateway/blob/aedd6db17429827b681395a22e7f4aaf3dc7e877/src/livepeer_gateway/lv2v.py#L255) during job initialization. 

This endpoint provides a wider view of the network capabilities by using data from multiple sources compared to the remote signer which may be geographically limited in responding to orchestrator discovery.

Selection is still owned by the SDK, so any unreachable or OrchestratorCapped nodes can be handled during streaming.

We can expand this feature to authenticated endpoints to allow NaaP users to customize their discovery and public apps can continue leveraging this public endpoint.

## Changes
<!-- Bullet list of what changed. -->
- Implemented a new GET endpoint at `/api/v1/network/discover-orchestrators` for public orchestrator discovery.
- Introduced functionality to filter orchestrators based on specified capabilities.
- Added caching support for the orchestrator discovery data to enhance performance.
- Updated overview-http-cache to include a constant for the new endpoint's caching duration.


## Testing

```
curl "http://localhost:3000/api/v1/network/discover-orchestrators"
curl "http://localhost:3000/api/v1/network/discover-orchestrators?caps=live-video-to-video/streamdiffusion-sdxl"
curl "http://localhost:3000/api/v1/network/discover-orchestrators?caps=live-video-to-video/streamdiffusion-sdxl&caps=live-video-to-video/streamdiffusion-sdxl-v2v"
```

Example response:
```
[
  {
    "address": "https://45.137.88.208:48935",
    "score": 1,
    "capabilities": [
      "live-video-to-video/streamdiffusion-sdxl"
    ],
    "last_seen_ms": 1776129492955,
    "last_seen": "2026-04-14T01:18:12.955Z"
  },
  {
    "address": "https://ai.ad-astra.live:9966",
    "score": 1,
    "capabilities": [
      "live-video-to-video/streamdiffusion-sdxl"
    ],
    "last_seen_ms": 1776129492955,
    "last_seen": "2026-04-14T01:18:12.955Z"
  },
  ...
]
```

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / Tooling
- [ ] Plugin (new or update)
- [ ] Dependencies

## Plugin(s) Affected

<!-- If this is a plugin PR, list the plugin name(s). Leave blank for core changes. -->
- dashboard-data-provider

## Checklist

- [ ] Tests pass locally
- [ ] Lint passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] No new lint warnings introduced
- [ ] Breaking changes documented below
- [ ] Database migration included (if Prisma schema changed)

## Breaking Changes

<!-- If none, write "None". Otherwise describe what breaks and migration path. -->

None

## Screenshots / Recordings

<!-- For UI changes, attach screenshots or a short recording. Delete this section if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New orchestrator discovery API endpoint to query available network orchestrators and their capabilities.
  * Capability-based filtering (supports repeated capability queries) to find orchestrators matching requested features.
  * Discovery results now include consolidated entries, improved capability-to-pipeline resolution, more accurate scoring/sorting, and stable last-seen information.
  * Tuned caching for fresher CDN responses and safer fallback when discovery data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->