### PR TITLE
fix: persist capabilities to DB so /filters works across serverless instances

### DIFF
--- a/apps/web-next/src/__tests__/api/orchestrator-leaderboard.test.ts
+++ b/apps/web-next/src/__tests__/api/orchestrator-leaderboard.test.ts
@@ -19,6 +19,10 @@ vi.mock('@/lib/orchestrator-leaderboard/global-dataset', () => ({
   getGlobalDataset: vi.fn().mockReturnValue(null),
 }));
 
+vi.mock('@/lib/orchestrator-leaderboard/config', () => ({
+  getKnownCapabilities: vi.fn().mockResolvedValue([]),
+}));
+
 import { authorize } from '@/lib/gateway/authorize';
 import { clearCache } from '@/lib/orchestrator-leaderboard/cache';
 

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
@@ -17,6 +17,7 @@ import { success } from '@/lib/api/response';
 import { getAuthToken } from '@/lib/api/response';
 import { resolveClickhouseGatewayQueryUrl } from '@/lib/orchestrator-leaderboard/query';
 import { getGlobalDataset } from '@/lib/orchestrator-leaderboard/global-dataset';
+import { getKnownCapabilities } from '@/lib/orchestrator-leaderboard/config';
 
 const FILTERS_SQL = `SELECT DISTINCT capability_name
 FROM semantic.network_capabilities
@@ -89,13 +90,17 @@ export async function GET(request: NextRequest): Promise<NextResponse | Response
     fromFallback = true;
   }
 
-  // Merge capabilities from the global dataset (includes all enabled sources)
+  // Merge capabilities from the global dataset (in-memory, same instance)
+  // or from the DB-persisted list (survives serverless cold starts)
   const globalDs = getGlobalDataset();
   const capSet = new Set(chCapabilities);
   if (globalDs) {
     for (const cap of Object.keys(globalDs.capabilities)) {
       if (cap !== '__uncategorized') capSet.add(cap);
     }
+  } else {
+    const persisted = await getKnownCapabilities();
+    for (const cap of persisted) capSet.add(cap);
   }
 
   const capabilities = Array.from(capSet).sort();

--- a/apps/web-next/src/lib/orchestrator-leaderboard/config.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/config.ts
@@ -79,16 +79,34 @@ export async function getRefreshIntervalMs(): Promise<number> {
 }
 
 /**
- * Record that a refresh just completed.
+ * Record that a refresh just completed, persisting the known capability list.
  */
-export async function markRefreshed(by: string): Promise<void> {
+export async function markRefreshed(by: string, capabilities?: string[]): Promise<void> {
+  const data: Record<string, unknown> = {
+    lastRefreshedAt: new Date(),
+    lastRefreshedBy: by,
+  };
+  if (capabilities) {
+    data.knownCapabilities = capabilities;
+  }
   await prisma.leaderboardConfig.upsert({
     where: { id: SINGLETON_ID },
-    update: { lastRefreshedAt: new Date(), lastRefreshedBy: by },
-    create: {
-      id: SINGLETON_ID,
-      lastRefreshedAt: new Date(),
-      lastRefreshedBy: by,
-    },
+    update: data,
+    create: { id: SINGLETON_ID, ...data },
   });
+}
+
+/**
+ * Read persisted capabilities from the DB (survives serverless cold starts).
+ */
+export async function getKnownCapabilities(): Promise<string[]> {
+  try {
+    const row = await prisma.leaderboardConfig.findUnique({
+      where: { id: SINGLETON_ID },
+      select: { knownCapabilities: true },
+    });
+    return row?.knownCapabilities ?? [];
+  } catch {
+    return [];
+  }
 }

--- a/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
@@ -153,7 +153,8 @@ export async function refreshGlobalDataset(
     intervalMs,
   );
 
-  await markRefreshed(refreshedBy);
+  const capabilityNames = Object.keys(capabilities).filter(k => k !== '__uncategorized').sort();
+  await markRefreshed(refreshedBy, capabilityNames);
 
   await writeAudit({
     ...audit,

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2275,6 +2275,7 @@ model LeaderboardConfig {
   refreshIntervalHours  Int       @default(1)
   lastRefreshedAt       DateTime?
   lastRefreshedBy       String?
+  knownCapabilities     String[]  @default([])
   updatedAt             DateTime  @updatedAt
 
   @@schema("plugin_orchestrator_leaderboard")


### PR DESCRIPTION
## Summary

After a dataset refresh reports 7 capabilities, the leaderboard UI only shows 4. Root cause: the global dataset is stored in module-level memory, which is **not shared across Vercel serverless instances**. The instance that runs the cron refresh has 7 capabilities in memory, but user requests hit different instances where `getGlobalDataset()` returns `null`.

**Fix:** Persist the full capability list to `LeaderboardConfig.knownCapabilities` in the database during each refresh. The `/filters` endpoint reads this persisted list as a fallback when the in-memory dataset is unavailable.

- Add `knownCapabilities String[]` field to `LeaderboardConfig` schema
- `markRefreshed()` now persists capability names alongside timestamp
- `/filters` reads from DB via `getKnownCapabilities()` when in-memory is empty

## Test plan

- [x] All 61 test files pass
- [x] Pre-push hooks pass (275 SDK tests)
- [ ] After deploy: trigger refresh, then verify `/filters` returns all 7 capabilities on any instance
- [ ] Verify UI shows all capabilities in the dropdown


Made with [Cursor](https://cursor.com)