### PR TITLE
fix(dashboard): always load headless data providers in personal context

### DIFF
--- a/apps/web-next/src/app/api/v1/base/plugins/personalized/__tests__/personalized.test.ts
+++ b/apps/web-next/src/app/api/v1/base/plugins/personalized/__tests__/personalized.test.ts
@@ -187,6 +187,86 @@ describe('Personalized API: visibility-gate', () => {
 });
 
 
+/**
+ * Mirrors the personal-context composition in route.ts: visible plugins (publish +
+ * visibility gated) are merged with headless providers (publish gated only), then
+ * deduplicated by normalized name with the visible entry winning. This guards the
+ * regression where headless data providers were dropped for non-admins in personal
+ * context, breaking the dashboard's `dashboard:query` event-bus handler.
+ */
+function buildPersonalizedPlugins(
+  globalPlugins: MockPlugin[],
+  publishedPackages: MockPublishedPackage[],
+  isAdmin: boolean
+): MockPlugin[] {
+  const visible = applyFilters(globalPlugins, publishedPackages, isAdmin);
+  const headless = extractHeadlessPlugins(globalPlugins, publishedPackages);
+
+  const seenNames = new Set<string>();
+  return [...visible, ...headless].filter((p) => {
+    const normalized = normalizePluginName(p.name);
+    if (seenNames.has(normalized)) return false;
+    seenNames.add(normalized);
+    return true;
+  });
+}
+
+describe('Personalized API: personal-context headless inclusion', () => {
+  it('includes a HIDDEN headless provider for a non-admin user', () => {
+    const globalPlugins = [
+      makePlugin('public-ui'),
+      makeHeadlessPlugin('dashboard-data-provider'),
+    ];
+    const publishedPackages = [
+      makePackage('public-ui', { visibleToUsers: true }),
+      makePackage('dashboard-data-provider', { visibleToUsers: false }),
+    ];
+
+    const result = buildPersonalizedPlugins(globalPlugins, publishedPackages, false);
+
+    expect(result.map((p) => p.name).sort()).toEqual([
+      'dashboard-data-provider',
+      'public-ui',
+    ]);
+  });
+
+  it('does not duplicate a VISIBLE headless provider', () => {
+    const globalPlugins = [makeHeadlessPlugin('dashboard-data-provider')];
+    const publishedPackages = [
+      makePackage('dashboard-data-provider', { visibleToUsers: true }),
+    ];
+
+    const result = buildPersonalizedPlugins(globalPlugins, publishedPackages, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('dashboard-data-provider');
+  });
+
+  it('still excludes a hidden UI (routed) plugin for a non-admin', () => {
+    const globalPlugins = [
+      makeHeadlessPlugin('dashboard-data-provider'),
+      makePlugin('secret-ui'),
+    ];
+    const publishedPackages = [
+      makePackage('dashboard-data-provider', { visibleToUsers: false }),
+      makePackage('secret-ui', { visibleToUsers: false }),
+    ];
+
+    const result = buildPersonalizedPlugins(globalPlugins, publishedPackages, false);
+
+    expect(result.map((p) => p.name)).toEqual(['dashboard-data-provider']);
+  });
+
+  it('excludes an UNPUBLISHED headless provider (publish gate still applies)', () => {
+    const globalPlugins = [makeHeadlessPlugin('draft-provider')];
+    const publishedPackages: MockPublishedPackage[] = [];
+
+    const result = buildPersonalizedPlugins(globalPlugins, publishedPackages, false);
+
+    expect(result).toHaveLength(0);
+  });
+});
+
 describe('Personalized API: preview tester allowlist', () => {
   it('shows hidden plugin to allowlisted user', () => {
     const globalPlugins = [makePlugin('my-wallet'), makePlugin('public-plugin')];

--- a/apps/web-next/src/app/api/v1/base/plugins/personalized/route.ts
+++ b/apps/web-next/src/app/api/v1/base/plugins/personalized/route.ts
@@ -337,9 +337,22 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         return a.order - b.order;
       });
 
-    // Deduplicate by normalized name
+    // Headless data providers (no routes) must always load regardless of the
+    // visibility gate — they register the event-bus handlers the shell and
+    // dashboard depend on (e.g. dashboard-data-provider serves `dashboard:query`).
+    // Mirror the team-context behavior so personal context never drops them when
+    // their package is hidden/preview-gated. Dedup below keeps any already-merged
+    // (visible) entry, so this only fills gaps for non-admins.
+    const headlessMerged = headlessPlugins.map((plugin) => ({
+      ...plugin,
+      enabled: true,
+      installed: true,
+      isCore: isCorePlugin(plugin.name),
+    }));
+
+    // Deduplicate by normalized name (merged visible plugins win — first occurrence)
     const seenNames = new Set<string>();
-    const personalizedPlugins = mergedPlugins.filter((plugin) => {
+    const personalizedPlugins = [...mergedPlugins, ...headlessMerged].filter((plugin) => {
       const normalized = normalizePluginName(plugin.name);
       if (seenNames.has(normalized)) {
         return false;


### PR DESCRIPTION
## Summary

The Overview dashboard on `operator.livepeer.org` is broken for non-admin users: the console shows `[EventBus] NO_HANDLER for "dashboard:query" — all registered keys: []` and `useDashboardQuery` retries until it gives up.

Root cause: the `dashboard-data-provider` **headless** plugin never mounts, so it never registers its `dashboard:query` / `dashboard:job-feed:subscribe` event-bus handlers. `BackgroundPluginLoader` loads headless providers from `GET /api/v1/base/plugins/personalized`, but that route only **force-includes** headless providers in the **team** context. In the **personal** (no-team) context — the default for most users — headless providers were subject to the same publish + **visibility** gate as navigable plugins. When `dashboard-data-provider`'s package is hidden/preview-gated, it gets filtered out for non-admins, so the dashboard's data provider never loads.

This contradicts the documented contract in `BackgroundPluginLoader` ("headless plugins … must always load … regardless of user/team enable/disable preferences").

## Fix

- In the personal-context branch of `personalized/route.ts`, append headless providers (publish-gated only, **never** visibility-gated), mirroring the existing team-context behavior.
- Dedup so an already-merged (visible) entry still wins — no duplicates, and visible metadata is preserved.
- This is intentionally minimal: the unpublished/publish gate still applies (drafts can't leak), and admins are unaffected.

## Tests

Added a `personal-context headless inclusion` suite to `personalized.test.ts` covering:
- hidden headless provider **is** included for a non-admin
- visible headless provider is **not** duplicated
- hidden **routed** (UI) plugin is still excluded for non-admins
- **unpublished** headless provider is still excluded (publish gate intact)

`npx vitest run …/personalized.test.ts` → 23 passed. No new `tsc` errors in the touched route.

## Notes / follow-up (data, out of scope for this PR)

The live API currently returns zero plugins to non-admins, which suggests `dashboard-data-provider` (and possibly others) are hidden/unlisted in the prod registry. This code change makes the dashboard resilient to that, but the team may still want to confirm the prod `PluginPackage` row is `enabled` + `published` + `visibleToUsers`.

## Test plan

- [ ] Non-admin user (personal context) loads `/dashboard` → `dashboard:query` handler registers, Overview renders
- [ ] Admin user unaffected
- [ ] Team context unaffected (headless still included)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Headless plugins are now properly included in personalized plugin responses, even when their packages are hidden from non-admin users.

* **Tests**
  * Added test suite validating headless plugin inclusion behavior, including deduplication and publish-gate filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->