### PR TITLE
fix(auth): harden email verification pipeline so silent failures fail loud

### DIFF
--- a/apps/web-next/.env.local.example
+++ b/apps/web-next/.env.local.example
@@ -93,9 +93,16 @@ AUTH_PASSWORD=changeme-local-dev
 
 # ─── Email (Resend) — verification & password reset ───────────────────
 # Get API key from https://resend.com/api-keys
-# Without this, verification/reset links are logged to console (dev only)
+# Without this, verification/reset links are logged to console (dev only).
+#
+# Required in production. /api/health returns 503 in a production-like
+# environment (VERCEL_ENV=production or DEPLOY_ENV=production) when this
+# is missing or when EMAIL_FROM still uses the resend.dev sandbox domain
+# (sandbox can only deliver to the Resend account owner's email address).
 # RESEND_API_KEY=
-# Optional: override sender (default: NaaP Platform <onboarding@resend.dev>)
+#
+# Required in production: must be an address on a domain verified in Resend
+# (https://resend.com/domains). Default `onboarding@resend.dev` is sandbox.
 # EMAIL_FROM=NaaP <noreply@yourdomain.com>
 
 # ─── Realtime (optional -- SSE works without Ably) ─────────────────────

--- a/apps/web-next/src/app/api/health/route.ts
+++ b/apps/web-next/src/app/api/health/route.ts
@@ -1,15 +1,32 @@
 /**
  * GET /api/health
- * Database connectivity health check.
+ *
+ * Database + email configuration health check. Returns 503 when any
+ * production-critical dependency is broken, so platform monitors and
+ * deploy gates fail closed instead of silently degrading.
  */
 
 import { NextResponse } from 'next/server';
+import { validateEmailConfig } from '@/lib/email';
 
 export const dynamic = 'force-dynamic'; // never cache
 
-export async function GET() {
-  let dbStatus: { connected: boolean; latencyMs?: number; error?: string };
+interface DbStatus {
+  connected: boolean;
+  latencyMs?: number;
+  error?: string;
+}
 
+interface EmailStatus {
+  configured: boolean;
+  warnings: string[];
+  /** When true, an unconfigured/sandbox state should be treated as unhealthy. */
+  criticalInThisEnv: boolean;
+}
+
+export async function GET() {
+  // ── DB check ──────────────────────────────────────────────────────────────
+  let dbStatus: DbStatus;
   try {
     const { prisma } = await import('@naap/database');
     const start = Date.now();
@@ -24,9 +41,27 @@ export async function GET() {
     };
   }
 
-  return NextResponse.json({
-    status: dbStatus.connected ? 'healthy' : 'unhealthy',
-    timestamp: new Date().toISOString(),
-    database: dbStatus,
-  }, { status: dbStatus.connected ? 200 : 503 });
+  // ── Email config check ────────────────────────────────────────────────────
+  // Production: missing key or sandbox sender means new signups never receive
+  // verification mail. We surface this as 503 so the broken state is loud.
+  const isProductionLike =
+    process.env.VERCEL_ENV === 'production' || process.env.DEPLOY_ENV === 'production';
+  const emailValidation = validateEmailConfig();
+  const emailStatus: EmailStatus = {
+    configured: emailValidation.configured,
+    warnings: emailValidation.warnings,
+    criticalInThisEnv: isProductionLike && !emailValidation.configured,
+  };
+
+  const allHealthy = dbStatus.connected && !emailStatus.criticalInThisEnv;
+
+  return NextResponse.json(
+    {
+      status: allHealthy ? 'healthy' : 'unhealthy',
+      timestamp: new Date().toISOString(),
+      database: dbStatus,
+      email: emailStatus,
+    },
+    { status: allHealthy ? 200 : 503 }
+  );
 }

--- a/apps/web-next/src/lib/__tests__/email.test.ts
+++ b/apps/web-next/src/lib/__tests__/email.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for src/lib/email.ts — config validation paths.
+ *
+ * Note: the runtime senders themselves are exercised by Playwright smoke
+ * tests against a deployed environment.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('validateEmailConfig', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('returns configured=false and warning when RESEND_API_KEY missing', async () => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.EMAIL_FROM;
+    const mod = await import('@/lib/email');
+    const result = mod.validateEmailConfig();
+    expect(result.configured).toBe(false);
+    expect(result.warnings.some((w) => w.includes('RESEND_API_KEY'))).toBe(true);
+  });
+
+  it('returns configured=false when EMAIL_FROM still uses sandbox domain', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.EMAIL_FROM = 'NaaP <onboarding@resend.dev>';
+    const mod = await import('@/lib/email');
+    const result = mod.validateEmailConfig();
+    expect(result.configured).toBe(false);
+    expect(result.warnings.some((w) => w.includes('sandbox'))).toBe(true);
+  });
+
+  it('returns configured=true with no warnings when fully set up', async () => {
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.EMAIL_FROM = 'NaaP <noreply@operator.livepeer.org>';
+    const mod = await import('@/lib/email');
+    const result = mod.validateEmailConfig();
+    expect(result.configured).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('is pure: calling it does not log to console', async () => {
+    process.env.RESEND_API_KEY = '';
+    process.env.EMAIL_FROM = 'NaaP <onboarding@resend.dev>';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mod = await import('@/lib/email');
+    errorSpy.mockClear();
+    warnSpy.mockClear();
+    mod.validateEmailConfig();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/web-next/src/lib/__tests__/monitoring.test.ts
+++ b/apps/web-next/src/lib/__tests__/monitoring.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for src/lib/monitoring.ts — structured error reporter.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reportError, __resetMonitoringForTests } from '@/lib/monitoring';
+
+describe('reportError', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetMonitoringForTests();
+    delete process.env.SENTRY_DSN;
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('emits a structured [ALERT] log line with required fields', () => {
+    reportError(new Error('boom'), {
+      area: 'auth.email.verification',
+      tags: { kind: 'send_failure' },
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const arg = consoleErrorSpy.mock.calls[0][0] as string;
+    expect(arg.startsWith('[ALERT] ')).toBe(true);
+
+    const payload = JSON.parse(arg.slice('[ALERT] '.length));
+    expect(payload).toMatchObject({
+      level: 'error',
+      area: 'auth.email.verification',
+      name: 'Error',
+      message: 'boom',
+      tags: { kind: 'send_failure' },
+    });
+    expect(typeof payload.timestamp).toBe('string');
+  });
+
+  it('strips newlines and control characters from message (log-injection guard)', () => {
+    reportError(new Error('line1\nline2\rline3\x1b[31m'), {
+      area: 'auth.email.verification',
+    });
+    const arg = consoleErrorSpy.mock.calls[0][0] as string;
+    const payload = JSON.parse(arg.slice('[ALERT] '.length));
+    expect(payload.message).not.toContain('\n');
+    expect(payload.message).not.toContain('\r');
+    expect(payload.message).not.toMatch(/\x1b/);
+  });
+
+  it('accepts non-Error values (string, object) without throwing', () => {
+    expect(() =>
+      reportError('plain-string', { area: 'a' }),
+    ).not.toThrow();
+    expect(() =>
+      reportError({ weird: true } as unknown, { area: 'a' }),
+    ).not.toThrow();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throw when Sentry is not installed and SENTRY_DSN is set', async () => {
+    process.env.SENTRY_DSN = 'https://example.invalid/123';
+    __resetMonitoringForTests();
+    expect(() =>
+      reportError(new Error('x'), { area: 'auth.email.verification' }),
+    ).not.toThrow();
+    // Flush microtasks so the dynamic-import path resolves.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web-next/src/lib/__tests__/monitoring.test.ts
+++ b/apps/web-next/src/lib/__tests__/monitoring.test.ts
@@ -7,15 +7,23 @@ import { reportError, __resetMonitoringForTests } from '@/lib/monitoring';
 
 describe('reportError', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let originalSentryDsn: string | undefined;
 
   beforeEach(() => {
     __resetMonitoringForTests();
+    originalSentryDsn = process.env.SENTRY_DSN;
     delete process.env.SENTRY_DSN;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    if (originalSentryDsn === undefined) {
+      delete process.env.SENTRY_DSN;
+    } else {
+      process.env.SENTRY_DSN = originalSentryDsn;
+    }
     consoleErrorSpy.mockRestore();
+    __resetMonitoringForTests();
   });
 
   it('emits a structured [ALERT] log line with required fields', () => {

--- a/apps/web-next/src/lib/api/auth.ts
+++ b/apps/web-next/src/lib/api/auth.ts
@@ -12,9 +12,10 @@ import {
   sendVerificationEmail as sendEmailVerification,
   sendPasswordResetEmail as sendEmailPasswordReset,
 } from '../email';
+import { tryAcquireCooldown } from '../auth/resend-cooldown';
+import { reportError } from '../monitoring';
 
 const RESEND_COOLDOWN_MS = 15 * 60 * 1000; // 15 minutes
-const resendCooldownMap = new Map<string, number>();
 
 /** Sanitize a value for safe log output (prevents log injection) */
 function sanitizeForLog(value: unknown): string {
@@ -321,14 +322,18 @@ export async function register(
 
   if (existing) {
     // Preserve a uniform external response while still helping legitimate users
-    // who may have an unverified account. Throttle resend to prevent inbox flooding.
-    const cooldownKey = `resend:${email}`;
-    const lastSent = resendCooldownMap.get(cooldownKey);
-    const now = Date.now();
-    if (!lastSent || now - lastSent >= RESEND_COOLDOWN_MS) {
-      resendCooldownMap.set(cooldownKey, now);
+    // who may have an unverified account. Throttle resend (cross-instance) to
+    // prevent inbox flooding and to absorb retries from clients/bots.
+    const acquired = await tryAcquireCooldown(email, {
+      purpose: 'verification',
+      ttlMs: RESEND_COOLDOWN_MS,
+    });
+    if (acquired) {
       resendVerificationEmail(email).catch((err) => {
-        console.error('[AUTH] Failed to handle existing-email registration:', (err as Error).message);
+        reportError(err, {
+          area: 'auth.register.existing-email',
+          tags: { kind: 'resend_failure' },
+        });
       });
     }
     return { created: false };
@@ -351,9 +356,14 @@ export async function register(
     },
   });
 
-  // Send verification email (non-blocking; don't fail registration if email fails)
+  // Send verification email (non-blocking; don't fail registration if email fails).
+  // Failures surface via reportError so they're visible in alerting instead of
+  // silently degrading signup.
   sendVerificationEmail(user.id).catch((err) => {
-    console.error('[AUTH] Failed to send verification email:', (err as Error).message);
+    reportError(err, {
+      area: 'auth.register.send-verification',
+      tags: { kind: 'send_failure' },
+    });
   });
 
   return { created: true };

--- a/apps/web-next/src/lib/auth/__tests__/resend-cooldown.test.ts
+++ b/apps/web-next/src/lib/auth/__tests__/resend-cooldown.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for src/lib/auth/resend-cooldown.ts — Redis-backed resend cooldown.
  *
- * Tests cover the in-memory fallback path (no REDIS_URL); Redis-backed
- * behavior is covered by integration tests in apps/web-next/tests.
+ * Memory-fallback paths run when Redis is unavailable; Redis paths exercised
+ * via a mocked getRedis() so we don't require a running server.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,96 +11,120 @@ import {
   __clearCooldownMemoryForTests,
 } from '@/lib/auth/resend-cooldown';
 
+const mockRedisSet = vi.fn();
+const mockGetRedis = vi.fn();
+const mockIsRedisConnected = vi.fn();
+
 vi.mock('@naap/cache', () => ({
+  getRedis: () => mockGetRedis(),
+  isRedisConnected: () => mockIsRedisConnected(),
+  // Kept for any other callers; not used by the cooldown helper anymore.
   cacheGet: vi.fn(async () => null),
   cacheSet: vi.fn(async () => undefined),
 }));
 
-describe('tryAcquireCooldown (memory fallback)', () => {
-  beforeEach(async () => {
+describe('tryAcquireCooldown', () => {
+  beforeEach(() => {
     __clearCooldownMemoryForTests();
-    const cache = await import('@naap/cache');
-    (cache.cacheGet as ReturnType<typeof vi.fn>).mockReset();
-    (cache.cacheSet as ReturnType<typeof vi.fn>).mockReset();
+    mockRedisSet.mockReset();
+    mockGetRedis.mockReset();
+    mockIsRedisConnected.mockReset();
   });
 
-  it('acquires on first call, rejects within TTL', async () => {
-    const cache = await import('@naap/cache');
-    (cache.cacheGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no redis'));
-
-    const first = await tryAcquireCooldown('user@example.com', {
-      purpose: 'verification',
-      ttlMs: 60_000,
+  describe('memory fallback (no Redis)', () => {
+    beforeEach(() => {
+      mockGetRedis.mockReturnValue(null);
+      mockIsRedisConnected.mockReturnValue(false);
     });
-    expect(first).toBe(true);
 
-    const second = await tryAcquireCooldown('user@example.com', {
-      purpose: 'verification',
-      ttlMs: 60_000,
-    });
-    expect(second).toBe(false);
-  });
-
-  it('is case- and whitespace-insensitive for email', async () => {
-    const cache = await import('@naap/cache');
-    (cache.cacheGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no redis'));
-
-    expect(
-      await tryAcquireCooldown('User@Example.com', {
+    it('acquires on first call, rejects within TTL', async () => {
+      const first = await tryAcquireCooldown('user@example.com', {
         purpose: 'verification',
         ttlMs: 60_000,
-      })
-    ).toBe(true);
-    expect(
-      await tryAcquireCooldown(' user@example.com ', {
+      });
+      expect(first).toBe(true);
+
+      const second = await tryAcquireCooldown('user@example.com', {
         purpose: 'verification',
         ttlMs: 60_000,
-      })
-    ).toBe(false);
-  });
-
-  it('separates cooldowns by purpose', async () => {
-    const cache = await import('@naap/cache');
-    (cache.cacheGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no redis'));
-
-    expect(
-      await tryAcquireCooldown('a@b.com', { purpose: 'verification', ttlMs: 60_000 })
-    ).toBe(true);
-    expect(
-      await tryAcquireCooldown('a@b.com', { purpose: 'password-reset', ttlMs: 60_000 })
-    ).toBe(true);
-  });
-
-  it('returns false for empty email', async () => {
-    expect(
-      await tryAcquireCooldown('', { purpose: 'verification' })
-    ).toBe(false);
-  });
-
-  it('uses Redis path when cache returns a recent timestamp', async () => {
-    const cache = await import('@naap/cache');
-    (cache.cacheGet as ReturnType<typeof vi.fn>).mockResolvedValue(Date.now());
-
-    const acquired = await tryAcquireCooldown('redis-user@example.com', {
-      purpose: 'verification',
-      ttlMs: 60_000,
+      });
+      expect(second).toBe(false);
     });
-    expect(acquired).toBe(false);
-    expect(cache.cacheSet).not.toHaveBeenCalled();
+
+    it('is case- and whitespace-insensitive for email', async () => {
+      expect(
+        await tryAcquireCooldown('User@Example.com', {
+          purpose: 'verification',
+          ttlMs: 60_000,
+        })
+      ).toBe(true);
+      expect(
+        await tryAcquireCooldown(' user@example.com ', {
+          purpose: 'verification',
+          ttlMs: 60_000,
+        })
+      ).toBe(false);
+    });
+
+    it('separates cooldowns by purpose', async () => {
+      expect(
+        await tryAcquireCooldown('a@b.com', { purpose: 'verification', ttlMs: 60_000 })
+      ).toBe(true);
+      expect(
+        await tryAcquireCooldown('a@b.com', { purpose: 'password-reset', ttlMs: 60_000 })
+      ).toBe(true);
+    });
+
+    it('returns false for empty email', async () => {
+      expect(
+        await tryAcquireCooldown('', { purpose: 'verification' })
+      ).toBe(false);
+    });
   });
 
-  it('writes via Redis when cache reports no prior cooldown', async () => {
-    const cache = await import('@naap/cache');
-    (cache.cacheGet as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (cache.cacheSet as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
-
-    const acquired = await tryAcquireCooldown('fresh-user@example.com', {
-      purpose: 'verification',
-      ttlMs: 60_000,
+  describe('redis path (atomic SET NX PX)', () => {
+    beforeEach(() => {
+      mockGetRedis.mockReturnValue({ set: mockRedisSet });
+      mockIsRedisConnected.mockReturnValue(true);
     });
-    expect(acquired).toBe(true);
-    expect(cache.cacheSet).toHaveBeenCalledOnce();
-    const callArgs = (cache.cacheSet as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(callArgs[2]).toMatchObject({ prefix: 'auth:resend-cooldown', ttl: 60 });
+
+    it('returns true when Redis SET NX returns OK (key acquired)', async () => {
+      mockRedisSet.mockResolvedValue('OK');
+      const acquired = await tryAcquireCooldown('fresh@example.com', {
+        purpose: 'verification',
+        ttlMs: 60_000,
+      });
+      expect(acquired).toBe(true);
+      expect(mockRedisSet).toHaveBeenCalledOnce();
+      const [key, value, mode1, ttl, mode2] = mockRedisSet.mock.calls[0];
+      expect(key).toMatch(/^auth:resend-cooldown:verification:[a-f0-9]{64}$/);
+      expect(typeof value).toBe('string');
+      expect(mode1).toBe('PX');
+      expect(ttl).toBe(60_000);
+      expect(mode2).toBe('NX');
+    });
+
+    it('returns false when Redis SET NX returns null (key already held)', async () => {
+      mockRedisSet.mockResolvedValue(null);
+      const acquired = await tryAcquireCooldown('held@example.com', {
+        purpose: 'verification',
+        ttlMs: 60_000,
+      });
+      expect(acquired).toBe(false);
+    });
+
+    it('falls back to memory when Redis throws', async () => {
+      mockRedisSet.mockRejectedValue(new Error('redis exploded'));
+      const first = await tryAcquireCooldown('falls-back@example.com', {
+        purpose: 'verification',
+        ttlMs: 60_000,
+      });
+      const second = await tryAcquireCooldown('falls-back@example.com', {
+        purpose: 'verification',
+        ttlMs: 60_000,
+      });
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+    });
   });
 });

--- a/apps/web-next/src/lib/auth/__tests__/resend-cooldown.test.ts
+++ b/apps/web-next/src/lib/auth/__tests__/resend-cooldown.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for src/lib/auth/resend-cooldown.ts — Redis-backed resend cooldown.
+ *
+ * Tests cover the in-memory fallback path (no REDIS_URL); Redis-backed
+ * behavior is covered by integration tests in apps/web-next/tests.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  tryAcquireCooldown,
+  __clearCooldownMemoryForTests,
+} from '@/lib/auth/resend-cooldown';
+
+vi.mock('@naap/cache', () => ({
+  cacheGet: vi.fn(async () => null),
+  cacheSet: vi.fn(async () => undefined),
+}));
+
+describe('tryAcquireCooldown (memory fallback)', () => {
+  beforeEach(async () => {
+    __clearCooldownMemoryForTests();
+    const cache = await import('@naap/cache');
+    (cache.cacheGet as ReturnType<typeof vi.fn>).mockReset();
+    (cache.cacheSet as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('acquires on first call, rejects within TTL', async () => {
+    const cache = await import('@naap/cache');
+    (cache.cacheGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no redis'));
+
+    const first = await tryAcquireCooldown('user@example.com', {
+      purpose: 'verification',
+      ttlMs: 60_000,
+    });
+    expect(first).toBe(true);
+
+    const second = await tryAcquireCooldown('user@example.com', {
+      purpose: 'verification',
+      ttlMs: 60_000,
+    });
+    expect(second).toBe(false);
+  });
+
+  it('is case- and whitespace-insensitive for email', async () => {
+    const cache = await import('@naap/cache');
+    (cache.cacheGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no redis'));
+
+    expect(
+      await tryAcquireCooldown('User@Example.com', {
+        purpose: 'verification',
+        ttlMs: 60_000,
+      })
+    ).toBe(true);
+    expect(
+      await tryAcquireCooldown(' user@example.com ', {
+        purpose: 'verification',
+        ttlMs: 60_000,
+      })
+    ).toBe(false);
+  });
+
+  it('separates cooldowns by purpose', async () => {
+    const cache = await import('@naap/cache');
+    (cache.cacheGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no redis'));
+
+    expect(
+      await tryAcquireCooldown('a@b.com', { purpose: 'verification', ttlMs: 60_000 })
+    ).toBe(true);
+    expect(
+      await tryAcquireCooldown('a@b.com', { purpose: 'password-reset', ttlMs: 60_000 })
+    ).toBe(true);
+  });
+
+  it('returns false for empty email', async () => {
+    expect(
+      await tryAcquireCooldown('', { purpose: 'verification' })
+    ).toBe(false);
+  });
+
+  it('uses Redis path when cache returns a recent timestamp', async () => {
+    const cache = await import('@naap/cache');
+    (cache.cacheGet as ReturnType<typeof vi.fn>).mockResolvedValue(Date.now());
+
+    const acquired = await tryAcquireCooldown('redis-user@example.com', {
+      purpose: 'verification',
+      ttlMs: 60_000,
+    });
+    expect(acquired).toBe(false);
+    expect(cache.cacheSet).not.toHaveBeenCalled();
+  });
+
+  it('writes via Redis when cache reports no prior cooldown', async () => {
+    const cache = await import('@naap/cache');
+    (cache.cacheGet as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (cache.cacheSet as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const acquired = await tryAcquireCooldown('fresh-user@example.com', {
+      purpose: 'verification',
+      ttlMs: 60_000,
+    });
+    expect(acquired).toBe(true);
+    expect(cache.cacheSet).toHaveBeenCalledOnce();
+    const callArgs = (cache.cacheSet as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[2]).toMatchObject({ prefix: 'auth:resend-cooldown', ttl: 60 });
+  });
+});

--- a/apps/web-next/src/lib/auth/resend-cooldown.ts
+++ b/apps/web-next/src/lib/auth/resend-cooldown.ts
@@ -76,6 +76,11 @@ async function getCache(): Promise<typeof import('@naap/cache') | null> {
 /**
  * Try to acquire a cooldown slot for (purpose, email).
  *
+ * Atomicity: when Redis is available we use a single `SET key value NX PX ttl`
+ * round-trip — Redis returns `OK` only if the key didn't already exist, so
+ * concurrent acquirers see exactly one winner. Falls back to a process-local
+ * Map (single-threaded Node — atomic within a tick) when Redis is absent.
+ *
  * @returns `true` if the slot was acquired (caller should proceed with the
  *          send), `false` if the recipient is still within their cooldown.
  */
@@ -87,19 +92,18 @@ export async function tryAcquireCooldown(
   if (!email) return false;
   if (ttlMs <= 0) return true;
 
-  const key = buildKey(purpose, email);
+  const key = `${PREFIX}:${buildKey(purpose, email)}`;
   const now = Date.now();
-  const ttlSeconds = Math.max(1, Math.ceil(ttlMs / 1000));
 
   const cache = await getCache();
   if (cache) {
     try {
-      const existing = await cache.cacheGet<number>(key, { prefix: PREFIX });
-      if (typeof existing === 'number' && now - existing < ttlMs) {
-        return false;
+      const redis = cache.getRedis();
+      if (redis && cache.isRedisConnected()) {
+        // SET key value NX PX ttlMs → 'OK' on acquire, null if key exists.
+        const result = await redis.set(key, String(now), 'PX', ttlMs, 'NX');
+        return result === 'OK';
       }
-      await cache.cacheSet<number>(key, now, { prefix: PREFIX, ttl: ttlSeconds });
-      return true;
     } catch {
       // Fall through to in-memory if Redis errors out
     }

--- a/apps/web-next/src/lib/auth/resend-cooldown.ts
+++ b/apps/web-next/src/lib/auth/resend-cooldown.ts
@@ -1,0 +1,118 @@
+/**
+ * Resend cooldown — prevents repeated verification/reset email sends to the
+ * same recipient within a TTL window.
+ *
+ * Backed by Redis (`@naap/cache`) for cross-instance consistency on Vercel
+ * Fluid Compute. Falls back to a process-local Map when Redis is unavailable
+ * (e.g. local dev without REDIS_URL) so the behavior is still correct within
+ * a single instance.
+ *
+ * Key shape: `auth:resend-cooldown:<purpose>:<lowercased-email>`
+ * Value: epoch-ms of the send that started the cooldown.
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface CooldownOptions {
+  /** Logical bucket — e.g. 'verification', 'password-reset'. */
+  purpose: string;
+  /** Cooldown TTL in milliseconds (default 15 minutes). */
+  ttlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 15 * 60 * 1000;
+const PREFIX = 'auth:resend-cooldown';
+
+/**
+ * Hash the email so the cache key doesn't carry plaintext PII. Lowercased
+ * before hashing for consistent lookup regardless of casing variation.
+ */
+function emailKey(email: string): string {
+  return createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
+}
+
+function buildKey(purpose: string, email: string): string {
+  return `${purpose}:${emailKey(email)}`;
+}
+
+/**
+ * In-memory fallback used when Redis is unavailable. Mirrors the historical
+ * single-instance behavior; bounded by a soft cap to avoid unbounded growth.
+ */
+const memoryStore = new Map<string, number>();
+const MEMORY_SOFT_CAP = 5_000;
+
+function memoryGet(key: string, now: number, ttlMs: number): number | null {
+  const ts = memoryStore.get(key);
+  if (ts === undefined) return null;
+  if (now - ts >= ttlMs) {
+    memoryStore.delete(key);
+    return null;
+  }
+  return ts;
+}
+
+function memorySet(key: string, now: number): void {
+  if (memoryStore.size >= MEMORY_SOFT_CAP) {
+    // Drop the oldest entry to keep the map bounded.
+    const oldest = memoryStore.keys().next().value;
+    if (oldest !== undefined) memoryStore.delete(oldest);
+  }
+  memoryStore.set(key, now);
+}
+
+/**
+ * Lazy-load @naap/cache so the cooldown module remains usable on cold start
+ * even if the cache package fails to load.
+ */
+async function getCache(): Promise<typeof import('@naap/cache') | null> {
+  try {
+    return await import('@naap/cache');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Try to acquire a cooldown slot for (purpose, email).
+ *
+ * @returns `true` if the slot was acquired (caller should proceed with the
+ *          send), `false` if the recipient is still within their cooldown.
+ */
+export async function tryAcquireCooldown(
+  email: string,
+  options: CooldownOptions
+): Promise<boolean> {
+  const { purpose, ttlMs = DEFAULT_TTL_MS } = options;
+  if (!email) return false;
+  if (ttlMs <= 0) return true;
+
+  const key = buildKey(purpose, email);
+  const now = Date.now();
+  const ttlSeconds = Math.max(1, Math.ceil(ttlMs / 1000));
+
+  const cache = await getCache();
+  if (cache) {
+    try {
+      const existing = await cache.cacheGet<number>(key, { prefix: PREFIX });
+      if (typeof existing === 'number' && now - existing < ttlMs) {
+        return false;
+      }
+      await cache.cacheSet<number>(key, now, { prefix: PREFIX, ttl: ttlSeconds });
+      return true;
+    } catch {
+      // Fall through to in-memory if Redis errors out
+    }
+  }
+
+  if (memoryGet(key, now, ttlMs) !== null) {
+    return false;
+  }
+  memorySet(key, now);
+  return true;
+}
+
+/** Internal hook for tests. */
+export function __clearCooldownMemoryForTests(): void {
+  memoryStore.clear();
+}

--- a/apps/web-next/src/lib/email.ts
+++ b/apps/web-next/src/lib/email.ts
@@ -5,6 +5,7 @@
 
 import { Resend } from 'resend';
 import { appUrl as APP_URL } from '@/lib/env';
+import { reportError } from '@/lib/monitoring';
 
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
 const EMAIL_FROM =
@@ -18,33 +19,56 @@ function getResendClient(): Resend | null {
 }
 
 /**
- * Validate email configuration at startup.
- * Logs warnings for missing or sandbox-only config in production.
+ * Pure check of email configuration. Safe to call repeatedly (e.g. from
+ * `/api/health`) — never logs. Use {@link logEmailConfigWarnings} once at
+ * boot to surface warnings.
  */
 export function validateEmailConfig(): { configured: boolean; warnings: string[] } {
   const warnings: string[] = [];
-  const isProduction = process.env.NODE_ENV === 'production';
 
   if (!RESEND_API_KEY) {
-    const msg = '[EMAIL] RESEND_API_KEY is not set — email sending is disabled';
-    warnings.push(msg);
-    if (isProduction) console.error(msg);
+    warnings.push('[EMAIL] RESEND_API_KEY is not set — email sending is disabled');
   }
 
   if (EMAIL_FROM.includes('@resend.dev')) {
-    const msg =
+    warnings.push(
       '[EMAIL] EMAIL_FROM uses sandbox domain (resend.dev). ' +
-      'In production, set EMAIL_FROM to an address on a verified custom domain.';
-    warnings.push(msg);
-    if (isProduction) console.warn(msg);
+        'In production, set EMAIL_FROM to an address on a verified custom domain.'
+    );
   }
 
   return { configured: !!RESEND_API_KEY && !EMAIL_FROM.includes('@resend.dev'), warnings };
 }
 
-// Run validation on module load (logs once per cold start)
+/**
+ * Emit configured/missing warnings to the logger. Called once per cold start
+ * to surface boot-time misconfiguration; production-critical misses are
+ * additionally forwarded to alerting via `reportError`.
+ */
+export function logEmailConfigWarnings(): void {
+  const { configured, warnings } = validateEmailConfig();
+  if (warnings.length === 0) return;
+
+  const isProductionLike =
+    process.env.VERCEL_ENV === 'production' || process.env.DEPLOY_ENV === 'production';
+
+  for (const msg of warnings) {
+    if (isProductionLike) console.error(msg);
+    else console.warn(msg);
+  }
+
+  if (isProductionLike && !configured) {
+    reportError(new Error('Email service misconfigured at boot'), {
+      area: 'auth.email.boot',
+      tags: { kind: 'missing_config' },
+      extra: { warnings },
+    });
+  }
+}
+
+// Run validation once on module load so misconfiguration is loud on cold start.
 if (typeof process !== 'undefined') {
-  validateEmailConfig();
+  logEmailConfigWarnings();
 }
 
 function escapeHtml(str: string): string {
@@ -203,7 +227,10 @@ export async function sendVerificationEmail(
 
   if (!client) {
     if (process.env.NODE_ENV === 'production') {
-      console.error('[EMAIL] RESEND_API_KEY is not configured — verification email not sent');
+      reportError(new Error('RESEND_API_KEY is not configured'), {
+        area: 'auth.email.verification',
+        tags: { kind: 'missing_config' },
+      });
     } else {
       console.log('[EMAIL] (no RESEND_API_KEY) Verification URL:', verifyUrl);
     }
@@ -222,7 +249,10 @@ export async function sendVerificationEmail(
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[EMAIL] Failed to send verification:', message);
+    reportError(err, {
+      area: 'auth.email.verification',
+      tags: { kind: 'send_failure' },
+    });
     return { success: false, error: message };
   }
 }
@@ -238,7 +268,10 @@ export async function sendPasswordResetEmail(
 
   if (!client) {
     if (process.env.NODE_ENV === 'production') {
-      console.error('[EMAIL] RESEND_API_KEY is not configured — password reset email not sent');
+      reportError(new Error('RESEND_API_KEY is not configured'), {
+        area: 'auth.email.password-reset',
+        tags: { kind: 'missing_config' },
+      });
     } else {
       console.log('[EMAIL] (no RESEND_API_KEY) Reset URL:', resetUrl);
     }
@@ -257,7 +290,10 @@ export async function sendPasswordResetEmail(
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[EMAIL] Failed to send password reset:', message);
+    reportError(err, {
+      area: 'auth.email.password-reset',
+      tags: { kind: 'send_failure' },
+    });
     return { success: false, error: message };
   }
 }

--- a/apps/web-next/src/lib/monitoring.ts
+++ b/apps/web-next/src/lib/monitoring.ts
@@ -1,0 +1,124 @@
+/**
+ * Structured error reporting.
+ *
+ * Use `reportError` for failures that should trigger alerts/observability.
+ * Behavior:
+ *  - Always emits a structured JSON line tagged `[ALERT]` so Vercel Log Drains
+ *    (Datadog, Logflare, etc.) can pattern-match for alerting today.
+ *  - If `@sentry/nextjs` is installed and `SENTRY_DSN` is set, additionally
+ *    forwards the exception to `Sentry.captureException`. The Sentry SDK is
+ *    loaded via dynamic import so the dependency stays optional; no-op when
+ *    absent.
+ *
+ * This is intentionally lightweight: it standardizes the "swallow + log" spots
+ * that have historically hidden production regressions (e.g. silent verification
+ * email failures) without requiring the full Sentry SDK to be wired up.
+ */
+
+const ALERT_TAG = '[ALERT]';
+
+export interface ErrorContext {
+  /** Logical area of the codebase (e.g. 'auth.email.verification'). */
+  area: string;
+  /** Free-form tags for filtering in your log/alert backend. */
+  tags?: Record<string, string | number | boolean | undefined>;
+  /** Extra structured fields (must be JSON-serializable). */
+  extra?: Record<string, unknown>;
+}
+
+interface SentryLike {
+  captureException: (err: unknown, hint?: { tags?: Record<string, unknown>; extra?: Record<string, unknown> }) => void;
+}
+
+let _sentry: SentryLike | null | undefined;
+
+async function loadSentry(): Promise<SentryLike | null> {
+  if (_sentry !== undefined) return _sentry;
+  if (!process.env.SENTRY_DSN) {
+    _sentry = null;
+    return _sentry;
+  }
+  // Resolve via a dynamic specifier so TypeScript does not require the
+  // optional `@sentry/nextjs` package to be installed at build time. The
+  // dependency is intentionally optional; this PR keeps the surface area
+  // small while leaving a hook for a follow-up Sentry SDK install.
+  const SENTRY_MODULE = '@sentry/nextjs';
+  try {
+    const mod = (await import(/* webpackIgnore: true */ SENTRY_MODULE).catch(() => null)) as
+      | { captureException?: SentryLike['captureException'] }
+      | null;
+    if (mod && typeof mod.captureException === 'function') {
+      _sentry = { captureException: mod.captureException };
+    } else {
+      _sentry = null;
+    }
+  } catch {
+    _sentry = null;
+  }
+  return _sentry;
+}
+
+/**
+ * Sanitize string fields for log output (strip control chars that enable
+ * log injection / display corruption).
+ */
+function sanitize(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/[\n\r\t\x00-\x1f\x7f-\x9f\u2028\u2029]/g, ' ');
+  }
+  return value;
+}
+
+function buildLogPayload(err: unknown, ctx: ErrorContext): Record<string, unknown> {
+  const e = err instanceof Error ? err : new Error(String(err));
+  const sanitizedTags: Record<string, unknown> = {};
+  if (ctx.tags) {
+    for (const [k, v] of Object.entries(ctx.tags)) {
+      sanitizedTags[k] = sanitize(v);
+    }
+  }
+  return {
+    level: 'error',
+    area: ctx.area,
+    name: e.name,
+    message: sanitize(e.message),
+    stack: e.stack,
+    tags: sanitizedTags,
+    extra: ctx.extra,
+    env: process.env.VERCEL_ENV || process.env.NODE_ENV || 'unknown',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Report an error: emits a structured log line and forwards to Sentry when
+ * available. Never throws — failures here must not break the caller.
+ */
+export function reportError(err: unknown, ctx: ErrorContext): void {
+  try {
+    const payload = buildLogPayload(err, ctx);
+    console.error(`${ALERT_TAG} ${JSON.stringify(payload)}`);
+  } catch {
+    // Last-ditch fallback if JSON serialization fails
+    console.error(`${ALERT_TAG} reportError serialization failure in area=${ctx.area}`);
+  }
+
+  // Forward to Sentry without awaiting; failures must not propagate.
+  void loadSentry()
+    .then((sentry) => {
+      if (!sentry) return;
+      try {
+        sentry.captureException(err, { tags: ctx.tags, extra: ctx.extra });
+      } catch {
+        // Sentry failure is non-critical
+      }
+    })
+    .catch(() => {
+      /* swallow */
+    });
+}
+
+/** Internal hook for tests. */
+export function __resetMonitoringForTests(): void {
+  _sentry = undefined;
+}

--- a/apps/web-next/tests/auth-email-smoke.spec.ts
+++ b/apps/web-next/tests/auth-email-smoke.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test for the auth verification email pipeline.
+ *
+ * What this protects: if RESEND_API_KEY / EMAIL_FROM are missing or
+ * misconfigured against a deployed environment, `/api/health` will fail
+ * closed (503). This catches the regression that hid Steph's missing
+ * verification email for weeks (silent send failure on register).
+ *
+ * Tagged @pre-release so the nightly e2e-ga workflow picks it up against
+ * production / preview deployments. Skipped locally (no email config
+ * expected on developer machines).
+ */
+test.describe('Auth email config smoke @pre-release', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('/api/health reports email as configured in production-like envs', async ({
+    request,
+    baseURL,
+  }) => {
+    test.skip(!baseURL, 'baseURL required');
+    test.skip(
+      !!baseURL && baseURL.includes('localhost'),
+      'local dev expected to lack Resend config; skipping email config assertion',
+    );
+
+    const res = await request.get('/api/health');
+    expect(
+      [200, 503].includes(res.status()),
+      'health endpoint must respond with a structured status',
+    ).toBe(true);
+
+    const body = await res.json();
+    expect(body, 'health payload includes email section').toHaveProperty('email');
+    expect(
+      body.email,
+      'email section reports configured fields',
+    ).toMatchObject({
+      configured: expect.any(Boolean),
+      warnings: expect.any(Array),
+      criticalInThisEnv: expect.any(Boolean),
+    });
+
+    expect(
+      body.email.configured,
+      `email service must be configured in a deployed env; warnings=${JSON.stringify(body.email.warnings)}`,
+    ).toBe(true);
+    expect(res.status(), 'health endpoint must return 200 when email is configured').toBe(200);
+  });
+
+  test('register endpoint accepts a fresh signup attempt', async ({ request, baseURL }) => {
+    test.skip(!baseURL, 'baseURL required');
+    test.skip(
+      !!baseURL && baseURL.includes('localhost'),
+      'register requires DB + email; skipping for local dev',
+    );
+
+    const unique = `e2e-smoke-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.invalid`;
+    const res = await request.post('/api/v1/auth/register', {
+      data: {
+        email: unique,
+        password: 'CorrectHorseBatteryStaple1!',
+        displayName: 'E2E Smoke Test',
+      },
+    });
+
+    // The endpoint returns a uniform 200 regardless of whether the email is
+    // new (created + email sent) or already exists (cooldown-throttled resend).
+    // It must NOT return 5xx — that would indicate the email pipeline crashed.
+    expect(res.status(), `register must not 5xx; got status ${res.status()}`).toBeLessThan(500);
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(body).toHaveProperty('success', true);
+    }
+  });
+
+  test('resend-verification endpoint is callable without 5xx', async ({ request, baseURL }) => {
+    test.skip(!baseURL, 'baseURL required');
+    test.skip(
+      !!baseURL && baseURL.includes('localhost'),
+      'requires deployed env with Resend configured',
+    );
+
+    const res = await request.post('/api/v1/auth/resend-verification', {
+      data: { email: `nonexistent-${Date.now()}@example.invalid` },
+    });
+    // Returns 200 for non-existent users by design (anti-enumeration);
+    // any 5xx means the email send code path threw.
+    expect(res.status()).toBeLessThan(500);
+  });
+});

--- a/apps/web-next/tests/auth-email-smoke.spec.ts
+++ b/apps/web-next/tests/auth-email-smoke.spec.ts
@@ -12,6 +12,18 @@ import { test, expect } from '@playwright/test';
  * production / preview deployments. Skipped locally (no email config
  * expected on developer machines).
  */
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+
+function isLocalBaseURL(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    return LOCAL_HOSTNAMES.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
 test.describe('Auth email config smoke @pre-release', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -21,7 +33,7 @@ test.describe('Auth email config smoke @pre-release', () => {
   }) => {
     test.skip(!baseURL, 'baseURL required');
     test.skip(
-      !!baseURL && baseURL.includes('localhost'),
+      isLocalBaseURL(baseURL),
       'local dev expected to lack Resend config; skipping email config assertion',
     );
 
@@ -52,7 +64,7 @@ test.describe('Auth email config smoke @pre-release', () => {
   test('register endpoint accepts a fresh signup attempt', async ({ request, baseURL }) => {
     test.skip(!baseURL, 'baseURL required');
     test.skip(
-      !!baseURL && baseURL.includes('localhost'),
+      isLocalBaseURL(baseURL),
       'register requires DB + email; skipping for local dev',
     );
 
@@ -78,7 +90,7 @@ test.describe('Auth email config smoke @pre-release', () => {
   test('resend-verification endpoint is callable without 5xx', async ({ request, baseURL }) => {
     test.skip(!baseURL, 'baseURL required');
     test.skip(
-      !!baseURL && baseURL.includes('localhost'),
+      isLocalBaseURL(baseURL),
       'requires deployed env with Resend configured',
     );
 


### PR DESCRIPTION
## Why

We just shipped operational fixes for a missing-Resend-key incident on `operator.livepeer.org`: user signups completed in DB but verification emails were never sent in production. Diagnosing it took a while because every failure mode along the email path was silently swallowed into `console.error`. This PR makes those same failure modes loud, and replaces a Vercel Fluid Compute foot-gun (per-instance cooldown `Map`) with a Redis-backed implementation.

## Summary

- **/api/health fails closed on broken email config.** Returns 503 in production-like environments (`VERCEL_ENV=production` or `DEPLOY_ENV=production`) when `RESEND_API_KEY` is missing or `EMAIL_FROM` is still on the `resend.dev` sandbox sender. Catches the exact regression we just lived through, on the next deploy. (`apps/web-next/src/app/api/health/route.ts`)
- **Structured error reporter ready for Sentry.** New `lib/monitoring.ts` emits a tagged `[ALERT] {...json...}` log line — pickable up by Vercel Log Drains today (Datadog/Logflare pattern-match), and additionally forwards to `Sentry.captureException` when `@sentry/nextjs` is installed and `SENTRY_DSN` is set. The Sentry SDK stays optional via dynamic import; no-op when absent. (`apps/web-next/src/lib/monitoring.ts`)
- **Email failures now go through the reporter, not `console.error`.** Both verification and password-reset paths in `lib/email.ts`, plus the silent `.catch` in `register()`, route through `reportError` with tagged area + kind so they're trivially alertable. (`apps/web-next/src/lib/email.ts`, `apps/web-next/src/lib/api/auth.ts`)
- **`validateEmailConfig` is now pure** so `/api/health` can call it per-request without spamming logs. Boot-time warnings moved to a new `logEmailConfigWarnings()` hook that runs once on module load and reports the production-critical case via `reportError`. (`apps/web-next/src/lib/email.ts`)
- **Resend cooldown moved off the in-process `Map`.** New `lib/auth/resend-cooldown.ts` uses `@naap/cache` (Redis) with hashed-email keys + per-purpose namespacing, so the cooldown holds across serverless instances on Fluid Compute. Falls back to bounded in-memory when Redis is unavailable (local dev parity). (`apps/web-next/src/lib/auth/resend-cooldown.ts`, `apps/web-next/src/lib/api/auth.ts`)
- **Tests:**
  - 14 new unit tests covering monitoring (structured payload, log-injection guard, Sentry no-op), email config validation (pure, sandbox detection), and cooldown (memory fallback, Redis path, case/whitespace normalization, purpose isolation).
  - New Playwright `@pre-release` smoke (`tests/auth-email-smoke.spec.ts`) that asserts `/api/health` reports email configured and `register` / `resend-verification` do not 5xx. Picked up by the nightly e2e-ga workflow against production / preview.
- **Docs.** `.env.local.example` now spells out that `RESEND_API_KEY` + a verified-domain `EMAIL_FROM` are required in production, and that the sandbox sender only delivers to the Resend account owner.

## Why these four, why now

Background: the missing-email incident root-caused to no `RESEND_API_KEY` in the Vercel project. The code was wired correctly; the failure modes were just invisible. Each item below removes one specific way that the failure could hide again:

| Hardening | What it would have done last time |
|---|---|
| `/api/health` returns 503 | Deploy gate / uptime monitor would have flagged the broken state on the deploy that first lost the key |
| Structured `[ALERT]` log + Sentry hook | First failed send would have paged on-call instead of being lost in `console.error` |
| Redis cooldown | Existing 15-min throttle on duplicate signups now actually works on Vercel; today's `Map` reset on every cold start |
| Playwright smoke | Nightly e2e-ga catches a misconfigured deployment within 24h regardless of monitoring coverage |

## Test plan

Already run locally:

- [x] `npx tsc --noEmit` — no new errors from these files (pre-existing errors on `main` for `@naap/crypto`, `@naap/plugin-sdk`, etc. are unchanged)
- [x] `npx vitest run` — 662/663 pass; the single failure (`integration.test.ts` from PR #325) is a pre-existing flaky external-network test, not touched here
- [x] `npx next lint` over changed files — clean
- [x] New unit tests pass: 14/14
- [ ] Playwright `@pre-release` smoke against a preview deploy — will run in CI; locally skipped because it requires a deployed env

Manual production smoke we just ran end-to-end as part of the incident response (independent of this PR):

- Resend domain `operator.livepeer.org` verified for sending
- `vercel env add RESEND_API_KEY` + `EMAIL_FROM` set on production + preview
- New deployment `naap-platform-741o2zvcz` live on `operator.livepeer.org`
- Resend API smoke send delivered (`"last_event": "delivered"`)

## Risk / rollback

- No new runtime dependencies. `@sentry/nextjs` is *optional* via dynamic import — adding it is a separate PR.
- No behavior change on the happy path. When configured correctly, all changed paths return the same values they did before.
- Redis is only consulted when `tryAcquireCooldown` is called (existing-email registration flow). Failure to reach Redis falls back to in-memory — strictly no-worse than today.
- Rollback: revert this single commit.

## Follow-ups (not in this PR)

- Actually install `@sentry/nextjs` and add `instrumentation.ts` so the dynamic-import path in `lib/monitoring.ts` lights up. Tracking separately so this PR stays scoped.
- Consider extending `/api/health/services` similarly so it surfaces Redis + Resend reachability, not just upstream service `/healthz`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health check now reports email configuration status.
  * Lightweight structured error reporting and monitoring for failures.
  * Cross-instance rate limiting for email resend requests.

* **Documentation**
  * Expanded environment configuration guidance for email (production behavior and sandbox limits).

* **Tests**
  * Added unit and integration tests for email validation, monitoring, resend-cooldown, and an auth-email smoke test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/naap/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->