### PR TITLE
fix: enable naap-discover source for leaderboard capability merging

### DIFF
--- a/apps/web-next/src/__tests__/api/orchestrator-leaderboard.test.ts
+++ b/apps/web-next/src/__tests__/api/orchestrator-leaderboard.test.ts
@@ -15,6 +15,10 @@ vi.mock('@/lib/db', () => ({
   prisma: {},
 }));
 
+vi.mock('@/lib/orchestrator-leaderboard/global-dataset', () => ({
+  getGlobalDataset: vi.fn().mockReturnValue(null),
+}));
+
 import { authorize } from '@/lib/gateway/authorize';
 import { clearCache } from '@/lib/orchestrator-leaderboard/cache';
 
@@ -238,6 +242,7 @@ describe('GET /api/v1/orchestrator-leaderboard/filters', () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(json.data.capabilities).toEqual(['noop', 'streamdiffusion-sdxl', 'streamdiffusion-sdxl-v2v']);
+    expect(json.data.sources).toEqual({ clickhouse: 3, merged: 3 });
   });
 
   it('returns fallback capabilities on ClickHouse error', async () => {

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
@@ -1,8 +1,10 @@
 /**
  * GET /api/v1/orchestrator-leaderboard/filters
  *
- * Returns available filter options (distinct capability names) by querying
- * ClickHouse for warm capabilities seen in the last hour.
+ * Returns available filter options (distinct capability names) by merging:
+ *   1. ClickHouse warm capabilities from the last hour
+ *   2. Capabilities from the global dataset (populated by cron from all sources)
+ *
  * Falls back to a known list when ClickHouse is unreachable (e.g. local dev).
  */
 
@@ -14,6 +16,7 @@ import { authorize } from '@/lib/gateway/authorize';
 import { success } from '@/lib/api/response';
 import { getAuthToken } from '@/lib/api/response';
 import { resolveClickhouseGatewayQueryUrl } from '@/lib/orchestrator-leaderboard/query';
+import { getGlobalDataset } from '@/lib/orchestrator-leaderboard/global-dataset';
 
 const FILTERS_SQL = `SELECT DISTINCT capability_name
 FROM semantic.network_capabilities
@@ -64,7 +67,7 @@ export async function GET(request: NextRequest): Promise<NextResponse | Response
     headers['x-vercel-protection-bypass'] = bypassSecret;
   }
 
-  let capabilities: string[];
+  let chCapabilities: string[];
   let fromFallback = false;
   try {
     const res = await fetch(url, {
@@ -80,13 +83,28 @@ export async function GET(request: NextRequest): Promise<NextResponse | Response
 
     const json = await res.json();
     const chData = (json.data ?? json) as { data?: Array<{ capability_name: string }> };
-    capabilities = (chData.data ?? []).map((row: { capability_name: string }) => row.capability_name);
+    chCapabilities = (chData.data ?? []).map((row: { capability_name: string }) => row.capability_name);
   } catch {
-    capabilities = FALLBACK_CAPABILITIES;
+    chCapabilities = FALLBACK_CAPABILITIES;
     fromFallback = true;
   }
 
-  const response = success({ capabilities, fromFallback });
+  // Merge capabilities from the global dataset (includes all enabled sources)
+  const globalDs = getGlobalDataset();
+  const capSet = new Set(chCapabilities);
+  if (globalDs) {
+    for (const cap of Object.keys(globalDs.capabilities)) {
+      if (cap !== '__uncategorized') capSet.add(cap);
+    }
+  }
+
+  const capabilities = Array.from(capSet).sort();
+
+  const response = success({
+    capabilities,
+    fromFallback,
+    sources: { clickhouse: chCapabilities.length, merged: capabilities.length },
+  });
   response.headers.set('Cache-Control', 'private, max-age=60');
   return response;
 }

--- a/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
@@ -28,7 +28,7 @@ import { clearPlanCache } from './refresh';
 const DEFAULT_SOURCES: { kind: SourceKind; priority: number; enabled: boolean }[] = [
   { kind: 'livepeer-subgraph', priority: 1, enabled: true },
   { kind: 'clickhouse-query', priority: 2, enabled: true },
-  { kind: 'naap-discover', priority: 3, enabled: false },
+  { kind: 'naap-discover', priority: 3, enabled: true },
   { kind: 'naap-pricing', priority: 4, enabled: false },
 ];
 

--- a/apps/web-next/src/lib/orchestrator-leaderboard/sources/naap-discover.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/sources/naap-discover.ts
@@ -2,15 +2,21 @@
  * Source Adapter: NaaP Orchestrator Discovery API
  *
  * Fetches from https://naap-api.cloudspe.com/v1/discover/orchestrators
- * via the gateway proxy. Returns per-capability rows with score, liveness,
- * and orchestrator URI.
+ * via the gateway proxy (user-facing) or directly (cron internal mode).
+ * Returns per-capability rows with score, liveness, and orchestrator URI.
+ *
+ * Two modes:
+ *   - Gateway mode (default): routes through /api/v1/gw/naap-discover/*
+ *   - Internal mode (ctx.internal): calls upstream directly (no auth needed)
  */
 
 import type { SourceAdapter, FetchCtx, SourceFetchResult, NormalizedOrch } from './types';
+import { resolveConnectorAuth } from './internal-resolve';
 
 const GW_PATH = '/api/v1/gw/naap-discover/orchestrators';
+const UPSTREAM_PATH = '/v1/discover/orchestrators';
 
-function resolveUrl(requestUrl?: string): string {
+function resolveGatewayUrl(requestUrl?: string): string {
   const origin =
     (requestUrl ? new URL(requestUrl).origin : undefined) ||
     process.env.NEXT_PUBLIC_APP_URL ||
@@ -19,7 +25,7 @@ function resolveUrl(requestUrl?: string): string {
   return new URL(GW_PATH, origin).toString();
 }
 
-function buildHeaders(ctx: FetchCtx): Record<string, string> {
+function buildGatewayHeaders(ctx: FetchCtx): Record<string, string> {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${ctx.authToken}`,
   };
@@ -27,6 +33,18 @@ function buildHeaders(ctx: FetchCtx): Record<string, string> {
   const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
   if (bypassSecret) headers['x-vercel-protection-bypass'] = bypassSecret;
   return headers;
+}
+
+async function resolveUrlAndHeaders(ctx: FetchCtx): Promise<{ url: string; headers: Record<string, string> }> {
+  if (ctx.internal) {
+    const auth = await resolveConnectorAuth('naap-discover');
+    if (auth) {
+      return { url: `${auth.upstreamBaseUrl}${UPSTREAM_PATH}`, headers: auth.headers };
+    }
+    // Fallback: call upstream directly with no auth (public API)
+    return { url: `https://naap-api.cloudspe.com${UPSTREAM_PATH}`, headers: {} };
+  }
+  return { url: resolveGatewayUrl(ctx.requestUrl), headers: buildGatewayHeaders(ctx) };
 }
 
 interface DiscoverRow {
@@ -53,11 +71,11 @@ export const naapDiscoverAdapter: SourceAdapter = {
 
   async fetchAll(ctx: FetchCtx): Promise<SourceFetchResult> {
     const t0 = Date.now();
-    const url = resolveUrl(ctx.requestUrl);
+    const { url, headers } = await resolveUrlAndHeaders(ctx);
 
     const res = await fetch(url, {
       method: 'GET',
-      headers: buildHeaders(ctx),
+      headers,
       signal: AbortSignal.timeout(15_000),
     });
 

--- a/bin/seed-gateway-connector.ts
+++ b/bin/seed-gateway-connector.ts
@@ -58,6 +58,11 @@ const CONNECTOR_SEEDS: ConnectorSeed[] = [
       'api-key': 'SUBGRAPH_API_KEY',
     },
   },
+  {
+    slug: 'naap-discover',
+    template: 'naap-discover.json',
+    secretMap: {},
+  },
 ];
 
 // ── Encryption (mirrors apps/web-next/src/lib/gateway/encryption.ts) ──
@@ -255,7 +260,7 @@ async function seedConnector(
 // ── Main ──
 
 async function main() {
-  console.log('[seed-gw] Seeding gateway connectors (ClickHouse + Subgraph)...');
+  console.log('[seed-gw] Seeding gateway connectors (ClickHouse + Subgraph + Discovery)...');
 
   const prisma = new PrismaClient();
 


### PR DESCRIPTION
## Summary

The leaderboard only showed ~4 ClickHouse-tracked capabilities (streamdiffusion variants), missing 25+ capabilities from the NaaP Discovery API (LLM, audio, image gen, text-to-speech, etc.).

**Root causes fixed:**
- `naap-discover` source was **disabled** by default in `LeaderboardSource`
- The `naap-discover` gateway connector was **never seeded** during builds
- The discover adapter had **no internal mode** (cron couldn't use it)
- The `/filters` endpoint **only queried ClickHouse** for capabilities

**Changes:**
- Add `naap-discover` to `CONNECTOR_SEEDS` in `bin/seed-gateway-connector.ts` (no secrets needed — public API)
- Enable `naap-discover` by default (`priority: 3, enabled: true`)
- Add internal mode to discover adapter — direct upstream call to `naap-api.cloudspe.com` for cron refresh
- Merge global dataset capabilities into `/filters` response, so discovery-only caps appear in the UI

## Test plan

- [x] All 61 test files pass locally (including naap-discover adapter tests)
- [x] Pre-push hooks pass (275 SDK tests, Vercel safety check)
- [ ] After deploy: trigger dataset refresh and verify `/filters` returns 25+ capabilities
- [ ] Verify leaderboard UI shows LLM, audio, image caps in the dropdown


Made with [Cursor](https://cursor.com)