### PR TITLE
fix: filter out capabilities with 0 orchestrators

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/filters/route.ts
@@ -91,12 +91,13 @@ export async function GET(request: NextRequest): Promise<NextResponse | Response
   }
 
   // Merge capabilities from the global dataset (in-memory, same instance)
-  // or from the DB-persisted list (survives serverless cold starts)
+  // or from the DB-persisted list (survives serverless cold starts).
+  // Only include capabilities that have at least 1 orchestrator.
   const globalDs = getGlobalDataset();
   const capSet = new Set(chCapabilities);
   if (globalDs) {
-    for (const cap of Object.keys(globalDs.capabilities)) {
-      if (cap !== '__uncategorized') capSet.add(cap);
+    for (const [cap, rows] of Object.entries(globalDs.capabilities)) {
+      if (rows.length > 0) capSet.add(cap);
     }
   } else {
     const persisted = await getKnownCapabilities();

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/resolver.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/resolver.test.ts
@@ -163,14 +163,14 @@ describe('resolve — capability explosion', () => {
     expect(result.capabilities['text-to-image'][0].orch_uri).toBe('https://orch-c.test');
   });
 
-  it('assigns __uncategorized when orch has no capabilities', () => {
+  it('excludes orchestrators with no capabilities (no __uncategorized)', () => {
     const perSource: Partial<Record<SourceKind, NormalizedOrch[]>> = {
       'livepeer-subgraph': [mkSubgraphOrch('0xddd', 'https://orch-d.test')],
     };
 
     const result = resolve(perSource, mkConfig());
-    expect(result.capabilities['__uncategorized']).toBeDefined();
-    expect(result.capabilities['__uncategorized']).toHaveLength(1);
+    expect(result.capabilities['__uncategorized']).toBeUndefined();
+    expect(Object.keys(result.capabilities)).toHaveLength(0);
   });
 });
 

--- a/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
@@ -153,7 +153,7 @@ export async function refreshGlobalDataset(
     intervalMs,
   );
 
-  const capabilityNames = Object.keys(capabilities).filter(k => k !== '__uncategorized').sort();
+  const capabilityNames = Object.keys(capabilities).sort();
   await markRefreshed(refreshedBy, capabilityNames);
 
   await writeAudit({

--- a/apps/web-next/src/lib/orchestrator-leaderboard/resolver.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/resolver.ts
@@ -404,9 +404,11 @@ export function resolve(
     }
   }
 
-  // Remove __uncategorized if it's empty or if there are categorized capabilities
-  if (capabilities['__uncategorized']?.length === 0) {
-    delete capabilities['__uncategorized'];
+  // Remove capabilities with 0 orchestrators (invalid/stale) and __uncategorized
+  for (const cap of Object.keys(capabilities)) {
+    if (capabilities[cap].length === 0 || cap === '__uncategorized') {
+      delete capabilities[cap];
+    }
   }
 
   return {
@@ -414,7 +416,7 @@ export function resolve(
     audit: {
       membershipSource,
       totalOrchestrators,
-      totalCapabilities: Object.keys(capabilities).filter(k => k !== '__uncategorized').length,
+      totalCapabilities: Object.keys(capabilities).length,
       conflicts,
       dropped,
       warnings,


### PR DESCRIPTION
## Summary

Capabilities that have no orchestrators backing them are invalid/stale and should not appear in the UI filter dropdown. They only become valid when at least 1 orchestrator is returned for them.

- **Resolver**: removes capability entries with empty row arrays from the output
- **/filters**: only includes in-memory dataset caps that have `rows.length > 0`
- Removes `__uncategorized` bucket entirely — orchs without capabilities are excluded from the dataset

This ensures the leaderboard only shows capabilities where actual orchestrator data exists.

## Test plan

- [x] 12 test files pass (resolver test updated)
- [x] Pre-push hooks pass
- [ ] After deploy + refresh: verify only capabilities with active orchestrators appear


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined capability data filtering in the orchestrator leaderboard to exclude empty capability entries and uncategorized groupings, resulting in a more accurate and streamlined leaderboard display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/naap/pull/324)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->