### PR TITLE
fix: mitigate leaderboard cold-start timeouts

### DIFF
--- a/apps/web-next/src/app/api/internal/bff-warm/route.ts
+++ b/apps/web-next/src/app/api/internal/bff-warm/route.ts
@@ -50,6 +50,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     `${base}/api/v1/network/capacity`,
   ];
 
+  const authedTargets = [
+    `${base}/api/v1/orchestrator-leaderboard/filters`,
+  ];
+
+  const cronSecret = process.env.CRON_SECRET;
+
   const results: { url: string; ok: boolean; status: number }[] = [];
   for (const url of targets) {
     try {
@@ -57,6 +63,20 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       results.push({ url, ok: r.ok, status: r.status });
     } catch {
       results.push({ url, ok: false, status: 0 });
+    }
+  }
+
+  if (cronSecret) {
+    for (const url of authedTargets) {
+      try {
+        const r = await fetch(url, {
+          cache: 'no-store',
+          headers: { Authorization: `Bearer ${cronSecret}` },
+        });
+        results.push({ url, ok: r.ok, status: r.status });
+      } catch {
+        results.push({ url, ok: false, status: 0 });
+      }
     }
   }
 

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
@@ -7,6 +7,7 @@
  */
 
 export const runtime = 'nodejs';
+export const maxDuration = 30;
 
 import { NextRequest, NextResponse } from 'next/server';
 import { authorize } from '@/lib/gateway/authorize';
@@ -28,16 +29,24 @@ const FALLBACK_CAPABILITIES = [
   'streamdiffusion-sdxl-v2v',
 ];
 
+function isCronAuth(request: NextRequest): boolean {
+  const auth = request.headers.get('authorization');
+  return Boolean(process.env.CRON_SECRET) && auth === `Bearer ${process.env.CRON_SECRET}`;
+}
+
 export async function GET(request: NextRequest): Promise<NextResponse | Response> {
-  const auth = await authorize(request);
-  if (!auth) {
-    return NextResponse.json(
-      { success: false, error: { code: 'UNAUTHORIZED', message: 'Missing or invalid authentication' } },
-      { status: 401 }
-    );
+  const cronAuthed = isCronAuth(request);
+  if (!cronAuthed) {
+    const auth = await authorize(request);
+    if (!auth) {
+      return NextResponse.json(
+        { success: false, error: { code: 'UNAUTHORIZED', message: 'Missing or invalid authentication' } },
+        { status: 401 }
+      );
+    }
   }
 
-  const authToken = getAuthToken(request) || '';
+  const authToken = cronAuthed ? '' : (getAuthToken(request) || '');
   const url = resolveClickhouseGatewayQueryUrl(request.url);
 
   const headers: Record<string, string> = {
@@ -62,7 +71,7 @@ export async function GET(request: NextRequest): Promise<NextResponse | Response
       method: 'POST',
       headers,
       body: FILTERS_SQL,
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(20_000),
     });
 
     if (!res.ok) {

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/rank/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/rank/route.ts
@@ -7,6 +7,7 @@
  */
 
 export const runtime = 'nodejs';
+export const maxDuration = 30;
 
 import { NextRequest, NextResponse } from 'next/server';
 import { authorize } from '@/lib/gateway/authorize';

--- a/apps/web-next/vercel.json
+++ b/apps/web-next/vercel.json
@@ -1,4 +1,5 @@
 {
+  "fluid": true,
   "crons": [
     {
       "path": "/api/internal/bff-warm",


### PR DESCRIPTION
## Summary

- Increase `/filters` ClickHouse fetch timeout from 10s → 20s so cold starts don't abort before the gateway responds
- Add `maxDuration = 30` to both `/filters` and `/rank` routes for Vercel function execution headroom
- Add `/filters` to the BFF warm-up cron (every 10 min via `CRON_SECRET` auth) so the ClickHouse gateway connection is pre-warmed before users hit it
- Explicitly enable Fluid Compute (`"fluid": true`) in `vercel.json` for optimal instance reuse

## Motivation

On production (`operator.livepeer.org`), cold starts were causing "signal timed out" errors on the leaderboard's first load. The existing in-memory caching is well-designed but only helps after the first request to a warm instance. These changes address the cold-start gap without adding new infrastructure.

## Test plan

- [ ] Verify Vercel preview deploys successfully
- [ ] Hit `/api/v1/orchestrator-leaderboard/filters` on preview — confirm no timeout
- [ ] Confirm BFF warm cron includes the leaderboard filters endpoint in its results
- [ ] After merge, confirm production leaderboard loads without "signal timed out"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased API timeout from 10 to 20 seconds to prevent premature timeouts on leaderboard queries.

* **New Features**
  * Added cron-based authentication support for leaderboard endpoints.
  * Implemented additional warm-up fetches for improved performance and cache optimization.

* **Chores**
  * Updated server configuration for enhanced request handling capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/naap/pull/318)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->