### PR TITLE
feat(developer-api): Python SDK docs tab

### DIFF
--- a/plugins/developer-api/frontend/src/lib/pymthouse-signer-base-url.ts
+++ b/plugins/developer-api/frontend/src/lib/pymthouse-signer-base-url.ts
@@ -1,0 +1,13 @@
+const DEFAULT_PMTHOUSE_ORIGIN = 'https://pymthouse.com';
+
+/**
+ * PymtHouse HTTP signer base for python-gateway SDK tokens (`signer` JSON field).
+ *
+ * Set at build/dev time via `PMTHOUSE_BASE_URL` (see `frontend/vite.config.ts`).
+ * Empty / unset falls back to {@link DEFAULT_PMTHOUSE_ORIGIN}.
+ */
+export function getPymthouseSignerBaseUrl(): string {
+  const raw = (import.meta.env.PMTHOUSE_BASE_URL as string | undefined)?.trim() || '';
+  const origin = (raw || DEFAULT_PMTHOUSE_ORIGIN).replace(/\/+$/, '');
+  return `${origin}/api/signer`;
+}

--- a/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
+++ b/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
@@ -20,10 +20,12 @@ import {
 ChevronUp,
   ChevronDown,
   ChevronsUpDown,
+  ExternalLink,
   CircleHelp,
 } from 'lucide-react';
 import { Card, Badge, Modal, Tooltip } from '@naap/ui';
 import type { NetworkModel } from '@naap/plugin-sdk';
+import { getPymthouseSignerBaseUrl } from '../lib/pymthouse-signer-base-url';
 
 const PIPELINE_COLOR: Record<string, string> = {
   'text-to-image':           '#f59e0b',
@@ -303,16 +305,52 @@ const selectClassName =
 const inputClassName =
   'w-full bg-bg-tertiary border border-white/10 rounded-lg py-2 px-3 text-sm text-text-primary focus:outline-none focus:border-accent-blue';
 
-const PYTHON_GATEWAY_DISCOVERY_BILLING_SLUGS = new Set(['pymthouse', 'daydream']);
+const PYTHON_GATEWAY_REPO_HREF = 'https://github.com/livepeer/livepeer-python-gateway';
 
-const DEFAULT_PYMTHOUSE_SIGNER_BASE_URL = 'https://pymthouse.com/api/signer';
-
-function getSignerBaseUrlForBillingProvider(slug: string): string {
-  if (slug === 'daydream') {
-    return 'https://signer.daydream.live';
-  }
-  return DEFAULT_PYMTHOUSE_SIGNER_BASE_URL;
+interface DocsBillingProvider {
+  id: string;
+  name: string;
+  signerUrl: string;
+  apiKeyHref: string;
+  /** Provider-specific notes shown in the signer section. */
+  signerNote: string;
+  /** Provider-specific note shown in the authentication section. */
+  authNote: React.ReactNode;
 }
+
+const DOCS_BILLING_PROVIDERS: DocsBillingProvider[] = [
+  {
+    id: 'pymthouse',
+    name: 'PymtHouse',
+    signerUrl: getPymthouseSignerBaseUrl(),
+    apiKeyHref: '/developer/keys',
+    signerNote:
+      'The PymtHouse signer validates your scoped signer session token on every ticket — your private key never leaves your machine.',
+    authNote: (
+      <>
+        Pass the signer session token from the API Keys tab as a Bearer token in the{' '}
+        <code className="text-slate-300">Authorization</code> header. Create a new key from this tab when needed.
+      </>
+    ),
+  },
+  {
+    id: 'daydream',
+    name: 'Daydream',
+    signerUrl: 'https://signer.daydream.live',
+    apiKeyHref: '/developer/keys',
+    signerNote:
+      'The Daydream signer co-signs Livepeer payment tickets on behalf of your account using your API key credentials.',
+    authNote: (
+      <>
+        Pass your Daydream API key as a Bearer token in the{' '}
+        <code className="text-slate-300">Authorization</code> header when calling the signer.{' '}
+        Generate a key from the API Keys tab.
+      </>
+    ),
+  },
+];
+
+const PYTHON_GATEWAY_DISCOVERY_BILLING_SLUGS = new Set(['pymthouse', 'daydream']);
 
 type UsagePeriodPreset = '1d' | '7d' | '30d' | 'mtd' | 'last_month';
 
@@ -364,6 +402,56 @@ const USAGE_PANEL_PROVIDER_SLUGS: readonly string[] = ['pymthouse', 'daydream'];
 
 function billingProviderSupportsPythonGatewayDiscovery(slug: string | undefined): boolean {
   return !!slug && PYTHON_GATEWAY_DISCOVERY_BILLING_SLUGS.has(slug);
+}
+
+function DocCodeBlock({ code, label }: { code: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* ignore */ }
+  }, [code]);
+  return (
+    <div className="relative group mt-2 mb-5">
+      {label && (
+        <span className="block text-[10px] font-mono text-text-secondary/60 mb-1 uppercase tracking-wide select-none">
+          {label}
+        </span>
+      )}
+      <div className="rounded-lg bg-black/50 border border-white/10 overflow-hidden">
+        <pre className="p-3 pr-14 text-[11.5px] leading-relaxed font-mono text-slate-300 overflow-x-auto whitespace-pre">
+          {code}
+        </pre>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy code"
+          className="absolute top-1/2 right-2 -translate-y-1/2 flex items-center gap-1 px-2 py-1 rounded-md border border-white/10 bg-white/5 text-text-secondary hover:text-text-primary hover:bg-white/10 transition-all opacity-0 group-hover:opacity-100 text-[10px] font-medium shrink-0"
+          style={{ top: label ? 'calc(50% + 0.625rem)' : '50%' }}
+        >
+          {copied ? <Check size={11} /> : <Copy size={11} />}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DocSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-7 first:mt-0">
+      <h3 className="text-[11px] font-semibold text-text-primary/60 uppercase tracking-widest mb-3">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function DocProse({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-text-secondary leading-relaxed mb-3">{children}</p>;
 }
 
 export const DeveloperView: React.FC = () => {
@@ -422,6 +510,8 @@ export const DeveloperView: React.FC = () => {
   /** Billing provider slug for Usage tab (pill tabs: Daydream / PymtHouse). */
   const [usageBillingProviderSlug, setUsageBillingProviderSlug] = useState('');
   const [usagePeriodPreset, setUsagePeriodPreset] = useState<UsagePeriodPreset>('mtd');
+  /** Selected billing provider for the Docs tab. */
+  const [docsBillingProviderId, setDocsBillingProviderId] = useState<string>(DOCS_BILLING_PROVIDERS[0].id);
 
   const copyCell = useCallback(async (key: string, text: string) => {
     try {
@@ -1050,7 +1140,12 @@ result = [...result].sort((a, b) => {
       setCreatedPythonGatewayToken('');
       setGatewayDiscoveryKeyMintError('');
       if (billingProviderSupportsPythonGatewayDiscovery(providerSlug)) {
-        const signerBase = getSignerBaseUrlForBillingProvider(providerSlug).replace(/\/+$/, '');
+        const docsBp = DOCS_BILLING_PROVIDERS.find((p) => p.id === providerSlug);
+        const signerBase =
+          docsBp?.signerUrl?.replace(/\/+$/, '') ??
+          (providerSlug === 'daydream'
+            ? 'https://signer.daydream.live'
+            : getPymthouseSignerBaseUrl().replace(/\/+$/, ''));
         const selectedPlanId = selectedDiscoveryPlanId.trim();
         const discoveryPath = selectedPlanId
           ? `/api/v1/orchestrator-leaderboard/plans/${encodeURIComponent(selectedPlanId)}/python-gateway`
@@ -1738,22 +1833,198 @@ result = [...result].sort((a, b) => {
             </div>
           )}
 
-          {activeTab === 'docs' && (
-            <Card>
-              <div className="prose prose-invert max-w-none">
+          {activeTab === 'docs' && (() => {
+            const bp = DOCS_BILLING_PROVIDERS.find((p) => p.id === docsBillingProviderId) ?? DOCS_BILLING_PROVIDERS[0];
+            return (
+            <div className="space-y-4">
+              {/* ── Getting Started ── */}
+              <Card>
                 <h2 className="text-sm font-semibold text-text-primary mb-3">Getting Started</h2>
-                <p className="text-text-secondary mb-3">
-                  Welcome to the NAAP Developer API. Follow these steps to integrate:
-                </p>
-                <ol className="list-decimal list-inside space-y-2 text-text-secondary">
-                  <li>Select a model from the Models tab</li>
-                  <li>Create an API key for your project</li>
-                  <li>Use the API key in your requests</li>
-                  <li>Monitor usage in the Usage & Billing tab</li>
+                <ol className="list-none space-y-2">
+                  {[
+                    'Browse available pipelines and models in the Models tab.',
+                    'Create an API key for your project in the API Keys tab.',
+                    'Use the API key in your requests to authenticate against the NAAP gateway.',
+                    'Track usage and billing in the Usage & Billing tab.',
+                  ].map((step, i) => (
+                    <li key={i} className="flex items-start gap-3 text-sm text-text-secondary">
+                      <span className="shrink-0 w-5 h-5 rounded-full bg-white/5 border border-white/10 flex items-center justify-center text-[10px] font-semibold text-text-primary mt-0.5">
+                        {i + 1}
+                      </span>
+                      {step}
+                    </li>
+                  ))}
                 </ol>
-              </div>
-            </Card>
-          )}
+              </Card>
+
+              {/* ── Python SDK ── */}
+              <Card>
+                {/* Header: title + provider tabs */}
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mb-6">
+                  <div>
+                    <h2 className="text-sm font-semibold text-text-primary">Python SDK</h2>
+                    <p className="text-xs text-text-secondary mt-1">
+                      <a
+                        href={PYTHON_GATEWAY_REPO_HREF}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-accent-blue hover:underline"
+                      >
+                        livepeer/livepeer-python-gateway
+                        <ExternalLink size={11} aria-hidden />
+                      </a>
+                      {' '}— orchestrator discovery, Live Video-to-Video jobs, frame publishing.
+                    </p>
+                  </div>
+
+                  {/* Billing provider pill tabs */}
+                  <div className="shrink-0">
+                    <p className="text-[10px] uppercase tracking-wider text-text-secondary/60 mb-1.5 font-medium">
+                      Billing provider
+                    </p>
+                    <div className="flex items-center gap-1 p-0.5 rounded-lg bg-black/30 border border-white/10">
+                      {DOCS_BILLING_PROVIDERS.map((p) => (
+                        <button
+                          key={p.id}
+                          type="button"
+                          onClick={() => setDocsBillingProviderId(p.id)}
+                          className={`px-3 py-1 rounded-md text-xs font-medium transition-all ${
+                            docsBillingProviderId === p.id
+                              ? 'bg-accent-blue text-white shadow-sm'
+                              : 'text-text-secondary hover:text-text-primary hover:bg-white/5'
+                          }`}
+                        >
+                          {p.name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Provider badge row */}
+                <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/3 border border-white/8 mb-7">
+                  <span className="text-[10px] uppercase tracking-wider text-text-secondary/60 font-medium shrink-0">
+                    Signer
+                  </span>
+                  <code className="text-xs text-accent-blue font-mono">{bp.signerUrl}</code>
+                  <span className="ml-auto shrink-0">
+                    <a
+                      href={bp.apiKeyHref}
+                      className="inline-flex items-center gap-1 text-[11px] text-text-secondary hover:text-accent-blue transition-colors font-medium"
+                    >
+                      Get API key
+                      <ExternalLink size={10} aria-hidden />
+                    </a>
+                  </span>
+                </div>
+
+                <DocSection title="Install">
+                  <DocProse>
+                    Clone the repository and install example dependencies with{' '}
+                    <code className="text-slate-300">uv</code>. The{' '}
+                    <code className="text-slate-300">--extra examples</code> group pulls in{' '}
+                    <code className="text-slate-300">av</code> and other packages needed to run the scripts.
+                  </DocProse>
+                  <DocCodeBlock code={`git clone https://github.com/livepeer/livepeer-python-gateway\ncd livepeer-python-gateway\nuv sync --extra examples`} />
+                </DocSection>
+
+                <DocSection title="Authentication">
+                  <DocProse>{bp.authNote}</DocProse>
+                  <DocCodeBlock
+                    label="Authorization header"
+                    code={`Authorization: Bearer <your-api-key>`}
+                  />
+                  <DocProse>{bp.signerNote}</DocProse>
+                </DocSection>
+
+                <DocSection title="Inspect orchestrators — get_orchestrator_info.py">
+                  <DocProse>
+                    Query a single orchestrator directly without any credentials — useful for quick capability checks on a known host.
+                  </DocProse>
+                  <DocCodeBlock
+                    label="off-chain (direct)"
+                    code={`uv run examples/get_orchestrator_info.py localhost:8935`}
+                  />
+
+                  <DocProse>
+                    Run in on-chain mode with the {bp.name} signer. The signer handles payment ticket co-signing; your private key never leaves your machine.
+                  </DocProse>
+                  <DocCodeBlock
+                    label="remote signer"
+                    code={`uv run examples/get_orchestrator_info.py --signer "${bp.signerUrl}"`}
+                  />
+
+                  <DocProse>
+                    Use <code className="text-slate-300">--discovery</code> to resolve orchestrators from a discovery endpoint. Append{' '}
+                    <code className="text-slate-300">?cap=&lt;capability-id&gt;</code> to filter by pipeline — for example{' '}
+                    <code className="text-slate-300">cap=live-video-to-video</code> or{' '}
+                    <code className="text-slate-300">cap=streamdiffusion-sdxl-v2v</code>.
+                  </DocProse>
+                  <DocCodeBlock
+                    label="discovery + capability filter + signer"
+                    code={`uv run examples/get_orchestrator_info.py \\\n  --discovery "https://discovery.example.com/discover-orchestrators?cap=live-video-to-video" \\\n  --signer "${bp.signerUrl}"`}
+                  />
+
+                  <DocProse>
+                    Output as JSON or JSONL for scripting or piping into other tools.
+                  </DocProse>
+                  <DocCodeBlock
+                    label="json output"
+                    code={`uv run examples/get_orchestrator_info.py localhost:8935 --format json`}
+                  />
+                </DocSection>
+
+                <DocSection title="Publish frames — write_frames.py">
+                  <DocProse>
+                    Start a Live Video-to-Video job and push raw frames to an orchestrator. Run{' '}
+                    <code className="text-slate-300">get_orchestrator_info.py</code> first to discover a suitable
+                    orchestrator URL (filtered by capability if needed), then pass it as the first argument here.
+                  </DocProse>
+                  <DocCodeBlock
+                    label="local orchestrator (off-chain)"
+                    code={`uv run examples/write_frames.py localhost:8935`}
+                  />
+                  <DocCodeBlock
+                    label={`remote orchestrator + ${bp.name} signer`}
+                    code={`uv run examples/write_frames.py https://orchestrator.example.com:8935 \\\n  --signer "${bp.signerUrl}" \\\n  --model noop \\\n  --count 90`}
+                  />
+
+                  <DocProse>
+                    To bundle signer, discovery, and orchestrator settings into a single reusable token, encode a JSON payload as base64 and pass it via{' '}
+                    <code className="text-slate-300">--token</code>. Token fields override explicit arguments. See the{' '}
+                    <a
+                      href={`${PYTHON_GATEWAY_REPO_HREF}#token-schema-base64-encoded-json-object`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-accent-blue hover:underline"
+                    >
+                      token schema
+                      <ExternalLink size={11} aria-hidden />
+                    </a>{' '}
+                    in the README.
+                  </DocProse>
+                </DocSection>
+
+                <DocSection title="VS Code / Cursor debugging">
+                  <DocProse>
+                    From the cloned repo root, these match what you would pass as <code className="text-slate-300">args</code>{' '}
+                    when debugging <code className="text-slate-300">examples/get_orchestrator_info.py</code> or{' '}
+                    <code className="text-slate-300">examples/write_frames.py</code> (<code className="text-slate-300">cwd</code>:{' '}
+                    workspace folder). Replace discovery and orchestrator URLs as needed.
+                  </DocProse>
+                  <DocCodeBlock
+                    label="debug get_orchestrator_info.py"
+                    code={`uv run examples/get_orchestrator_info.py \\\n  --discovery "https://discovery.example.com/discover-orchestrators?cap=live-video-to-video" \\\n  --signer "${bp.signerUrl}"`}
+                  />
+                  <DocCodeBlock
+                    label="debug write_frames.py"
+                    code={`uv run examples/write_frames.py https://orchestrator.example.com:8935 \\\n  --signer "${bp.signerUrl}" \\\n  --model noop \\\n  --count 90`}
+                  />
+                </DocSection>
+              </Card>
+            </div>
+            );
+          })()}
         </motion.div>
       </AnimatePresence>
 

--- a/plugins/developer-api/frontend/src/vite-env.d.ts
+++ b/plugins/developer-api/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly PMTHOUSE_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/plugins/developer-api/frontend/vite.config.ts
+++ b/plugins/developer-api/frontend/vite.config.ts
@@ -1,11 +1,46 @@
 /**
  * Vite Configuration for Developer API Plugin
  */
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig, loadEnv, mergeConfig, type ConfigEnv, type UserConfig } from 'vite';
 import { createPluginConfig } from '@naap/plugin-build/vite';
 
-export default createPluginConfig({
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const basePluginConfig = createPluginConfig({
   name: 'developer-api',
   displayName: 'Developer API',
   globalName: 'NaapPluginDeveloperApi',
   defaultCategory: 'developer',
+});
+
+function loadPmthouseBaseUrl(mode: string): string {
+  const roots = [
+    path.resolve(__dirname, '../../../apps/web-next'),
+    path.resolve(__dirname, '../../..'),
+    __dirname,
+  ];
+  for (const root of roots) {
+    const loaded = loadEnv(mode, root, '');
+    const value = loaded.PMTHOUSE_BASE_URL?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return process.env.PMTHOUSE_BASE_URL?.trim() || '';
+}
+
+export default defineConfig((configEnv: ConfigEnv) => {
+  const base = (
+    typeof basePluginConfig === 'function'
+      ? (basePluginConfig as (env: ConfigEnv) => UserConfig)(configEnv)
+      : basePluginConfig
+  ) as UserConfig;
+  const pmthouseBaseUrl = loadPmthouseBaseUrl(configEnv.mode);
+  return mergeConfig(base, {
+    define: {
+      'import.meta.env.PMTHOUSE_BASE_URL': JSON.stringify(pmthouseBaseUrl),
+    },
+  });
 });


### PR DESCRIPTION
## Summary

Stacks on #307. Moves the expanded `/developer/docs` experience into its own PR so the PymtHouse integration follow-up stays smaller and easier to review.

- Python SDK guide with PymtHouse / Daydream billing-provider tabs
- Copyable `DocCodeBlock` sections for install, auth, discovery, and `write_frames.py`
- `PMTHOUSE_BASE_URL` vite define + `pymthouse-signer-base-url` helper for configurable signer URLs in docs

## Test plan

- [ ] Open preview `/developer/docs` and switch PymtHouse / Daydream tabs; signer URLs and code samples update
- [ ] Confirm API Keys flow in #307 preview still mints python-gateway tokens (unchanged in this PR)
- [ ] Build developer-api plugin with `PMTHOUSE_BASE_URL` set and verify docs show custom signer origin


Made with [Cursor](https://cursor.com)