### PR TITLE
feat(leaderboard): union membership strategy + improved data sources UI

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/dataset/config/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/dataset/config/route.ts
@@ -62,7 +62,12 @@ export async function PUT(request: NextRequest): Promise<NextResponse | Response
     if (membershipStrategy !== 'union' && membershipStrategy !== 'intersection') {
       return errors.badRequest('membershipStrategy must be "union" or "intersection"');
     }
-    await updateMembershipStrategy(membershipStrategy);
+    try {
+      await updateMembershipStrategy(membershipStrategy);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update membership strategy';
+      return errors.internal(message);
+    }
   }
 
   if (refreshIntervalHours !== undefined) {

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/dataset/config/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/dataset/config/route.ts
@@ -1,6 +1,6 @@
 /**
  * GET  /api/v1/orchestrator-leaderboard/dataset/config — read config (admin only)
- * PUT  /api/v1/orchestrator-leaderboard/dataset/config — update interval (admin only)
+ * PUT  /api/v1/orchestrator-leaderboard/dataset/config — update interval + strategy (admin only)
  */
 
 export const runtime = 'nodejs';
@@ -8,7 +8,13 @@ export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
 import { validateSession } from '@/lib/api/auth';
 import { success, errors, getAuthToken } from '@/lib/api/response';
-import { getConfig, updateConfig, isValidInterval } from '@/lib/orchestrator-leaderboard/config';
+import {
+  getConfig,
+  updateConfig,
+  isValidInterval,
+  getMembershipStrategy,
+  updateMembershipStrategy,
+} from '@/lib/orchestrator-leaderboard/config';
 
 export async function GET(request: NextRequest): Promise<NextResponse | Response> {
   const token = getAuthToken(request);
@@ -21,7 +27,8 @@ export async function GET(request: NextRequest): Promise<NextResponse | Response
 
   try {
     const config = await getConfig();
-    return success(config);
+    const membershipStrategy = await getMembershipStrategy();
+    return success({ ...config, membershipStrategy });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to read config';
     return errors.internal(message);
@@ -46,17 +53,33 @@ export async function PUT(request: NextRequest): Promise<NextResponse | Response
     return errors.badRequest('Invalid JSON body');
   }
 
-  const { refreshIntervalHours } = body as { refreshIntervalHours?: unknown };
+  const { refreshIntervalHours, membershipStrategy } = body as {
+    refreshIntervalHours?: unknown;
+    membershipStrategy?: unknown;
+  };
 
-  if (!isValidInterval(refreshIntervalHours)) {
-    return errors.badRequest('refreshIntervalHours must be one of: 1, 4, 8, 12');
+  if (membershipStrategy !== undefined) {
+    if (membershipStrategy !== 'union' && membershipStrategy !== 'intersection') {
+      return errors.badRequest('membershipStrategy must be "union" or "intersection"');
+    }
+    await updateMembershipStrategy(membershipStrategy);
   }
 
-  try {
-    const config = await updateConfig(refreshIntervalHours);
-    return success(config);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to update config';
-    return errors.internal(message);
+  if (refreshIntervalHours !== undefined) {
+    if (!isValidInterval(refreshIntervalHours)) {
+      return errors.badRequest('refreshIntervalHours must be one of: 1, 4, 8, 12');
+    }
+    try {
+      const config = await updateConfig(refreshIntervalHours);
+      const strategy = await getMembershipStrategy();
+      return success({ ...config, membershipStrategy: strategy });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update config';
+      return errors.internal(message);
+    }
   }
+
+  const config = await getConfig();
+  const strategy = await getMembershipStrategy();
+  return success({ ...config, membershipStrategy: strategy });
 }

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/sources/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/sources/route.ts
@@ -1,5 +1,5 @@
 /**
- * GET  /api/v1/orchestrator-leaderboard/sources — list all data sources
+ * GET  /api/v1/orchestrator-leaderboard/sources — list all data sources with connector details
  * PUT  /api/v1/orchestrator-leaderboard/sources — update source priority/enabled (admin only)
  */
 
@@ -16,9 +16,16 @@ import { z } from 'zod';
 const DEFAULT_SOURCES: { kind: SourceKind; priority: number; enabled: boolean }[] = [
   { kind: 'livepeer-subgraph', priority: 1, enabled: true },
   { kind: 'clickhouse-query', priority: 2, enabled: true },
-  { kind: 'naap-discover', priority: 3, enabled: false },
+  { kind: 'naap-discover', priority: 3, enabled: true },
   { kind: 'naap-pricing', priority: 4, enabled: false },
 ];
+
+const SOURCE_TO_CONNECTOR: Record<string, string> = {
+  'livepeer-subgraph': 'livepeer-subgraph',
+  'clickhouse-query': 'clickhouse-query',
+  'naap-discover': 'naap-discover',
+  'naap-pricing': 'naap-pricing',
+};
 
 async function ensureSeeded() {
   const count = await prisma.leaderboardSource.count();
@@ -58,15 +65,43 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       orderBy: { priority: 'asc' },
     });
 
+    // Fetch connector details for each source
+    const connectorSlugs = sources.map((s) => SOURCE_TO_CONNECTOR[s.kind]).filter(Boolean);
+    const connectors = await prisma.serviceConnector.findMany({
+      where: { slug: { in: connectorSlugs }, status: 'published' },
+      select: { slug: true, displayName: true, upstreamBaseUrl: true, status: true },
+    });
+    const connectorMap = new Map(connectors.map((c) => [c.slug, c]));
+
+    // Fetch latest audit for per-source stats
+    const lastAudit = await prisma.leaderboardRefreshAudit.findFirst({
+      orderBy: { refreshedAt: 'desc' },
+      select: { refreshedAt: true, durationMs: true, perSource: true },
+    });
+
+    const perSourceStats = (lastAudit?.perSource as Record<string, { ok?: boolean; fetched?: number; durationMs?: number; errorMessage?: string }>) ?? {};
+
     return NextResponse.json({
       success: true,
-      data: sources.map((s) => ({
-        kind: s.kind,
-        enabled: s.enabled,
-        priority: s.priority,
-        config: s.config,
-        updatedAt: s.updatedAt.toISOString(),
-      })),
+      data: sources.map((s) => {
+        const connSlug = SOURCE_TO_CONNECTOR[s.kind];
+        const conn = connSlug ? connectorMap.get(connSlug) : undefined;
+        const stats = perSourceStats[s.kind];
+        return {
+          kind: s.kind,
+          enabled: s.enabled,
+          priority: s.priority,
+          config: s.config,
+          updatedAt: s.updatedAt.toISOString(),
+          connector: conn
+            ? { slug: conn.slug, displayName: conn.displayName, upstreamBaseUrl: conn.upstreamBaseUrl, status: conn.status }
+            : connSlug ? { slug: connSlug, displayName: null, upstreamBaseUrl: null, status: 'not_configured' } : null,
+          lastFetch: stats
+            ? { ok: stats.ok ?? false, fetched: stats.fetched ?? 0, durationMs: stats.durationMs ?? 0, error: stats.errorMessage ?? null }
+            : null,
+        };
+      }),
+      lastRefreshedAt: lastAudit?.refreshedAt?.toISOString() ?? null,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to list sources';

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/resolver.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/resolver.test.ts
@@ -34,7 +34,7 @@ function mkClickhouseOrch(uri: string, cap: string): NormalizedOrch {
   };
 }
 
-describe('resolve — membership', () => {
+describe('resolve — membership (intersection mode)', () => {
   it('only includes orchs from the membership source', () => {
     const perSource: Partial<Record<SourceKind, NormalizedOrch[]>> = {
       'livepeer-subgraph': [mkSubgraphOrch('0xaaa', 'https://orch-a.test')],
@@ -44,7 +44,7 @@ describe('resolve — membership', () => {
       ],
     };
 
-    const result = resolve(perSource, mkConfig());
+    const result = resolve(perSource, mkConfig({ membershipStrategy: 'intersection' }));
     expect(result.audit.totalOrchestrators).toBe(1);
     expect(result.audit.dropped).toHaveLength(1);
     expect(result.audit.dropped[0].orchKey).toContain('orch-unknown');
@@ -63,20 +63,71 @@ describe('resolve — membership', () => {
     expect(result.audit.warnings).toContain('No sources enabled — returning empty dataset');
   });
 
-  it('uses second source as membership when first is disabled', () => {
+  it('uses second source as membership when first returns 0 rows', () => {
     const cfg = mkConfig({
+      membershipStrategy: 'intersection',
       sources: [
-        { kind: 'livepeer-subgraph', priority: 1, enabled: false },
+        { kind: 'livepeer-subgraph', priority: 1, enabled: true },
         { kind: 'clickhouse-query', priority: 2, enabled: true },
       ],
     });
     const perSource: Partial<Record<SourceKind, NormalizedOrch[]>> = {
+      'livepeer-subgraph': [],
       'clickhouse-query': [mkClickhouseOrch('https://orch-b.test', 'noop')],
     };
 
     const result = resolve(perSource, cfg);
     expect(result.audit.membershipSource).toBe('clickhouse-query');
     expect(result.audit.totalOrchestrators).toBe(1);
+  });
+});
+
+describe('resolve — membership (union mode)', () => {
+  it('includes orchs from ALL enabled sources', () => {
+    const perSource: Partial<Record<SourceKind, NormalizedOrch[]>> = {
+      'livepeer-subgraph': [mkSubgraphOrch('0xaaa', 'https://orch-a.test')],
+      'clickhouse-query': [
+        mkClickhouseOrch('https://orch-a.test', 'noop'),
+        mkClickhouseOrch('https://orch-unknown.test', 'noop'),
+      ],
+      'naap-discover': [
+        { orchUri: 'https://orch-discovery-only.test', capabilities: ['llm'], score: 0.8 },
+      ],
+    };
+
+    const result = resolve(perSource, mkConfig({ membershipStrategy: 'union' }));
+    expect(result.audit.membershipSource).toContain('union(');
+    expect(result.audit.totalOrchestrators).toBe(3);
+    expect(result.audit.dropped).toHaveLength(0);
+    expect(Object.keys(result.capabilities)).toContain('noop');
+    expect(Object.keys(result.capabilities)).toContain('llm');
+  });
+
+  it('union is the default strategy when not specified', () => {
+    const perSource: Partial<Record<SourceKind, NormalizedOrch[]>> = {
+      'livepeer-subgraph': [mkSubgraphOrch('0xaaa', 'https://orch-a.test')],
+      'clickhouse-query': [
+        mkClickhouseOrch('https://orch-a.test', 'noop'),
+        mkClickhouseOrch('https://orch-extra.test', 'noop'),
+      ],
+    };
+
+    const result = resolve(perSource, mkConfig());
+    expect(result.audit.membershipSource).toContain('union(');
+    expect(result.audit.totalOrchestrators).toBe(2);
+  });
+
+  it('cross-references eth/uri in union mode', () => {
+    const perSource: Partial<Record<SourceKind, NormalizedOrch[]>> = {
+      'livepeer-subgraph': [mkSubgraphOrch('0xfff', 'https://orch-f.test')],
+      'naap-discover': [
+        { orchUri: 'https://orch-f.test', capabilities: ['text-to-image'], score: 0.9 },
+      ],
+    };
+
+    const result = resolve(perSource, mkConfig({ membershipStrategy: 'union' }));
+    expect(result.audit.totalOrchestrators).toBe(1);
+    expect(Object.keys(result.capabilities)).toContain('text-to-image');
   });
 });
 

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/sources/integration.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/sources/integration.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Integration tests for source adapters.
+ *
+ * Unit tests: validate parsing with synthetic data.
+ * Live tests (skipped in CI): validate real network endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FetchCtx, NormalizedOrch } from '../../sources/types';
+
+const IS_CI = !!process.env.CI;
+
+const internalCtx: FetchCtx = { authToken: 'test-token', internal: true };
+
+// ---------------------------------------------------------------------------
+// naap-discover — unit
+// ---------------------------------------------------------------------------
+
+vi.mock('../../sources/internal-resolve', () => ({
+  resolveConnectorAuth: vi.fn().mockResolvedValue(null),
+}));
+
+describe('naap-discover adapter (unit)', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('parses response and normalizes capabilities', async () => {
+    const mockResponse = [
+      {
+        address: 'https://ai-worker.example.com:8935',
+        score: 0.95,
+        capabilities: ['live-video-to-video/streamdiffusion-sdxl', 'text-to-image/Qwen3.6-27B'],
+        last_seen_ms: 5000,
+        last_seen: '2026-05-10T00:00:00Z',
+        recent_work: true,
+      },
+      {
+        address: 'https://another-orch.test:7953',
+        score: 0.8,
+        capabilities: ['llm/Qwen3.6-27B'],
+        last_seen_ms: 10000,
+        last_seen: '2026-05-09T00:00:00Z',
+        recent_work: false,
+      },
+    ];
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { naapDiscoverAdapter } = await import('../../sources/naap-discover');
+    const result = await naapDiscoverAdapter.fetchAll(internalCtx);
+
+    expect(result.stats.ok).toBe(true);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].orchUri).toBe('https://ai-worker.example.com:8935');
+    expect(result.rows[0].capabilities).toContain('streamdiffusion-sdxl');
+    expect(result.rows[0].capabilities).toContain('Qwen3.6-27B');
+    expect(result.rows[0].score).toBe(0.95);
+    expect(result.rows[1].orchUri).toBe('https://another-orch.test:7953');
+  });
+
+  it('skips rows with undefined/empty capabilities', async () => {
+    const mockResponse = [
+      {
+        address: 'https://valid.test:8935',
+        score: 0.9,
+        capabilities: ['llm/test-model'],
+        last_seen_ms: 1000,
+        last_seen: '2026-05-10T00:00:00Z',
+        recent_work: true,
+      },
+      {
+        address: 'https://no-caps.test:8935',
+        score: 0.5,
+        capabilities: null,
+        last_seen_ms: 2000,
+        last_seen: '2026-05-09T00:00:00Z',
+        recent_work: false,
+      },
+      {
+        address: 'https://empty-caps.test:8935',
+        score: 0.4,
+        capabilities: [],
+        last_seen_ms: 3000,
+        last_seen: '2026-05-09T00:00:00Z',
+        recent_work: false,
+      },
+    ];
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const { naapDiscoverAdapter } = await import('../../sources/naap-discover');
+    const result = await naapDiscoverAdapter.fetchAll(internalCtx);
+
+    expect(result.stats.ok).toBe(true);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].orchUri).toBe('https://valid.test:8935');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// livepeer-subgraph — unit
+// ---------------------------------------------------------------------------
+
+describe('livepeer-subgraph adapter (unit)', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('parses GraphQL transcoder response', async () => {
+    const mockGraphQL = {
+      data: {
+        transcoders: [
+          { id: '0xabc123', activationRound: '100', deactivationRound: '0', serviceURI: 'https://orch-a.test:8935', active: true },
+          { id: '0xdef456', activationRound: '200', deactivationRound: '0', serviceURI: 'https://orch-b.test:8935', active: true },
+        ],
+      },
+    };
+
+    const { resolveConnectorAuth } = await import('../../sources/internal-resolve');
+    (resolveConnectorAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      upstreamBaseUrl: 'https://gateway.thegraph.com',
+      headers: { Authorization: 'Bearer test-key' },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockGraphQL),
+      text: () => Promise.resolve(JSON.stringify(mockGraphQL)),
+    });
+
+    const { subgraphAdapter } = await import('../../sources/subgraph');
+    const result = await subgraphAdapter.fetchAll(internalCtx);
+
+    expect(result.stats.ok).toBe(true);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].ethAddress).toBe('0xabc123');
+    expect(result.rows[0].orchUri).toBe('https://orch-a.test:8935');
+    expect(result.rows[0].activationRound).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolver integration — verifies union membership includes discovery orchs
+// ---------------------------------------------------------------------------
+
+describe('resolver with union membership (integration)', () => {
+  it('discovery-only orchestrators appear in final dataset', async () => {
+    // Simulates the production scenario where AI orchestrators appear in
+    // Discovery but NOT in the subgraph or ClickHouse.
+    const { resolve } = await import('../../resolver');
+
+    const perSource = {
+      'livepeer-subgraph': [
+        { ethAddress: '0xaaa', orchUri: 'https://staked-orch.test', activationRound: 1, deactivationRound: 0 },
+      ] as NormalizedOrch[],
+      'clickhouse-query': [
+        { orchUri: 'https://staked-orch.test', gpuName: 'A100', gpuGb: 80, avail: 5, totalCap: 8, pricePerUnit: 50, bestLatMs: 30, avgLatMs: 40, swapRatio: 0.01, avgAvail: 6, capabilities: ['noop'] },
+      ] as NormalizedOrch[],
+      'naap-discover': [
+        { orchUri: 'https://ai-only-worker.test:7953', capabilities: ['Qwen3.6-27B', 'streamdiffusion-sdxl'], score: 0.9 },
+        { orchUri: 'https://another-ai.test:8935', capabilities: ['llm-generate'], score: 0.85 },
+      ] as NormalizedOrch[],
+    };
+
+    const cfg = {
+      sources: [
+        { kind: 'livepeer-subgraph', priority: 1, enabled: true },
+        { kind: 'clickhouse-query', priority: 2, enabled: true },
+        { kind: 'naap-discover', priority: 3, enabled: true },
+      ],
+      membershipStrategy: 'union' as const,
+    };
+
+    const result = resolve(perSource, cfg);
+
+    // All 3 unique orchestrators should be in the dataset
+    expect(result.audit.totalOrchestrators).toBe(3);
+    expect(result.audit.membershipSource).toContain('union');
+    expect(result.audit.dropped).toHaveLength(0);
+
+    // Discovery capabilities should be present
+    expect(Object.keys(result.capabilities)).toContain('Qwen3.6-27B');
+    expect(Object.keys(result.capabilities)).toContain('streamdiffusion-sdxl');
+    expect(Object.keys(result.capabilities)).toContain('llm-generate');
+    expect(Object.keys(result.capabilities)).toContain('noop');
+
+    // Verify Discovery-only orchs have their data
+    const qwenRows = result.capabilities['Qwen3.6-27B'];
+    expect(qwenRows).toHaveLength(1);
+    expect(qwenRows[0].orch_uri).toBe('https://ai-only-worker.test:7953');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live integration tests (skipped in CI — run locally with `CI= npx vitest run ...`)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(IS_CI)('naap-discover adapter (live)', () => {
+  it('fetches real orchestrators from public Discovery API', async () => {
+    // Call the public endpoint directly (bypasses mocks)
+    const res = await globalThis.fetch('https://naap-api.cloudspe.com/v1/discover/orchestrators', {
+      signal: AbortSignal.timeout(15_000),
+    });
+    expect(res.ok).toBe(true);
+    const json = await res.json();
+    const rows = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : [];
+
+    console.log(`[naap-discover live] Rows: ${rows.length}`);
+    if (rows.length > 0) {
+      console.log(`  Sample: ${rows[0].address} -> caps: ${rows[0].capabilities?.join(', ')}`);
+    }
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].address).toBeTruthy();
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/config.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/config.ts
@@ -110,3 +110,32 @@ export async function getKnownCapabilities(): Promise<string[]> {
     return [];
   }
 }
+
+/**
+ * Read the membership strategy from the DB. Defaults to "union".
+ */
+export async function getMembershipStrategy(): Promise<'union' | 'intersection'> {
+  try {
+    const row = await prisma.leaderboardConfig.findUnique({
+      where: { id: SINGLETON_ID },
+      select: { membershipStrategy: true },
+    });
+    const val = row?.membershipStrategy;
+    return val === 'intersection' ? 'intersection' : 'union';
+  } catch {
+    return 'union';
+  }
+}
+
+/**
+ * Update the membership strategy.
+ */
+export async function updateMembershipStrategy(
+  strategy: 'union' | 'intersection',
+): Promise<void> {
+  await prisma.leaderboardConfig.upsert({
+    where: { id: SINGLETON_ID },
+    update: { membershipStrategy: strategy },
+    create: { id: SINGLETON_ID, membershipStrategy: strategy },
+  });
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
@@ -18,7 +18,7 @@ import type { SourceKind, NormalizedOrch, SourceStats } from './sources/types';
 import { getAdapter } from './sources';
 import { resolve, type ResolverConfig, type AuditEntry } from './resolver';
 import { setGlobalDataset } from './global-dataset';
-import { getRefreshIntervalMs, markRefreshed } from './config';
+import { getRefreshIntervalMs, markRefreshed, getMembershipStrategy } from './config';
 import { clearPlanCache } from './refresh';
 
 // ---------------------------------------------------------------------------
@@ -112,6 +112,7 @@ export async function refreshGlobalDataset(
 }> {
   const t0 = Date.now();
   const cfg = await loadResolverConfig();
+  cfg.membershipStrategy = await getMembershipStrategy();
   const enabled = cfg.sources.filter((s) => s.enabled).sort((a, b) => a.priority - b.priority);
   const ctx = { authToken, requestUrl, cookieHeader, internal: options?.internal };
 

--- a/apps/web-next/src/lib/orchestrator-leaderboard/resolver.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/resolver.ts
@@ -24,6 +24,7 @@ import type { SourceKind, NormalizedOrch } from './sources/types';
 export interface ResolverConfig {
   sources: { kind: SourceKind; priority: number; enabled: boolean }[];
   fieldPriority?: Partial<Record<string, SourceKind[]>>;
+  membershipStrategy?: 'union' | 'intersection';
 }
 
 export interface ConflictEntry {
@@ -40,7 +41,7 @@ export interface DroppedEntry {
 }
 
 export interface AuditEntry {
-  membershipSource: SourceKind;
+  membershipSource: string;
   totalOrchestrators: number;
   totalCapabilities: number;
   conflicts: ConflictEntry[];
@@ -160,29 +161,45 @@ export function resolve(
     sourceIndexes.set(s.kind, indexByOrch(rows));
   }
 
-  // Membership set = keys from the highest-priority source that returned data.
-  // Falls back to the next source if higher-priority ones returned 0 rows
-  // (e.g. subgraph auth failure should not wipe out the entire dataset).
-  let membershipSource = enabled[0].kind;
-  let membershipIndex = sourceIndexes.get(membershipSource)!;
-  if (membershipIndex.size === 0 && enabled.length > 1) {
-    for (const s of enabled.slice(1)) {
+  // Membership set determines which orchestrators make it into the final dataset.
+  const strategy = cfg.membershipStrategy ?? 'union';
+  let membershipSource: string;
+  const membershipKeys = new Set<OrchKey>();
+
+  if (strategy === 'union') {
+    // Union: any orch from any enabled source is included
+    for (const s of enabled) {
       const idx = sourceIndexes.get(s.kind)!;
-      if (idx.size > 0) {
-        membershipSource = s.kind;
-        membershipIndex = idx;
-        warnings.push(
-          `Primary membership source "${enabled[0].kind}" returned 0 rows — ` +
-          `falling back to "${s.kind}" (${idx.size} orchestrators)`,
-        );
-        break;
-      }
+      for (const key of idx.keys()) membershipKeys.add(key);
     }
-    if (membershipIndex.size === 0) {
+    membershipSource = `union(${enabled.map((s) => s.kind).join(',')})`;
+    if (membershipKeys.size === 0) {
       warnings.push('All sources returned 0 rows — empty dataset');
     }
+  } else {
+    // Intersection (legacy): keys from the highest-priority source that returned data.
+    // Falls back to the next source if higher-priority ones returned 0 rows.
+    membershipSource = enabled[0].kind;
+    let membershipIndex = sourceIndexes.get(enabled[0].kind)!;
+    if (membershipIndex.size === 0 && enabled.length > 1) {
+      for (const s of enabled.slice(1)) {
+        const idx = sourceIndexes.get(s.kind)!;
+        if (idx.size > 0) {
+          membershipSource = s.kind;
+          membershipIndex = idx;
+          warnings.push(
+            `Primary membership source "${enabled[0].kind}" returned 0 rows — ` +
+            `falling back to "${s.kind}" (${idx.size} orchestrators)`,
+          );
+          break;
+        }
+      }
+      if (membershipIndex.size === 0) {
+        warnings.push('All sources returned 0 rows — empty dataset');
+      }
+    }
+    for (const key of membershipIndex.keys()) membershipKeys.add(key);
   }
-  const membershipKeys = new Set(membershipIndex.keys());
 
   // Also build a cross-reference: orchUri <-> ethAddress for join
   const uriToEth = new Map<string, string>();
@@ -193,6 +210,22 @@ export function resolve(
         if (r.ethAddress && r.orchUri) {
           uriToEth.set(r.orchUri, r.ethAddress.toLowerCase());
           ethToUri.set(r.ethAddress.toLowerCase(), r.orchUri);
+        }
+      }
+    }
+  }
+
+  // Deduplicate membership keys: collapse eth:X and uri:Y referring to the
+  // same orchestrator into a single canonical key (prefer eth: if available).
+  for (const key of [...membershipKeys]) {
+    const normalized = normalizeKey(key);
+    if (normalized.startsWith('uri:')) {
+      const uri = normalized.slice(4);
+      const eth = uriToEth.get(uri);
+      if (eth) {
+        const ethKey: OrchKey = `eth:${eth}`;
+        if (membershipKeys.has(ethKey)) {
+          membershipKeys.delete(key);
         }
       }
     }
@@ -221,17 +254,19 @@ export function resolve(
     return null;
   }
 
-  // Record dropped from non-membership sources
-  for (const s of enabled) {
-    if (s.kind === membershipSource) continue;
-    const srcIndex = sourceIndexes.get(s.kind)!;
-    for (const key of srcIndex.keys()) {
-      if (!resolveOrchKey(key)) {
-        dropped.push({
-          orchKey: key,
-          source: s.kind,
-          reason: `not present in membership source (${membershipSource})`,
-        });
+  // Record dropped from non-membership sources (only relevant in intersection mode)
+  if (strategy !== 'union') {
+    for (const s of enabled) {
+      if (s.kind === membershipSource) continue;
+      const srcIndex = sourceIndexes.get(s.kind)!;
+      for (const key of srcIndex.keys()) {
+        if (!resolveOrchKey(key)) {
+          dropped.push({
+            orchKey: key,
+            source: s.kind,
+            reason: `not present in membership source (${membershipSource})`,
+          });
+        }
       }
     }
   }

--- a/apps/web-next/src/lib/orchestrator-leaderboard/sources/naap-discover.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/sources/naap-discover.ts
@@ -94,7 +94,9 @@ export const naapDiscoverAdapter: SourceAdapter = {
     const rows: NormalizedOrch[] = [];
 
     for (const r of rawRows) {
-      const shortCaps = r.capabilities.map(extractCapabilityName);
+      const rawCaps = Array.isArray(r.capabilities) ? r.capabilities : [];
+      if (rawCaps.length === 0) continue;
+      const shortCaps = rawCaps.map(extractCapabilityName);
       rows.push({
         orchUri: r.address,
         capabilities: shortCaps,

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2273,6 +2273,7 @@ model DiscoveryPlan {
 model LeaderboardConfig {
   id                    String    @id @default("singleton")
   refreshIntervalHours  Int       @default(1)
+  membershipStrategy    String    @default("union")
   lastRefreshedAt       DateTime?
   lastRefreshedBy       String?
   knownCapabilities     String[]  @default([])

--- a/plugins/orchestrator-leaderboard/frontend/src/components/AdminSettings.tsx
+++ b/plugins/orchestrator-leaderboard/frontend/src/components/AdminSettings.tsx
@@ -144,6 +144,7 @@ const DataSourcesPanel: React.FC = () => {
   };
 
   const handleStrategyChange = async (newStrategy: 'union' | 'intersection') => {
+    const prev = strategy;
     setStrategy(newStrategy);
     setStrategySaving(true);
     try {
@@ -151,7 +152,7 @@ const DataSourcesPanel: React.FC = () => {
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to update strategy');
-      setStrategy(strategy === 'union' ? 'intersection' : 'union');
+      setStrategy(prev);
     } finally {
       setStrategySaving(false);
     }

--- a/plugins/orchestrator-leaderboard/frontend/src/components/AdminSettings.tsx
+++ b/plugins/orchestrator-leaderboard/frontend/src/components/AdminSettings.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Settings, RefreshCw, Clock, Database, Layers, FileText, GripVertical, ChevronDown, ChevronRight } from 'lucide-react';
+import { Settings, RefreshCw, Clock, Database, Layers, FileText, GripVertical, ChevronDown, ChevronRight, ExternalLink, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
 import { useAuthService } from '@naap/plugin-sdk';
 import { useDatasetConfig } from '../hooks/useDatasetConfig';
 import {
   fetchSources,
   updateSources,
+  updateMembershipStrategy,
   fetchAudits,
   type LeaderboardSourceDTO,
   type RefreshAuditDTO,
@@ -54,12 +55,28 @@ type AdminTab = 'config' | 'sources' | 'audits';
 // Data Sources Panel
 // ---------------------------------------------------------------------------
 
+const ConnectorStatusIcon: React.FC<{ status: string }> = ({ status }) => {
+  if (status === 'published') return <CheckCircle size={10} style={{ color: 'var(--accent-emerald)' }} />;
+  if (status === 'not_configured') return <XCircle size={10} style={{ color: 'var(--accent-rose)' }} />;
+  return <AlertCircle size={10} style={{ color: 'var(--accent-amber)' }} />;
+};
+
 const DataSourcesPanel: React.FC = () => {
   const [sources, setSources] = useState<LeaderboardSourceDTO[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [strategy, setStrategy] = useState<'union' | 'intersection'>('union');
+  const [strategySaving, setStrategySaving] = useState(false);
+
+  const { config } = useDatasetConfig();
+
+  useEffect(() => {
+    if (config?.membershipStrategy) {
+      setStrategy(config.membershipStrategy);
+    }
+  }, [config?.membershipStrategy]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -126,68 +143,151 @@ const DataSourcesPanel: React.FC = () => {
     }
   };
 
+  const handleStrategyChange = async (newStrategy: 'union' | 'intersection') => {
+    setStrategy(newStrategy);
+    setStrategySaving(true);
+    try {
+      await updateMembershipStrategy(newStrategy);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update strategy');
+      setStrategy(strategy === 'union' ? 'intersection' : 'union');
+    } finally {
+      setStrategySaving(false);
+    }
+  };
+
   if (loading) {
     return <p className="text-sm" style={{ color: 'var(--text-muted)' }}>Loading sources…</p>;
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       {error && (
         <p className="text-xs" style={{ color: 'var(--accent-rose)' }}>{error}</p>
       )}
-      <p className="text-xs" style={{ color: 'var(--text-supporting)' }}>
-        Drag to reorder priority (top = highest). Tier-1 source owns orchestrator membership.
-        {saving && <span className="ml-2 italic">Saving…</span>}
-      </p>
-      <div className="space-y-1">
-        {sources.map((src, idx) => {
-          const meta = SOURCE_LABELS[src.kind] ?? { label: src.kind, description: '' };
-          return (
-            <div
-              key={src.kind}
-              draggable
-              onDragStart={() => handleDragStart(idx)}
-              onDragOver={(e) => handleDragOver(e, idx)}
-              onDragEnd={handleDragEnd}
-              className="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors"
-              style={{
-                background: dragIdx === idx ? 'var(--bg-tertiary)' : 'var(--bg-secondary)',
-                border: '1px solid var(--border-color)',
-                opacity: src.enabled ? 1 : 0.5,
-                cursor: 'grab',
-              }}
-            >
-              <GripVertical size={14} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
-              <span
-                className="text-xs font-bold w-5 text-center"
-                style={{ color: 'var(--text-supporting)' }}
-              >
-                {src.priority}
-              </span>
-              <div className="flex-1 min-w-0">
-                <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                  {meta.label}
-                </p>
-                <p className="text-[10px] truncate" style={{ color: 'var(--text-muted)' }}>
-                  {meta.description}
-                </p>
-              </div>
-              <button
-                onClick={(e) => { e.stopPropagation(); handleToggle(src.kind); }}
-                className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors flex-shrink-0"
+
+      {/* Membership Strategy Toggle */}
+      <div className="rounded-lg p-3" style={{ background: 'var(--bg-tertiary)', border: '1px solid var(--border-color)' }}>
+        <p className="text-xs font-medium mb-2" style={{ color: 'var(--text-secondary)' }}>
+          Membership Strategy
+          {strategySaving && <span className="ml-2 italic" style={{ color: 'var(--text-muted)' }}>Saving…</span>}
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleStrategyChange('union')}
+            className="px-3 py-1.5 text-xs font-medium rounded-full border transition-all"
+            style={
+              strategy === 'union'
+                ? { background: 'rgba(30, 153, 96, 0.15)', color: 'var(--accent-emerald)', borderColor: 'rgba(30, 153, 96, 0.3)' }
+                : { background: 'var(--bg-secondary)', color: 'var(--text-secondary)', borderColor: 'var(--border-color)' }
+            }
+          >
+            Union (all sources)
+          </button>
+          <button
+            onClick={() => handleStrategyChange('intersection')}
+            className="px-3 py-1.5 text-xs font-medium rounded-full border transition-all"
+            style={
+              strategy === 'intersection'
+                ? { background: 'rgba(30, 153, 96, 0.15)', color: 'var(--accent-emerald)', borderColor: 'rgba(30, 153, 96, 0.3)' }
+                : { background: 'var(--bg-secondary)', color: 'var(--text-secondary)', borderColor: 'var(--border-color)' }
+            }
+          >
+            Intersection (primary only)
+          </button>
+        </div>
+        <p className="text-[10px] mt-1.5" style={{ color: 'var(--text-muted)' }}>
+          {strategy === 'union'
+            ? 'Includes orchestrators from any enabled source. Recommended for AI workloads.'
+            : 'Only includes orchestrators from the highest-priority source. Legacy mode for on-chain-only.'}
+        </p>
+      </div>
+
+      {/* Sources list */}
+      <div>
+        <p className="text-xs mb-2" style={{ color: 'var(--text-supporting)' }}>
+          Drag to reorder priority. {strategy === 'intersection' && 'Top source owns orchestrator membership.'}
+          {saving && <span className="ml-2 italic">Saving…</span>}
+        </p>
+        <div className="space-y-2">
+          {sources.map((src, idx) => {
+            const meta = SOURCE_LABELS[src.kind] ?? { label: src.kind, description: '' };
+            return (
+              <div
+                key={src.kind}
+                draggable
+                onDragStart={() => handleDragStart(idx)}
+                onDragOver={(e) => handleDragOver(e, idx)}
+                onDragEnd={handleDragEnd}
+                className="rounded-lg transition-colors"
                 style={{
-                  background: src.enabled ? 'var(--accent-emerald)' : 'var(--bg-tertiary)',
+                  background: dragIdx === idx ? 'var(--bg-tertiary)' : 'var(--bg-secondary)',
                   border: '1px solid var(--border-color)',
+                  opacity: src.enabled ? 1 : 0.5,
+                  cursor: 'grab',
                 }}
               >
-                <span
-                  className="inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform"
-                  style={{ transform: src.enabled ? 'translateX(16px)' : 'translateX(2px)' }}
-                />
-              </button>
-            </div>
-          );
-        })}
+                <div className="flex items-center gap-3 px-3 py-2">
+                  <GripVertical size={14} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+                  <span
+                    className="text-xs font-bold w-5 text-center"
+                    style={{ color: 'var(--text-supporting)' }}
+                  >
+                    {src.priority}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                      {meta.label}
+                    </p>
+                    <p className="text-[10px] truncate" style={{ color: 'var(--text-muted)' }}>
+                      {meta.description}
+                    </p>
+                  </div>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleToggle(src.kind); }}
+                    className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors flex-shrink-0"
+                    style={{
+                      background: src.enabled ? 'var(--accent-emerald)' : 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-color)',
+                    }}
+                  >
+                    <span
+                      className="inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform"
+                      style={{ transform: src.enabled ? 'translateX(16px)' : 'translateX(2px)' }}
+                    />
+                  </button>
+                </div>
+
+                {/* Connector details row */}
+                <div className="px-3 pb-2 flex items-center gap-3 flex-wrap" style={{ marginLeft: '2rem' }}>
+                  {src.connector && (
+                    <span className="flex items-center gap-1 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                      <ConnectorStatusIcon status={src.connector.status} />
+                      <span>{src.connector.displayName || src.connector.slug}</span>
+                      {src.connector.upstreamBaseUrl && (
+                        <span className="flex items-center gap-0.5">
+                          <ExternalLink size={8} />
+                          <span className="truncate max-w-[180px]">{src.connector.upstreamBaseUrl}</span>
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  {src.lastFetch && (
+                    <span className="text-[10px]" style={{ color: src.lastFetch.ok ? 'var(--text-supporting)' : 'var(--accent-rose)' }}>
+                      {src.lastFetch.ok
+                        ? `${src.lastFetch.fetched} rows in ${formatDuration(src.lastFetch.durationMs)}`
+                        : `Error: ${src.lastFetch.error || 'unknown'}`}
+                    </span>
+                  )}
+                  {!src.connector && (
+                    <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>No connector configured</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/plugins/orchestrator-leaderboard/frontend/src/lib/api.ts
+++ b/plugins/orchestrator-leaderboard/frontend/src/lib/api.ts
@@ -243,6 +243,7 @@ export interface DatasetConfig {
   lastRefreshedAt: string | null;
   lastRefreshedBy: string | null;
   updatedAt: string;
+  membershipStrategy?: 'union' | 'intersection';
 }
 
 export async function fetchDatasetConfig(): Promise<DatasetConfig> {
@@ -316,12 +317,28 @@ export async function triggerDatasetRefresh(): Promise<{
 // Data Sources (admin)
 // ---------------------------------------------------------------------------
 
+export interface ConnectorInfo {
+  slug: string;
+  displayName: string | null;
+  upstreamBaseUrl: string | null;
+  status: string;
+}
+
+export interface LastFetchStats {
+  ok: boolean;
+  fetched: number;
+  durationMs: number;
+  error: string | null;
+}
+
 export interface LeaderboardSourceDTO {
   kind: string;
   enabled: boolean;
   priority: number;
   config: Record<string, unknown> | null;
   updatedAt: string;
+  connector: ConnectorInfo | null;
+  lastFetch: LastFetchStats | null;
 }
 
 export async function fetchSources(): Promise<LeaderboardSourceDTO[]> {
@@ -340,6 +357,23 @@ export async function fetchSources(): Promise<LeaderboardSourceDTO[]> {
   if (!json.success) throw new Error(json.error?.message || 'Request failed');
 
   return json.data;
+}
+
+export async function updateMembershipStrategy(
+  strategy: 'union' | 'intersection',
+): Promise<void> {
+  const res = await fetch(`${BASE_URL}/dataset/config`, {
+    method: 'PUT',
+    headers: buildHeaders(true),
+    body: JSON.stringify({ membershipStrategy: strategy }),
+    credentials: 'include',
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    throw new Error(json?.error?.message || `Request failed (${res.status})`);
+  }
 }
 
 export async function updateSources(


### PR DESCRIPTION
## Summary

- **Fix Discovery orchestrators being dropped**: Adds a "union" membership strategy (new default) that includes orchestrators from ALL enabled data sources. Previously, only orchestrators known to the highest-priority source (Livepeer Subgraph) made it into the leaderboard, silently dropping AI-only orchestrators that aren't bonded on-chain.
- **Improve Data Sources admin panel**: Shows connector details (slug, upstream URL, status), last fetch statistics (rows, duration, errors), and a membership strategy toggle (union vs. intersection).
- **Enhance APIs**: `/sources` GET returns connector info + last audit stats. `/dataset/config` GET/PUT supports `membershipStrategy` field.
- **Fix naap-discover null capabilities**: Adapter now safely skips orchestrators with null/empty capabilities.
- **Sync DEFAULT_SOURCES**: `naap-discover` now correctly marked as `enabled: true` in the sources API route.

## Key files changed

| File | Change |
|------|--------|
| `schema.prisma` | Add `membershipStrategy` field to `LeaderboardConfig` |
| `resolver.ts` | Union/intersection membership logic with key deduplication |
| `config.ts` | `getMembershipStrategy()` / `updateMembershipStrategy()` |
| `global-refresh.ts` | Pass strategy to resolver |
| `sources/route.ts` | Enriched GET response with connector details |
| `dataset/config/route.ts` | Support `membershipStrategy` in GET/PUT |
| `AdminSettings.tsx` | Enhanced DataSourcesPanel UI |
| `api.ts` (frontend) | New types + `updateMembershipStrategy()` |
| `naap-discover.ts` | Skip orchs with null/empty capabilities |
| `integration.test.ts` | New adapter + resolver integration tests |

## Test plan

- [x] All 124 leaderboard tests pass (resolver, query, filters, ranking, plans)
- [x] New integration tests validate adapter parsing and union resolver behavior
- [x] TypeScript compiles with no new errors
- [x] Pre-push hooks pass (SDK tests + Vercel safety checks)
- [ ] Verify Vercel preview deploys and leaderboard loads with Discovery orchestrators visible
- [ ] Verify admin can toggle membership strategy in Data Sources panel
- [ ] After merge, trigger a dataset refresh to confirm union mode populates all orchestrators


Made with [Cursor](https://cursor.com)