### PR TITLE
fix(security): address Copilot review findings from PR #292

### DIFF
--- a/apps/web-next/next.config.js
+++ b/apps/web-next/next.config.js
@@ -27,6 +27,7 @@ const nextConfig = {
     '@naap/config',
     '@naap/plugin-sdk',
     '@naap/cache',
+    '@naap/crypto',
   ],
 
   // Image optimization

--- a/apps/web-next/src/app/(dashboard)/marketplace/page.tsx
+++ b/apps/web-next/src/app/(dashboard)/marketplace/page.tsx
@@ -13,7 +13,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useShell, useEvents } from '@/contexts/shell-context';
-import { getCsrfToken } from '@/lib/api/csrf';
+import { getCsrfToken } from '@/lib/api/csrf-client';
 import { Button, Input, Select, Textarea, Modal } from '@naap/ui';
 import {
   Search,

--- a/apps/web-next/src/app/(dashboard)/settings/page.tsx
+++ b/apps/web-next/src/app/(dashboard)/settings/page.tsx
@@ -6,7 +6,7 @@ import { Reorder } from 'framer-motion';
 import { useAuth } from '@/contexts/auth-context';
 import { useShell, useEvents } from '@/contexts/shell-context';
 import { usePlugins } from '@/contexts/plugin-context';
-import { getCsrfToken } from '@/lib/api/csrf';
+import { getCsrfToken } from '@/lib/api/csrf-client';
 import {
   User, Bell, Palette, Shield, LogOut, Save, Globe,
   Eye, EyeOff, Pin, GripVertical, Trash2, Settings as SettingsIcon,

--- a/apps/web-next/src/lib/api/auth.ts
+++ b/apps/web-next/src/lib/api/auth.ts
@@ -23,6 +23,9 @@ function sanitizeForLog(value: unknown): string {
 function hmacToken(plaintext: string): string {
   const pepper = process.env.SESSION_TOKEN_PEPPER;
   if (!pepper) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('SESSION_TOKEN_PEPPER is required in production');
+    }
     return crypto.createHash('sha256').update(plaintext).digest('hex');
   }
   return crypto.createHmac('sha256', pepper).update(plaintext).digest('hex');
@@ -69,14 +72,16 @@ async function verifyPassword(password: string, storedHash: string): Promise<{ v
 
   if (!salt || !hash) return { valid: false, needsRehash: false };
   const verifyHash = crypto.pbkdf2Sync(password, salt, iterations, 64, digest).toString('hex');
-  if (hash.length !== verifyHash.length) return { valid: false, needsRehash: false };
 
-  const valid = crypto.timingSafeEqual(
-    Buffer.from(hash, 'hex'),
-    Buffer.from(verifyHash, 'hex')
-  );
-
-  return { valid, needsRehash: valid && needsRehash };
+  try {
+    const storedBuf = Buffer.from(hash, 'hex');
+    const verifyBuf = Buffer.from(verifyHash, 'hex');
+    if (storedBuf.length !== verifyBuf.length) return { valid: false, needsRehash: false };
+    const valid = crypto.timingSafeEqual(storedBuf, verifyBuf);
+    return { valid, needsRehash: valid && needsRehash };
+  } catch {
+    return { valid: false, needsRehash: false };
+  }
 }
 
 function generateToken(): string {

--- a/apps/web-next/src/lib/api/csrf-client.ts
+++ b/apps/web-next/src/lib/api/csrf-client.ts
@@ -1,0 +1,70 @@
+/**
+ * CSRF Token Utilities — client-safe module
+ * Uses Web Crypto API (no Node.js imports) so this can be bundled
+ * for both server and browser environments.
+ */
+
+const CSRF_TOKEN_LIFETIME = 60 * 60 * 1000; // 1 hour
+
+let cachedToken: string | null = null;
+let tokenExpiry: number = 0;
+
+function generateClientCsrfToken(): string {
+  const buf = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(buf);
+  return Array.from(buf, b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function getCsrfToken(): Promise<string> {
+  if (cachedToken && Date.now() < tokenExpiry) {
+    return cachedToken;
+  }
+
+  try {
+    const response = await fetch('/api/v1/auth/csrf', {
+      method: 'GET',
+      credentials: 'include',
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      cachedToken = data.token || data.data?.token;
+      tokenExpiry = Date.now() + CSRF_TOKEN_LIFETIME;
+      return cachedToken!;
+    }
+  } catch (error) {
+    console.warn('Failed to fetch CSRF token:', error);
+  }
+
+  cachedToken = generateClientCsrfToken();
+  tokenExpiry = Date.now() + CSRF_TOKEN_LIFETIME;
+  return cachedToken;
+}
+
+export function clearCsrfToken(): void {
+  cachedToken = null;
+  tokenExpiry = 0;
+}
+
+export async function withCsrf(
+  headers: HeadersInit = {}
+): Promise<HeadersInit> {
+  const token = await getCsrfToken();
+  return {
+    ...headers,
+    'X-CSRF-Token': token,
+  };
+}
+
+export async function csrfFetch(
+  url: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const csrfHeaders = await withCsrf(options.headers || {});
+  
+  return fetch(url, {
+    ...options,
+    headers: csrfHeaders,
+    credentials: 'include',
+  });
+}

--- a/apps/web-next/src/lib/api/csrf.ts
+++ b/apps/web-next/src/lib/api/csrf.ts
@@ -1,6 +1,10 @@
 /**
- * CSRF Token Utilities
+ * CSRF Token Utilities — server-only module
  * Double-submit cookie pattern with HMAC binding to session.
+ *
+ * Client helpers (getCsrfToken, csrfFetch, withCsrf, clearCsrfToken)
+ * live in ./csrf-client.ts to avoid pulling Node-only modules into
+ * the client bundle.
  */
 
 import * as crypto from 'crypto';
@@ -8,7 +12,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { errors } from './response';
 
 const CSRF_PEPPER = process.env.CSRF_PEPPER || process.env.NEXTAUTH_SECRET || '';
-const CSRF_TOKEN_LIFETIME = 60 * 60 * 1000; // 1 hour
 
 /**
  * Server-side CSRF validation using double-submit cookie pattern.
@@ -24,7 +27,6 @@ export function validateCSRF(
 ): NextResponse | null {
   if (options?.exempt) return null;
 
-  // In development, be lenient
   if (process.env.NODE_ENV === 'development') {
     return null;
   }
@@ -44,7 +46,6 @@ export function validateCSRF(
     return errors.forbidden('CSRF token required');
   }
 
-  // Timing-safe comparison of header value vs cookie value
   try {
     const headerBuf = Buffer.from(headerToken, 'utf8');
     const cookieBuf = Buffer.from(cookieToken, 'utf8');
@@ -93,63 +94,4 @@ export function createSessionCSRFToken(sessionId: string): string {
   const payload = `${sessionId}:${Date.now()}`;
   const sig = crypto.createHmac('sha256', CSRF_PEPPER).update(payload).digest('hex');
   return `${payload}:${sig}`;
-}
-
-// Client-side utilities below — kept for backwards compatibility with existing imports
-
-let cachedToken: string | null = null;
-let tokenExpiry: number = 0;
-
-export async function getCsrfToken(): Promise<string> {
-  if (cachedToken && Date.now() < tokenExpiry) {
-    return cachedToken;
-  }
-
-  try {
-    const response = await fetch('/api/v1/auth/csrf', {
-      method: 'GET',
-      credentials: 'include',
-    });
-
-    if (response.ok) {
-      const data = await response.json();
-      cachedToken = data.token || data.data?.token;
-      tokenExpiry = Date.now() + CSRF_TOKEN_LIFETIME;
-      return cachedToken!;
-    }
-  } catch (error) {
-    console.warn('Failed to fetch CSRF token:', error);
-  }
-
-  cachedToken = generateCsrfToken();
-  tokenExpiry = Date.now() + CSRF_TOKEN_LIFETIME;
-  return cachedToken;
-}
-
-export function clearCsrfToken(): void {
-  cachedToken = null;
-  tokenExpiry = 0;
-}
-
-export async function withCsrf(
-  headers: HeadersInit = {}
-): Promise<HeadersInit> {
-  const token = await getCsrfToken();
-  return {
-    ...headers,
-    'X-CSRF-Token': token,
-  };
-}
-
-export async function csrfFetch(
-  url: string,
-  options: RequestInit = {}
-): Promise<Response> {
-  const csrfHeaders = await withCsrf(options.headers || {});
-  
-  return fetch(url, {
-    ...options,
-    headers: csrfHeaders,
-    credentials: 'include',
-  });
 }

--- a/apps/web-next/src/lib/api/index.ts
+++ b/apps/web-next/src/lib/api/index.ts
@@ -5,3 +5,4 @@
 export * from './response';
 export * from './auth';
 export * from './csrf';
+export * from './csrf-client';

--- a/packages/crypto/src/token-hash.ts
+++ b/packages/crypto/src/token-hash.ts
@@ -2,15 +2,18 @@ import * as crypto from 'crypto';
 
 /**
  * HMAC-SHA256 token hashing with pepper.
- * Falls back to plain SHA-256 when SESSION_TOKEN_PEPPER is unset,
- * matching the behaviour of the auth service implementations.
+ * In production, SESSION_TOKEN_PEPPER must be set; in dev/test
+ * falls back to plain SHA-256 for convenience.
  */
 export function hmacToken(plaintext: string): string {
   const pepper = process.env.SESSION_TOKEN_PEPPER;
-  if (pepper) {
-    return crypto.createHmac('sha256', pepper).update(plaintext).digest('hex');
+  if (!pepper) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('SESSION_TOKEN_PEPPER is required in production');
+    }
+    return crypto.createHash('sha256').update(plaintext).digest('hex');
   }
-  return crypto.createHash('sha256').update(plaintext).digest('hex');
+  return crypto.createHmac('sha256', pepper).update(plaintext).digest('hex');
 }
 
 export function hmacTokenSafe(plaintext: string): string | null {

--- a/scripts/neon-roles.sql
+++ b/scripts/neon-roles.sql
@@ -120,5 +120,5 @@ GRANT ALL PRIVILEGES ON SCHEMA plugin_orchestrator_leaderboard TO naap_migrator;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA plugin_orchestrator_leaderboard TO naap_migrator;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA plugin_orchestrator_leaderboard TO naap_migrator;
 
--- 8. Allow migrator to create new schemas (for new plugins)
-ALTER ROLE naap_migrator CREATEDB;
+-- 8. Allow migrator to create new schemas for plugins (least-privilege)
+GRANT CREATE ON DATABASE neondb TO naap_migrator;

--- a/scripts/verify-token-hashing.sql
+++ b/scripts/verify-token-hashing.sql
@@ -1,5 +1,8 @@
--- Verify that no session tokens are stored in plaintext
--- (tokenHash should be populated for all rows; token should be NULL after cutover)
+-- Verify token hashing rollout progress.
+-- During dual-write phase, both token and tokenHash are populated.
+-- The token column remains non-nullable in the schema; it will only
+-- become nullable in a future migration once all tokenHash backfills
+-- are confirmed and the plaintext column is ready to be dropped.
 
 -- Check for sessions with tokenHash but also a non-null token (pre-cutover, expected)
 SELECT 'Sessions with both token and tokenHash (pre-cutover):' AS check,

--- a/services/base-svc/src/services/auth.ts
+++ b/services/base-svc/src/services/auth.ts
@@ -16,6 +16,9 @@ function sanitizeForLog(value: unknown): string {
 function hmacToken(plaintext: string): string {
   const pepper = process.env.SESSION_TOKEN_PEPPER;
   if (!pepper) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('SESSION_TOKEN_PEPPER is required in production');
+    }
     return crypto.createHash('sha256').update(plaintext).digest('hex');
   }
   return crypto.createHmac('sha256', pepper).update(plaintext).digest('hex');
@@ -62,14 +65,16 @@ async function verifyPassword(password: string, storedHash: string): Promise<{ v
 
   if (!salt || !hash) return { valid: false, needsRehash: false };
   const verifyHash = crypto.pbkdf2Sync(password, salt, iterations, 64, digest).toString('hex');
-  if (hash.length !== verifyHash.length) return { valid: false, needsRehash: false };
 
-  const valid = crypto.timingSafeEqual(
-    Buffer.from(hash, 'hex'),
-    Buffer.from(verifyHash, 'hex')
-  );
-
-  return { valid, needsRehash: valid && needsRehash };
+  try {
+    const storedBuf = Buffer.from(hash, 'hex');
+    const verifyBuf = Buffer.from(verifyHash, 'hex');
+    if (storedBuf.length !== verifyBuf.length) return { valid: false, needsRehash: false };
+    const valid = crypto.timingSafeEqual(storedBuf, verifyBuf);
+    return { valid, needsRehash: valid && needsRehash };
+  } catch {
+    return { valid: false, needsRehash: false };
+  }
 }
 
 function generateToken(): string {
@@ -229,12 +234,18 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
     const token = generateToken();
     const expiresAt = new Date(Date.now() + SESSION_DURATION_HOURS * 60 * 60 * 1000);
 
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { sessionVersion: true },
+    });
+
     await prisma.session.create({
       data: {
         userId,
         token,
         tokenHash: hmacToken(token),
         expiresAt,
+        versionAtCreation: user?.sessionVersion ?? 0,
       },
     });
 
@@ -402,6 +413,11 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
         return null;
       }
 
+      if (session.user.sessionVersion !== (session.versionAtCreation ?? 0)) {
+        await prisma.session.delete({ where: { id: session.id } });
+        return null;
+      }
+
       const updateData: Record<string, unknown> = { lastUsedAt: new Date() };
       if (!session.tokenHash) {
         updateData.tokenHash = hash;
@@ -439,6 +455,11 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
         return null;
       }
 
+      if (session.user.sessionVersion !== (session.versionAtCreation ?? 0)) {
+        await prisma.session.delete({ where: { id: session.id } });
+        return null;
+      }
+
       const updateData: Record<string, unknown> = { lastUsedAt: new Date() };
       if (!session.tokenHash) {
         updateData.tokenHash = hash;
@@ -462,15 +483,22 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
 
       let session = await prisma.session.findUnique({
         where: { tokenHash: hash },
+        include: { user: true },
       });
 
       if (!session) {
         session = await prisma.session.findUnique({
           where: { token },
+          include: { user: true },
         });
       }
 
       if (!session) return null;
+
+      if (session.user.sessionVersion !== (session.versionAtCreation ?? 0)) {
+        await prisma.session.delete({ where: { id: session.id } });
+        return null;
+      }
 
       if (new Date(session.expiresAt) < new Date()) {
         await prisma.session.delete({ where: { id: session.id } });


### PR DESCRIPTION
## Summary

Follow-up to PR #292 — addresses all 10 Copilot review comments:

- **C1**: Split `csrf.ts` into server-only (`crypto`/`NextRequest`) and `csrf-client.ts` (Web Crypto API) to prevent Next.js client bundle from pulling in Node-only modules
- **C2**: Add `@naap/crypto` to `transpilePackages` in `next.config.js` so the TS-only workspace package is transpiled during `next build`
- **C3**: Guard `verifyPassword` `timingSafeEqual` with try/catch and buffer length check to gracefully handle malformed hex in stored password hashes
- **C4**: base-svc `createSession` now captures `versionAtCreation` from `user.sessionVersion`, matching web-next behaviour
- **C5**: base-svc `validateSession`, `validateSessionWithExpiry`, and `refreshSession` now enforce `sessionVersion` vs `versionAtCreation` — sign-out-everywhere works for base-svc sessions too
- **C6**: `hmacToken` requires `SESSION_TOKEN_PEPPER` in production (throws), fallback to SHA-256 only in dev/test — applied in both auth services and `@naap/crypto`
- **C7**: `verify-token-hashing.sql` runbook updated to match dual-write plan (token column stays non-nullable)
- **C8**: `neon-roles.sql` uses `GRANT CREATE ON DATABASE` instead of overly broad `CREATEDB` for migrator role

## Test plan

- [x] 275 pre-push SDK tests pass
- [ ] Lockfile Sync CI passes
- [ ] Lint & TypeCheck CI passes
- [ ] Build CI passes (validates transpilePackages fix)
- [ ] Vercel preview deploy succeeds
- [ ] Quality Gates pass


Made with [Cursor](https://cursor.com)