### PR TITLE
fix: allow dots and colons in capability names

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/rank/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/rank/route.ts
@@ -49,9 +49,9 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
     );
   }
 
-  if (!/^[a-zA-Z0-9_-]+$/.test((body as LeaderboardRequest).capability)) {
+  if (!/^[a-zA-Z0-9._:-]+$/.test((body as LeaderboardRequest).capability)) {
     return NextResponse.json(
-      { success: false, error: { code: 'VALIDATION_ERROR', message: 'capability must contain only alphanumeric characters, hyphens, and underscores' } },
+      { success: false, error: { code: 'VALIDATION_ERROR', message: 'capability contains invalid characters' } },
       { status: 400 }
     );
   }

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/query.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/query.test.ts
@@ -12,6 +12,10 @@ describe('validateCapability', () => {
     expect(() => validateCapability('noop')).not.toThrow();
     expect(() => validateCapability('stream_diffusion_v2')).not.toThrow();
     expect(() => validateCapability('abc-123_XYZ')).not.toThrow();
+    expect(() => validateCapability('Qwen3.6-27B')).not.toThrow();
+    expect(() => validateCapability('gemma3:4b')).not.toThrow();
+    expect(() => validateCapability('qwen2.5-coder:32b')).not.toThrow();
+    expect(() => validateCapability('nomic-embed-text:latest')).not.toThrow();
   });
 
   it('rejects empty string', () => {
@@ -30,11 +34,12 @@ describe('validateCapability', () => {
     expect(() => validateCapability("a' OR 'x'='x")).toThrow();
   });
 
-  it('rejects special characters', () => {
+  it('rejects dangerous characters', () => {
     expect(() => validateCapability('foo bar')).toThrow();
-    expect(() => validateCapability('foo.bar')).toThrow();
     expect(() => validateCapability('foo/bar')).toThrow();
     expect(() => validateCapability('foo@bar')).toThrow();
+    expect(() => validateCapability("foo'bar")).toThrow();
+    expect(() => validateCapability('foo"bar')).toThrow();
   });
 
   it('rejects overly long names', () => {

--- a/apps/web-next/src/lib/orchestrator-leaderboard/query.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/query.ts
@@ -11,7 +11,7 @@ import { getCached, setCached } from './cache';
 
 const MAX_QUERY_ROWS = 1000;
 
-const CAPABILITY_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CAPABILITY_PATTERN = /^[a-zA-Z0-9._:-]+$/;
 
 const CLICKHOUSE_GW_PATH = '/api/v1/gw/clickhouse-query/query';
 
@@ -89,7 +89,7 @@ export function validateCapability(capability: string): void {
     throw new Error('capability is required and must be a string');
   }
   if (!CAPABILITY_PATTERN.test(capability)) {
-    throw new Error('capability must contain only alphanumeric characters, hyphens, and underscores');
+    throw new Error('capability contains invalid characters');
   }
   if (capability.length > 128) {
     throw new Error('capability must be 128 characters or fewer');


### PR DESCRIPTION
## Summary

Discovery capabilities use model naming conventions with dots and colons (e.g. `Qwen3.6-27B`, `gemma3:4b`, `qwen2.5-coder:32b`). The validation regex `[a-zA-Z0-9_-]` rejected these with a 400 error.

Expanded to `[a-zA-Z0-9._:-]` — still SQL-safe (values are inside single quotes in ClickHouse queries) while allowing standard model version notation.

## Test plan

- [x] Unit tests updated and pass (33 assertions)
- [ ] After deploy: selecting `Qwen3.6-27B` or `gemma3:4b` no longer returns 400


Made with [Cursor](https://cursor.com)