### PR TITLE
fix(cache): document REDIS_URL requirement + add BFF cache regression guards (#304)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,9 +211,11 @@ FACADE_USE_STUBS=
 # CACHING
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Redis URL for caching and rate limiting
+# REDIS_URL — Redis URL for BFF/SWR cache and rate limiting.
 # Format: redis://[[username:]password@]host[:port][/database]
-# Without this, in-memory caching is used (not recommended for production)
+# WITHOUT this in production: BFF cache is per-instance only and is wiped on every
+# serverless cold start, causing dashboard load timeouts on Overview (see issue #304).
+# Used by: packages/cache, apps/web-next/src/lib/api/bff-swr.ts, services/base-svc rate limiter.
 REDIS_URL=redis://localhost:6379
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/apps/web-next/src/lib/api/__tests__/bff-swr.test.ts
+++ b/apps/web-next/src/lib/api/__tests__/bff-swr.test.ts
@@ -46,7 +46,7 @@ describe('bffStaleWhileRevalidate — BFF SWR contract (regression guard for #30
 
     expect(a.data).toEqual(b.data);
     expect(b.data).toEqual(c.data);
-    expect(calls, 'concurrent callers must coalesce onto one upstream fetch').toBeLessThanOrEqual(1);
+    expect(calls, 'concurrent callers must coalesce onto exactly one upstream fetch').toBe(1);
   });
 
   it('propagates fetcher errors on initial MISS and leaves cache empty', async () => {

--- a/apps/web-next/src/lib/api/__tests__/bff-swr.test.ts
+++ b/apps/web-next/src/lib/api/__tests__/bff-swr.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  after: (work: () => Promise<void>) => {
+    void work().catch(() => {
+      /* swallow background errors in tests */
+    });
+  },
+}));
+
+import { bffStaleWhileRevalidate } from '../bff-swr';
+
+describe('bffStaleWhileRevalidate — BFF SWR contract (regression guard for #304)', () => {
+  it('returns MISS on first call, HIT on second call within softTtl', async () => {
+    const key = `test-miss-then-hit-${Date.now()}-${Math.random()}`;
+    let calls = 0;
+    const fetcher = async (): Promise<{ kpi: number }> => {
+      calls++;
+      return { kpi: calls };
+    };
+
+    const first = await bffStaleWhileRevalidate(key, fetcher, 'test');
+    expect(first.cache).toBe('MISS');
+    expect(first.data).toEqual({ kpi: 1 });
+
+    const second = await bffStaleWhileRevalidate(key, fetcher, 'test');
+    expect(second.cache).toBe('HIT');
+    expect(second.data).toEqual({ kpi: 1 });
+    expect(calls, 'fetcher must not re-run while envelope is fresh').toBe(1);
+  });
+
+  it('coalesces concurrent callers onto a single upstream fetch', async () => {
+    const key = `test-coalesce-${Date.now()}-${Math.random()}`;
+    let calls = 0;
+    const fetcher = async (): Promise<{ kpi: number }> => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 30));
+      return { kpi: calls };
+    };
+
+    const [a, b, c] = await Promise.all([
+      bffStaleWhileRevalidate(key, fetcher, 'test'),
+      bffStaleWhileRevalidate(key, fetcher, 'test'),
+      bffStaleWhileRevalidate(key, fetcher, 'test'),
+    ]);
+
+    expect(a.data).toEqual(b.data);
+    expect(b.data).toEqual(c.data);
+    expect(calls, 'concurrent callers must coalesce onto one upstream fetch').toBeLessThanOrEqual(1);
+  });
+
+  it('propagates fetcher errors on initial MISS and leaves cache empty', async () => {
+    const key = `test-error-${Date.now()}-${Math.random()}`;
+    const fetcher = async (): Promise<never> => {
+      throw new Error('upstream boom');
+    };
+
+    await expect(bffStaleWhileRevalidate(key, fetcher, 'test')).rejects.toThrow('upstream boom');
+
+    // Subsequent call with a different fetcher should still see MISS (no cached error)
+    let calls = 0;
+    const goodFetcher = async (): Promise<{ ok: true; calls: number }> => {
+      calls++;
+      return { ok: true, calls };
+    };
+    const recovery = await bffStaleWhileRevalidate(key, goodFetcher, 'test');
+    expect(recovery.cache).toBe('MISS');
+    expect(recovery.data).toEqual({ ok: true, calls: 1 });
+  });
+});

--- a/apps/web-next/tests/bff-redis-cache.spec.ts
+++ b/apps/web-next/tests/bff-redis-cache.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression guard for issue #304 — BFF SWR cache must persist across
+ * serverless instances via Redis.
+ *
+ * Strategy
+ * --------
+ * The Vercel CDN keys responses by full URL; the BFF cache (apps/web-next/src/lib/
+ * api/bff-swr.ts → @naap/cache staleWhileRevalidate) keys by the route's logical
+ * cacheKey, e.g. `kpi:${hours}:${pipeline ?? 'all'}:${model_id ?? 'all'}` from
+ * apps/web-next/src/app/api/v1/dashboard/kpi/route.ts.
+ *
+ * Adding `?cb=<unique>` to each request defeats the CDN (different URL) but
+ * reuses the BFF cache key (cb is not in the key). With REDIS_URL set: every
+ * function invocation — possibly on different serverless instances — reads the
+ * same envelope and returns `X-Cache: HIT|STALE`. Without Redis (the #304 bug):
+ * each new instance returns `X-Cache: MISS`.
+ *
+ * Tagged @pre-release so the nightly e2e-ga workflow
+ * (.github/workflows/e2e-nightly.yml) picks it up against production.
+ */
+test.describe('BFF Redis cache (issue #304) @pre-release', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('dashboard KPI BFF returns X-Cache: HIT across CDN-busted requests', async ({
+    request,
+    baseURL,
+  }) => {
+    test.skip(!baseURL, 'baseURL required');
+    test.skip(
+      baseURL!.includes('localhost'),
+      'requires a deployed Vercel env with REDIS_URL set (local dev defaults to in-memory)',
+    );
+
+    // Warm the BFF — first invocation populates the SWR envelope in Redis.
+    const warmRes = await request.get(
+      `/api/v1/dashboard/kpi?timeframe=24&cb=warm-${Date.now()}`,
+    );
+    expect(warmRes.status(), 'KPI endpoint must respond 200 on warm').toBe(200);
+
+    // Small settle to let the SWR write land in Redis before the next read.
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const samples: Array<{
+      xCache: string | undefined;
+      xVercelCache: string | undefined;
+    }> = [];
+
+    for (let i = 0; i < 5; i++) {
+      const res = await request.get(
+        `/api/v1/dashboard/kpi?timeframe=24&cb=${Date.now()}-${i}`,
+      );
+      expect(res.status(), `KPI endpoint must respond 200 (sample ${i})`).toBe(200);
+      samples.push({
+        xCache: res.headers()['x-cache'],
+        xVercelCache: res.headers()['x-vercel-cache'],
+      });
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    console.log('\n=== BFF cache samples (issue #304 guardrail) ===');
+    for (const s of samples) {
+      console.log(
+        `  X-Cache=${s.xCache ?? '(none)'}  x-vercel-cache=${s.xVercelCache ?? '(none)'}`,
+      );
+    }
+    console.log('');
+
+    // Regression guard A: the route must always emit X-Cache (proves SWR is wired).
+    for (const [i, s] of samples.entries()) {
+      expect(
+        s.xCache,
+        `X-Cache header missing on sample ${i}: route is bypassing bffStaleWhileRevalidate`,
+      ).toBeTruthy();
+    }
+
+    // Regression guard B: with Redis, ≥4/5 cache-busted calls should HIT or STALE.
+    // A MISS rate > 1/5 means the envelope is per-instance (the #304 bug).
+    const hitOrStale = samples.filter(
+      (s) => s.xCache === 'HIT' || s.xCache === 'STALE',
+    ).length;
+    expect(
+      hitOrStale,
+      `Expected >=4/5 X-Cache HIT|STALE across CDN-busted requests, got ${hitOrStale}/5. ` +
+        `Indicates REDIS_URL is not set or the BFF SWR envelope is per-instance (#304).`,
+    ).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #304.

The code already supports Redis-backed BFF cache with in-memory fallback ([`packages/cache`](packages/cache), [`apps/web-next/src/lib/api/bff-swr.ts`](apps/web-next/src/lib/api/bff-swr.ts)). Production was running with `REDIS_URL=""`, so every Vercel instance silently used a per-process `Map` that wipes on cold start — that is the entire bug.

The actual fix is an **operator action**: set `REDIS_URL` in the Vercel project's `Production` and `Preview` env scopes (the URL is already provisioned). This PR carries the documentation and the regression guards so the bug cannot return silently.

### Why not a service-gateway connector?

Considered and rejected. The gateway response cache at `apps/web-next/src/lib/gateway/cache.ts` is explicitly in-memory only (`Map`, max 1000 entries) and does not read `REDIS_URL` — it has the same cross-instance problem #304 describes. The BFF SWR path is already Redis-backed with stale-while-revalidate + distributed locks; it just needed the env wired up.

## Changes

- **[`.env.example`](.env.example)** — strengthen the `REDIS_URL` block to call out the per-instance fallback failure mode and reference #304.
- **[`apps/web-next/src/lib/api/__tests__/bff-swr.test.ts`](apps/web-next/src/lib/api/__tests__/bff-swr.test.ts)** (new) — vitest unit covering the SWR state machine (MISS→HIT, concurrent-call coalesce, error recovery) via the in-memory fallback. Locks the contract down without requiring Redis in CI.
- **[`apps/web-next/tests/bff-redis-cache.spec.ts`](apps/web-next/tests/bff-redis-cache.spec.ts)** (new) — Playwright `@pre-release` e2e that hits `/api/v1/dashboard/kpi` with CDN-busting query params and asserts `X-Cache: HIT|STALE` on ≥4/5 cache-busted calls.

### How the e2e proves cross-instance Redis works

The BFF cache key in [`apps/web-next/src/app/api/v1/dashboard/kpi/route.ts:16`](apps/web-next/src/app/api/v1/dashboard/kpi/route.ts) is built from `timeframe`/`pipeline`/`model_id` — extra query params do not change it. The CDN keys on the full URL. So `?cb=<unique>` defeats CDN caching but reuses the BFF key. With Redis: every invocation (possibly on different instances) reads the same envelope → `X-Cache: HIT`. Without Redis: each new instance returns `MISS`.

## Operator action required (before/at merge)

The PR cannot fix the bug by itself — Vercel reads env from its own store, not from `.env.vercel-prod`. Run these from `apps/web-next/`:

```bash
# Provisioned Redis URL goes here (already exists per #304):
printf '%s' "$REDIS_URL_PROVISIONED" | npx vercel env add REDIS_URL preview --sensitive --force
printf '%s' "$REDIS_URL_PROVISIONED" | npx vercel env add REDIS_URL production --sensitive --force
```

Or via the Vercel dashboard: **Project → Settings → Environment Variables → add `REDIS_URL` with Production + Preview checked**.

Vercel only picks up env changes on the next deploy for each scope. So:
- This PR's preview build needs the **Preview** env set **before** redeploying the preview (push a noop commit or trigger a redeploy after setting the env).
- The post-merge production deploy needs the **Production** env set **before** merging.

## Test plan

- [x] Local vitest: **515/515 pass** (`apps/web-next` workspace, 48 test files) — including the new `bff-swr.test.ts` (3/3).
- [x] Local typecheck: error count unchanged from `main` (26 → 26, all pre-existing in unrelated files).
- [x] Local lint: new files clean (`No ESLint warnings or errors`).
- [ ] CI green: `lint-typecheck`, `shell-tests`, `build`, `quality-gates` jobs.
- [ ] After operator sets `REDIS_URL` for Preview + redeploys preview: Vercel function logs show `[Redis] Connected`.
- [ ] After preview redeploy: `cd apps/web-next && PLAYWRIGHT_BASE_URL=<preview-url> npx playwright test bff-redis-cache.spec.ts --project=chromium` passes.
- [ ] Manual: `curl -i 'https://<preview>/api/v1/dashboard/kpi?timeframe=24&cb=1'` then `cb=2` → both show `X-Cache: HIT|STALE`.
- [ ] After merge (with Production env set): same checks on `https://naap-platform.vercel.app`.
- [ ] Trigger a production redeploy and confirm dashboard cold load is fast — cache survives because it's in Redis, not in the recycled process.

## Regression protection

| Gate | Where | What it catches |
|------|-------|-----------------|
| `npm run test` (vitest) | CI `shell-tests` job | New `bff-swr.test.ts` + all 515 existing tests |
| `npm run test:coverage` thresholds (70%) | CI `shell-tests` job | Coverage drop |
| `./bin/vercel-build.sh` | CI `build` job | Next.js build regression |
| `bff-redis-cache.spec.ts` (`@pre-release`) | Manual on PR preview + nightly `e2e-ga` job | The exact #304 bug returning — fails if BFF cache becomes per-instance again |
| Existing `dashboard-loading.spec.ts` | Nightly `e2e-ga` job | Regression in `Cache-Control` / `s-maxage` / `stale-while-revalidate` |
| `lockfile-sync`, `audit`, `quality-gates` | CI | Same as before; this PR doesn't touch `package.json` |

No source-code changes to the caching mechanism — runtime on `main` is provably unchanged until the operator sets `REDIS_URL` in Vercel. In-memory fallback is preserved and now explicitly tested.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Redis configuration in the example env file, added explicit REDIS_URL guidance (format, usage for cache and rate limiting) and production caveats.

* **Tests**
  * Added unit tests validating BFF stale-while-revalidate behavior, cache hits/coalescing, and error recovery.
  * Added e2e regression test ensuring Redis-backed cache persists across serverless/CDN-busted requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/naap/pull/305)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->