### PR TITLE
fix(security): comprehensive hardening round 2

### DIFF
--- a/apps/web-next/src/app/api/health/route.ts
+++ b/apps/web-next/src/app/api/health/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
     dbStatus = { connected: true, latencyMs: Date.now() - start };
   } catch (err) {
     const e = err as Error & { code?: string };
-    console.error('[health] DB check failed:', e.name, e.message, e.code);
+    console.error('[health] DB check failed:', e.name, e.message, e.code, '\n', e.stack);
     dbStatus = {
       connected: false,
       error: 'Database connection failed',

--- a/apps/web-next/src/app/api/health/route.ts
+++ b/apps/web-next/src/app/api/health/route.ts
@@ -17,9 +17,10 @@ export async function GET() {
     dbStatus = { connected: true, latencyMs: Date.now() - start };
   } catch (err) {
     const e = err as Error & { code?: string };
+    console.error('[health] DB check failed:', e.name, e.message, e.code);
     dbStatus = {
       connected: false,
-      error: `${e.name}: ${e.message} [code=${e.code || 'none'}]`,
+      error: 'Database connection failed',
     };
   }
 

--- a/apps/web-next/src/app/api/v1/secrets/[key]/rotate/route.ts
+++ b/apps/web-next/src/app/api/v1/secrets/[key]/rotate/route.ts
@@ -1,52 +1,68 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { validateSession } from '@/lib/api/auth';
+import { errors, getAuthToken } from '@/lib/api/response';
 import * as crypto from 'crypto';
 
-const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || crypto.randomBytes(32).toString('hex');
-
-function encrypt(text: string): { encryptedValue: string; iv: string } {
-  const iv = crypto.randomBytes(16);
-  const key = Buffer.from(ENCRYPTION_KEY.slice(0, 32).padEnd(32, '0'));
-  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-  
-  let encrypted = cipher.update(text, 'utf8', 'hex');
-  encrypted += cipher.final('hex');
-  
-  const authTag = cipher.getAuthTag();
-  
-  return {
-    encryptedValue: encrypted + ':' + authTag.toString('hex'),
-    iv: iv.toString('hex'),
-  };
+async function requireAdmin(request: NextRequest) {
+  const token = getAuthToken(request);
+  if (!token) return { error: errors.unauthorized('No auth token provided') };
+  const user = await validateSession(token);
+  if (!user) return { error: errors.unauthorized('Invalid or expired session') };
+  if (!user.roles.includes('system:admin')) return { error: errors.forbidden('Admin permission required') };
+  return { user };
 }
 
-// POST /api/v1/secrets/[key]/rotate - Rotate a secret's value
+function getEncryptionKey(): string {
+  const key = process.env.ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error('ENCRYPTION_KEY environment variable is required.');
+  }
+  return key;
+}
+
+function encrypt(text: string): { encryptedValue: string; iv: string } {
+  const masterKey = getEncryptionKey();
+  const salt = crypto.randomBytes(32);
+  const iv = crypto.randomBytes(16);
+  const derivedKey = crypto.scryptSync(masterKey, salt, 32, { N: 16384, r: 8, p: 1 });
+
+  const cipher = crypto.createCipheriv('aes-256-gcm', derivedKey, iv);
+  const ct = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const encryptedValue = `v1:gcm:scrypt:${salt.toString('hex')}:${iv.toString('hex')}:${ct.toString('hex')}:${tag.toString('hex')}`;
+  return { encryptedValue, iv: iv.toString('hex') };
+}
+
+// POST /api/v1/secrets/[key]/rotate - Rotate a secret's value (admin only)
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ key: string }> }
 ) {
   try {
-    const { key } = await params;
-    const body = await request.json();
-    const { newValue } = body;
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
 
-    if (!newValue) {
-      return NextResponse.json(
-        { error: 'New value is required' },
-        { status: 400 }
-      );
+    const { key } = await params;
+
+    let body: { newValue?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (!body.newValue || typeof body.newValue !== 'string') {
+      return NextResponse.json({ error: 'newValue (string) is required' }, { status: 400 });
     }
 
     const secret = await prisma.secretVault.findUnique({ where: { key } });
     if (!secret) {
-      return NextResponse.json(
-        { error: 'Secret not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: 'Secret not found' }, { status: 404 });
     }
 
-    // Encrypt the new value
-    const { encryptedValue, iv } = encrypt(newValue);
+    const { encryptedValue, iv } = encrypt(body.newValue);
 
     const updated = await prisma.secretVault.update({
       where: { key },
@@ -71,9 +87,6 @@ export async function POST(
     });
   } catch (error) {
     console.error('Error rotating secret:', error);
-    return NextResponse.json(
-      { error: 'Failed to rotate secret' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to rotate secret' }, { status: 500 });
   }
 }

--- a/apps/web-next/src/app/api/v1/secrets/[key]/route.ts
+++ b/apps/web-next/src/app/api/v1/secrets/[key]/route.ts
@@ -1,12 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { validateSession } from '@/lib/api/auth';
+import { errors, getAuthToken } from '@/lib/api/response';
 
-// DELETE /api/v1/secrets/[key] - Delete a secret
+async function requireAdmin(request: NextRequest) {
+  const token = getAuthToken(request);
+  if (!token) return { error: errors.unauthorized('No auth token provided') };
+  const user = await validateSession(token);
+  if (!user) return { error: errors.unauthorized('Invalid or expired session') };
+  if (!user.roles.includes('system:admin')) return { error: errors.forbidden('Admin permission required') };
+  return { user };
+}
+
+// DELETE /api/v1/secrets/[key] - Delete a secret (admin only)
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ key: string }> }
 ) {
   try {
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
     const { key } = await params;
 
     const secret = await prisma.secretVault.findUnique({ where: { key } });
@@ -32,12 +46,15 @@ export async function DELETE(
   }
 }
 
-// GET /api/v1/secrets/[key] - Get secret metadata (not the value)
+// GET /api/v1/secrets/[key] - Get secret metadata (admin only)
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ key: string }> }
 ) {
   try {
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
     const { key } = await params;
 
     const secret = await prisma.secretVault.findUnique({

--- a/apps/web-next/src/app/api/v1/secrets/route.ts
+++ b/apps/web-next/src/app/api/v1/secrets/route.ts
@@ -1,6 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { validateSession } from '@/lib/api/auth';
+import { errors, getAuthToken } from '@/lib/api/response';
 import * as crypto from 'crypto';
+
+async function requireAdmin(request: NextRequest) {
+  const token = getAuthToken(request);
+  if (!token) return { error: errors.unauthorized('No auth token provided') };
+  const user = await validateSession(token);
+  if (!user) return { error: errors.unauthorized('Invalid or expired session') };
+  if (!user.roles.includes('system:admin')) return { error: errors.forbidden('Admin permission required') };
+  return { user };
+}
 
 function getEncryptionKey(): string {
   const key = process.env.ENCRYPTION_KEY;
@@ -36,9 +47,12 @@ function maskValue(key: string): string {
   return key.slice(0, 4) + '*'.repeat(Math.min(key.length - 4, 20));
 }
 
-// GET /api/v1/secrets - List all secrets (masked values)
+// GET /api/v1/secrets - List all secrets (masked values, admin only)
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
     const { searchParams } = new URL(request.url);
     const scope = searchParams.get('scope') || 'global';
 
@@ -78,9 +92,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 }
 
-// POST /api/v1/secrets - Create a new secret
+// POST /api/v1/secrets - Create a new secret (admin only)
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
     const body = await request.json();
     const { key, value, description, scope = 'global' } = body;
 

--- a/apps/web-next/src/lib/api/auth.ts
+++ b/apps/web-next/src/lib/api/auth.ts
@@ -452,8 +452,12 @@ export async function validateSession(token: string): Promise<AuthUser | null> {
     return null;
   }
 
-  // sessionVersion check: if user bumped their version, this session is stale
   if (session.user.sessionVersion !== (session.versionAtCreation ?? 0)) {
+    await prisma.session.delete({ where: { id: session.id } });
+    return null;
+  }
+
+  if (session.user.suspendedAt) {
     await prisma.session.delete({ where: { id: session.id } });
     return null;
   }
@@ -500,6 +504,11 @@ export async function validateSessionWithExpiry(token: string): Promise<{ user: 
     return null;
   }
 
+  if (session.user.suspendedAt) {
+    await prisma.session.delete({ where: { id: session.id } });
+    return null;
+  }
+
   const updateData: Record<string, unknown> = { lastUsedAt: new Date() };
   if (!session.tokenHash) {
     updateData.tokenHash = hash;
@@ -536,6 +545,11 @@ export async function refreshSession(token: string): Promise<{ expiresAt: Date }
   if (!session) return null;
 
   if (session.user.sessionVersion !== (session.versionAtCreation ?? 0)) {
+    await prisma.session.delete({ where: { id: session.id } });
+    return null;
+  }
+
+  if (session.user.suspendedAt) {
     await prisma.session.delete({ where: { id: session.id } });
     return null;
   }

--- a/apps/web-next/src/lib/api/rate-limit.ts
+++ b/apps/web-next/src/lib/api/rate-limit.ts
@@ -36,8 +36,7 @@ export function enforceRateLimit(
   const now = Date.now();
   const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
   const maxRequests = options.maxRequests ?? DEFAULT_MAX_REQUESTS;
-  const ip = getClientIP(request);
-  if (!ip) return null;
+  const ip = getClientIP(request) || 'unknown';
   const key = `${options.keyPrefix}:${ip}`;
 
   cleanupExpiredEntries(now);

--- a/packages/plugin-server-sdk/src/server.ts
+++ b/packages/plugin-server-sdk/src/server.ts
@@ -109,7 +109,13 @@ export function createPluginServer(config: PluginServerConfig): PluginServer {
     corsOrigins,
     requireAuth = true,
     publicRoutes = ['/healthz'],
-    jwtSecret = process.env.NEXTAUTH_SECRET || process.env.JWT_SECRET || 'dev-secret',
+    jwtSecret = (() => {
+      const s = process.env.NEXTAUTH_SECRET || process.env.JWT_SECRET;
+      if (!s && process.env.NODE_ENV === 'production') {
+        throw new Error('NEXTAUTH_SECRET or JWT_SECRET is required in production');
+      }
+      return s || 'dev-secret';
+    })(),
     compression: enableCompression = true,
     helmet: enableHelmet = true,
     rateLimit: rateLimitConfig = {},

--- a/packages/plugin-server-sdk/src/server.ts
+++ b/packages/plugin-server-sdk/src/server.ts
@@ -109,13 +109,7 @@ export function createPluginServer(config: PluginServerConfig): PluginServer {
     corsOrigins,
     requireAuth = true,
     publicRoutes = ['/healthz'],
-    jwtSecret = (() => {
-      const s = process.env.NEXTAUTH_SECRET || process.env.JWT_SECRET;
-      if (!s && process.env.NODE_ENV === 'production') {
-        throw new Error('NEXTAUTH_SECRET or JWT_SECRET is required in production');
-      }
-      return s || 'dev-secret';
-    })(),
+    jwtSecret,
     compression: enableCompression = true,
     helmet: enableHelmet = true,
     rateLimit: rateLimitConfig = {},
@@ -235,8 +229,15 @@ export function createPluginServer(config: PluginServerConfig): PluginServer {
   // ─── Auth Middleware ───────────────────────────────────────────────
 
   if (requireAuth) {
+    const resolvedSecret = jwtSecret ?? (() => {
+      const s = process.env.NEXTAUTH_SECRET || process.env.JWT_SECRET;
+      if (!s && process.env.NODE_ENV === 'production') {
+        throw new Error('NEXTAUTH_SECRET or JWT_SECRET is required in production');
+      }
+      return s || 'dev-secret';
+    })();
     const authMiddleware = createAuthMiddleware({
-      secret: jwtSecret,
+      secret: resolvedSecret,
       publicPaths: publicRoutes,
     });
     app.use(authMiddleware);

--- a/services/base-svc/src/services/auth.ts
+++ b/services/base-svc/src/services/auth.ts
@@ -425,6 +425,11 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
         return null;
       }
 
+      if (session.user.suspendedAt) {
+        await prisma.session.delete({ where: { id: session.id } });
+        return null;
+      }
+
       const updateData: Record<string, unknown> = { lastUsedAt: new Date() };
       if (!session.tokenHash) {
         updateData.tokenHash = hash;
@@ -467,6 +472,11 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
         return null;
       }
 
+      if (session.user.suspendedAt) {
+        await prisma.session.delete({ where: { id: session.id } });
+        return null;
+      }
+
       const updateData: Record<string, unknown> = { lastUsedAt: new Date() };
       if (!session.tokenHash) {
         updateData.tokenHash = hash;
@@ -503,6 +513,11 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
       if (!session) return null;
 
       if (session.user.sessionVersion !== (session.versionAtCreation ?? 0)) {
+        await prisma.session.delete({ where: { id: session.id } });
+        return null;
+      }
+
+      if (session.user.suspendedAt) {
         await prisma.session.delete({ where: { id: session.id } });
         return null;
       }
@@ -710,6 +725,14 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
         userId = user.id;
       }
 
+      const userRecord = await prisma.user.findUnique({ where: { id: userId } });
+      if (userRecord?.suspendedAt) {
+        const err = new Error('Account suspended') as Error & { code?: string; reason?: string | null };
+        err.code = 'ACCOUNT_SUSPENDED';
+        err.reason = (userRecord as any).suspendedReason;
+        throw err;
+      }
+
       // Create session
       const { token, expiresAt } = await createSession(userId);
 
@@ -816,10 +839,12 @@ export function createAuthService(prisma: PrismaClient, oauthConfig?: OAuthConfi
 
       const passwordHash = await hashPassword(newPassword);
 
-      // Update user password
       await prisma.user.update({
         where: { id: resetToken.userId },
-        data: { passwordHash },
+        data: {
+          passwordHash,
+          sessionVersion: { increment: 1 },
+        },
       });
 
       // Mark token as used

--- a/services/base-svc/src/services/encryption.ts
+++ b/services/base-svc/src/services/encryption.ts
@@ -20,6 +20,9 @@ const ITERATIONS = 100000;
 function getMasterKey(): string {
   const masterKey = process.env.ENCRYPTION_MASTER_KEY || process.env.SECRET_KEY;
   if (!masterKey) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('ENCRYPTION_MASTER_KEY or SECRET_KEY is required in production');
+    }
     console.warn('WARNING: No encryption master key set. Using default for development.');
     return 'naap-dev-master-key-change-in-production';
   }


### PR DESCRIPTION
## Summary

Addresses all remaining critical/high/medium security vulnerabilities identified in the second security audit.

### CRITICAL fixes
- **Unauthenticated SecretVault API**: Added admin auth guard (`system:admin` role required) to all `/api/v1/secrets` routes — GET, POST, DELETE, and rotate. Previously anyone on the internet could list, create, delete, and rotate vault secrets.
- **Broken rotate route crypto**: Replaced the completely broken encryption in the rotate route (random key per instance, incompatible format) with the canonical `v1:gcm:scrypt:` envelope matching the create route. `ENCRYPTION_KEY` env var is now required (no random fallback).
- **Suspended users not blocked on active sessions**: Added `suspendedAt` check to `validateSession`, `validateSessionWithExpiry`, and `refreshSession` in both web-next and base-svc. Suspended users' existing sessions are now terminated on next API request.

### HIGH fixes
- **base-svc OAuth bypass**: Added `suspendedAt` check to `handleOAuthCallback` — was previously missing, allowing suspended users to create new sessions via OAuth.
- **base-svc password reset session leak**: Added `sessionVersion` increment on password reset, matching web-next — previously old sessions survived password changes.
- **base-svc encryption default**: Fails closed in production when `ENCRYPTION_MASTER_KEY`/`SECRET_KEY` is missing (was falling back to `'naap-dev-master-key-change-in-production'`).
- **Health endpoint info disclosure**: Sanitized DB error output — no longer returns `error.name`, `error.message`, or `error.code` to unauthenticated callers.

### MEDIUM fixes
- **Rate limiter bypass**: Uses `'unknown'` fallback when client IP cannot be resolved (was silently skipping rate limits entirely).
- **Plugin SDK JWT secret**: Fails closed in production when JWT secret env vars are missing (was falling back to `'dev-secret'`).

### Regression-safe decisions
- Plaintext token fallback lookups kept with existing backfill behavior — full removal requires production DB audit to confirm all sessions have `tokenHash` populated.
- CSRF shadow mode left as-is — switching to enforce mode is a separate effort that requires all clients to send the `X-CSRF-Token` header.

## Test plan
- [x] Pre-push validation: 275 SDK tests pass, TypeScript build OK, Vercel safety check OK
- [ ] CI: Lint & TypeCheck, Build, SDK Tests, Shell Tests, Lifecycle BDD, Quality Gates
- [ ] Manual: verify admin secrets page still works (with cookie-based auth)
- [ ] Manual: verify non-admin user gets 401/403 on `/api/v1/secrets`
- [ ] Manual: verify suspended user's session is terminated on next request


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access Control**
  * Added admin-only authentication requirements for secret management endpoints
  * Suspended user accounts now automatically invalidate all active sessions
  * Password resets now force re-authentication on next login
  * Improved secret rotation encryption with versioning and salt-based key derivation

* **Bug Fixes**
  * Rate limiting now properly handles unknown client IPs
  * Health check endpoint provides safer error responses
  * Enforced encryption master key validation in production environments

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/naap/pull/302)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->