### PR TITLE
fix: subgraph auth, configurable ID, and resolver membership fallback

### DIFF
--- a/apps/web-next/src/lib/orchestrator-leaderboard/resolver.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/resolver.ts
@@ -150,7 +150,6 @@ export function resolve(
     };
   }
 
-  const membershipSource = enabled[0].kind;
   const fieldPriority = { ...DEFAULT_FIELD_PRIORITY, ...cfg.fieldPriority };
 
   // Index each source's rows by orchKey
@@ -161,8 +160,28 @@ export function resolve(
     sourceIndexes.set(s.kind, indexByOrch(rows));
   }
 
-  // Membership set = keys from the highest-priority source
-  const membershipIndex = sourceIndexes.get(membershipSource)!;
+  // Membership set = keys from the highest-priority source that returned data.
+  // Falls back to the next source if higher-priority ones returned 0 rows
+  // (e.g. subgraph auth failure should not wipe out the entire dataset).
+  let membershipSource = enabled[0].kind;
+  let membershipIndex = sourceIndexes.get(membershipSource)!;
+  if (membershipIndex.size === 0 && enabled.length > 1) {
+    for (const s of enabled.slice(1)) {
+      const idx = sourceIndexes.get(s.kind)!;
+      if (idx.size > 0) {
+        membershipSource = s.kind;
+        membershipIndex = idx;
+        warnings.push(
+          `Primary membership source "${enabled[0].kind}" returned 0 rows — ` +
+          `falling back to "${s.kind}" (${idx.size} orchestrators)`,
+        );
+        break;
+      }
+    }
+    if (membershipIndex.size === 0) {
+      warnings.push('All sources returned 0 rows — empty dataset');
+    }
+  }
   const membershipKeys = new Set(membershipIndex.keys());
 
   // Also build a cross-reference: orchUri <-> ethAddress for join

--- a/apps/web-next/src/lib/orchestrator-leaderboard/sources/subgraph.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/sources/subgraph.ts
@@ -14,7 +14,12 @@ import type { SourceAdapter, FetchCtx, SourceFetchResult, NormalizedOrch } from 
 import { resolveConnectorAuth } from './internal-resolve';
 
 const GW_PATH = '/api/v1/gw/livepeer-subgraph/transcoders';
-const UPSTREAM_PATH = '/api/subgraphs/id/FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC';
+const DEFAULT_SUBGRAPH_ID = 'FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC';
+
+function getUpstreamPath(): string {
+  const id = process.env.SUBGRAPH_ID || DEFAULT_SUBGRAPH_ID;
+  return `/api/subgraphs/id/${id}`;
+}
 
 const TRANSCODERS_QUERY = `{
   transcoders(
@@ -90,7 +95,7 @@ export const subgraphAdapter: SourceAdapter = {
     if (ctx.internal) {
       const auth = await resolveConnectorAuth('livepeer-subgraph');
       if (!auth) throw new Error('livepeer-subgraph connector not found or not published');
-      url = `${auth.upstreamBaseUrl}${UPSTREAM_PATH}`;
+      url = `${auth.upstreamBaseUrl}${getUpstreamPath()}`;
       headers = auth.headers;
     } else {
       url = resolveGatewayUrl(ctx.requestUrl);

--- a/bin/seed-gateway-connector.ts
+++ b/bin/seed-gateway-connector.ts
@@ -147,6 +147,16 @@ async function seedConnector(
 
   if (connector) {
     console.log(`[seed-gw]   Connector exists: ${connector.id}`);
+    // Sync authConfig from template (fixes misconfigured connectors)
+    const templateAuthConfig = conn.authConfig || {};
+    const currentAuthConfig = (connector.authConfig as Record<string, unknown>) || {};
+    if (JSON.stringify(currentAuthConfig) !== JSON.stringify(templateAuthConfig)) {
+      await prisma.serviceConnector.update({
+        where: { id: connector.id },
+        data: { authConfig: templateAuthConfig },
+      });
+      console.log(`[seed-gw]   Updated authConfig for ${slug}`);
+    }
   } else {
     connector = await prisma.serviceConnector.create({
       data: {

--- a/plugins/service-gateway/connectors/livepeer-subgraph.json
+++ b/plugins/service-gateway/connectors/livepeer-subgraph.json
@@ -13,9 +13,9 @@
     "upstreamBaseUrl": "https://gateway.thegraph.com",
     "allowedHosts": ["gateway.thegraph.com", "gateway-arbitrum.network.thegraph.com"],
     "defaultTimeout": 15000,
-    "healthCheckPath": "/api/subgraphs/id/FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC",
+    "healthCheckPath": null,
     "authType": "bearer",
-    "authConfig": {},
+    "authConfig": { "tokenRef": "api-key" },
     "secretRefs": ["api-key"],
     "streamingEnabled": false,
     "tags": ["livepeer", "subgraph", "on-chain", "arbitrum", "the-graph", "registry"]


### PR DESCRIPTION
## Summary

Three bugs prevented the on-chain registry (Livepeer Subgraph) from working correctly in the leaderboard pipeline:

- **Bearer auth was never sent**: connector template had empty `authConfig`, so the bearer strategy defaulted to looking for a secret named `"token"` instead of `"api-key"`. The Graph Gateway never received auth → 0 results.
- **Subgraph ID was hardcoded**: the `SUBGRAPH_ID` env var was configured in Vercel but never read by the adapter. Now configurable with a fallback.
- **Empty membership = empty dataset**: if the subgraph (priority 1) returned 0 rows (auth failure), ALL orchestrators from other sources were dropped. The resolver now gracefully falls back to the next source with data.

Additionally, the seed script now syncs `authConfig` on existing connectors during each deploy, so the auth fix applies to already-seeded production databases.

## Test plan

- [x] All 61 test files pass (336+ assertions)
- [x] Pre-push hooks pass (275 SDK tests, Vercel safety)
- [ ] After deploy: verify subgraph returns active transcoders in refresh audit
- [ ] Verify resolver uses subgraph as membership when it has data, falls back when empty


Made with [Cursor](https://cursor.com)