### PR TITLE
feat(billing): BPP contracts + conformance suite (C0)

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -78,6 +78,8 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.0.18",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^2.1.1",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.16.0",
     "eslint-config-next": "15.5.12",

--- a/apps/web-next/src/lib/billing/bpp/conformance.test.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.test.ts
@@ -36,6 +36,54 @@ describe('BPP conformance — stub provider', () => {
     expect(report.accountRefMismatches).toEqual([]);
     expect(report.passed).toBe(true);
   });
+
+  // signerSession is a oneOf of an endpoint form {url, headers} and a token
+  // bundle {accessToken, ...}. The default stub uses the endpoint form; a real
+  // BillingProviderAdapter / NAAP-C front door returns the token bundle, so the
+  // validate seam MUST accept that form too (else a conformant provider fails).
+  it('accepts a token-bundle signerSession from validate (adapter/NAAP-C form)', async () => {
+    const tokenized: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async validate(key: string) {
+        const base = (await createStubBillingProvider().validate(key)) as Record<string, unknown>;
+        return {
+          ...base,
+          signerSession: {
+            accessToken: 'stub-signer-token',
+            tokenType: 'Bearer',
+            expiresIn: 3600,
+            scope: 'sign:job',
+          },
+        };
+      },
+    };
+    const report = await runConformance(tokenized);
+    const validateSeam = report.seams.find((s) => s.seam === 'validate');
+    expect(validateSeam?.valid, JSON.stringify(validateSeam?.errors, null, 2)).toBe(true);
+    expect(report.passed).toBe(true);
+  });
+
+  // The two forms are mutually exclusive (each forbids extra properties), so
+  // mixing them is a contract violation the suite must reject.
+  it('rejects a signerSession that mixes the endpoint and token-bundle forms', async () => {
+    const mixed: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async validate(key: string) {
+        const base = (await createStubBillingProvider().validate(key)) as Record<string, unknown>;
+        return {
+          ...base,
+          signerSession: {
+            url: 'https://signer.stub.example/session',
+            headers: { Authorization: 'Bearer x' },
+            accessToken: 'should-not-be-here',
+          },
+        };
+      },
+    };
+    const report = await runConformance(mixed);
+    expect(report.seams.find((s) => s.seam === 'validate')?.valid).toBe(false);
+    expect(report.passed).toBe(false);
+  });
 });
 
 describe('BPP conformance — negative cases (the suite catches drift)', () => {

--- a/apps/web-next/src/lib/billing/bpp/conformance.test.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.test.ts
@@ -33,6 +33,7 @@ describe('BPP conformance — stub provider', () => {
     const failing = report.seams.filter((s) => !s.valid);
     expect(failing, JSON.stringify(failing, null, 2)).toHaveLength(0);
     expect(report.leakedFields).toEqual([]);
+    expect(report.accountRefMismatches).toEqual([]);
     expect(report.passed).toBe(true);
   });
 });
@@ -61,6 +62,38 @@ describe('BPP conformance — negative cases (the suite catches drift)', () => {
     };
     const report = await runConformance(leaky);
     expect(report.leakedFields).toContain('openmeter_subscription_id');
+    expect(report.passed).toBe(false);
+  });
+
+  it('fails seam isolation when a provider-internal id leaks through usage ingest (⑥)', async () => {
+    const leaky: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async getUsageIngest() {
+        const base = (await createStubBillingProvider().getUsageIngest()) as Record<
+          string,
+          unknown
+        >;
+        return { ...base, openmeter_subscription_id: '01J-usage-leak' };
+      },
+    };
+    const report = await runConformance(leaky);
+    expect(report.leakedFields).toContain('openmeter_subscription_id');
+    expect(report.passed).toBe(false);
+  });
+
+  it('fails when account.id diverges from billingAccountRef.accountId (⑤ identity)', async () => {
+    const mismatched: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async getAccount() {
+        const base = (await createStubBillingProvider().getAccount()) as Record<string, unknown>;
+        return {
+          ...base,
+          billingAccountRef: { providerSlug: 'stub', accountId: 'acct_DIFFERENT' },
+        };
+      },
+    };
+    const report = await runConformance(mismatched);
+    expect(report.accountRefMismatches.length).toBeGreaterThan(0);
     expect(report.passed).toBe(false);
   });
 

--- a/apps/web-next/src/lib/billing/bpp/conformance.test.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.test.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+
+import { createStubBillingProvider, type BppConformanceProvider } from './stub-provider';
+import {
+  ALL_SCHEMA_FILES,
+  compileAllSchemas,
+  getForbiddenInternalFieldNames,
+  findLeakedInternalFields,
+  runConformance,
+} from './conformance';
+
+describe('BPP contracts', () => {
+  it('every schema file compiles (schema lint)', () => {
+    const compiled = compileAllSchemas();
+    expect(Object.keys(compiled)).toEqual([...ALL_SCHEMA_FILES]);
+    for (const file of ALL_SCHEMA_FILES) {
+      expect(typeof compiled[file]).toBe('function');
+    }
+  });
+
+  it('declares forbidden provider-internal field names (⑨ seam isolation)', () => {
+    const forbidden = getForbiddenInternalFieldNames();
+    expect(forbidden).toContain('openmeter_subscription_id');
+    expect(forbidden).toContain('network_fee_usd_micros');
+  });
+});
+
+describe('BPP conformance — stub provider', () => {
+  it('passes every BPP seam and the seam-isolation assertion', async () => {
+    const report = await runConformance(createStubBillingProvider());
+    const failing = report.seams.filter((s) => !s.valid);
+    expect(failing, JSON.stringify(failing, null, 2)).toHaveLength(0);
+    expect(report.leakedFields).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+});
+
+describe('BPP conformance — negative cases (the suite catches drift)', () => {
+  it('fails schema validation when validate returns the wrong shape', async () => {
+    const broken: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      // `valid` must be a boolean; a string violates the schema.
+      async validate() {
+        return { valid: 'yes' };
+      },
+    };
+    const report = await runConformance(broken);
+    expect(report.passed).toBe(false);
+    expect(report.seams.find((s) => s.seam === 'validate')?.valid).toBe(false);
+  });
+
+  it('fails seam isolation when a provider-internal id leaks through validate', async () => {
+    const leaky: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async validate(key: string) {
+        const base = (await createStubBillingProvider().validate(key)) as Record<string, unknown>;
+        return { ...base, openmeter_subscription_id: '01J-leaky' };
+      },
+    };
+    const report = await runConformance(leaky);
+    expect(report.leakedFields).toContain('openmeter_subscription_id');
+    expect(report.passed).toBe(false);
+  });
+
+  it('findLeakedInternalFields detects nested leaks', () => {
+    const forbidden = getForbiddenInternalFieldNames();
+    const leaked = findLeakedInternalFields(
+      { window: { from: 'x' }, meta: { source: 'openmeter', model_id: 'm' } },
+      forbidden,
+    );
+    expect(leaked).toContain('model_id');
+  });
+});

--- a/apps/web-next/src/lib/billing/bpp/conformance.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.ts
@@ -64,7 +64,16 @@ export function getForbiddenInternalFieldNames(): string[] {
   if (!Array.isArray(names)) {
     throw new Error('provider-internal-openmeter.schema.json missing x-bpp-forbidden-field-names');
   }
-  return names.map((n) => String(n));
+  // Fail fast on malformed schema values rather than silently coercing with
+  // String(): a non-string entry means the contract itself is wrong.
+  return names.map((n) => {
+    if (typeof n !== 'string') {
+      throw new Error(
+        'provider-internal-openmeter.schema.json x-bpp-forbidden-field-names entries must be strings',
+      );
+    }
+    return n;
+  });
 }
 
 /** Recursively collect every object key present in a payload. */
@@ -88,6 +97,35 @@ export function findLeakedInternalFields(payload: unknown, forbidden: string[]):
   return forbidden.filter((name) => keys.has(name));
 }
 
+/**
+ * Enforce the ⑤ account identity invariant that plain JSON Schema (2020-12)
+ * cannot express: `account.id` / `account.providerSlug` MUST equal the neutral
+ * `billingAccountRef.accountId` / `billingAccountRef.providerSlug` pointer. NaaP
+ * only ever persists `billingAccountRef`, so a divergence would leave the stored
+ * pointer aimed at a different account than the one the provider described.
+ * Returns a list of human-readable mismatches (empty when consistent).
+ */
+export function checkAccountRefIdentity(accountPayload: unknown): string[] {
+  if (!accountPayload || typeof accountPayload !== 'object') return [];
+  const root = accountPayload as Record<string, unknown>;
+  const account = root.account as Record<string, unknown> | undefined;
+  const ref = root.billingAccountRef as Record<string, unknown> | undefined;
+  if (!account || !ref) return [];
+
+  const mismatches: string[] = [];
+  if (account.id !== ref.accountId) {
+    mismatches.push(
+      `account.id (${String(account.id)}) !== billingAccountRef.accountId (${String(ref.accountId)})`,
+    );
+  }
+  if (account.providerSlug !== ref.providerSlug) {
+    mismatches.push(
+      `account.providerSlug (${String(account.providerSlug)}) !== billingAccountRef.providerSlug (${String(ref.providerSlug)})`,
+    );
+  }
+  return mismatches;
+}
+
 export interface SeamResult {
   seam: BppSeam;
   valid: boolean;
@@ -99,6 +137,8 @@ export interface ConformanceReport {
   seams: SeamResult[];
   /** Seam-isolation: provider-internal (⑨) names found in ② and ⑥ payloads. */
   leakedFields: string[];
+  /** ⑤ account ↔ billingAccountRef identity-invariant violations. */
+  accountRefMismatches: string[];
   passed: boolean;
 }
 
@@ -126,31 +166,39 @@ async function payloadForSeam(
 
 /**
  * Run the BPP conformance suite (② ④ ⑤ ⑥ ⑧) against a provider plus the
- * seam-isolation assertion on the ② validate and ⑥ usage payloads.
+ * seam-isolation assertion on the ② validate and ⑥ usage payloads and the ⑤
+ * account-ref identity invariant. Each seam is fetched from the provider exactly
+ * once and the captured payloads are reused for the cross-cutting checks, so a
+ * provider with time-varying/stateful responses cannot make the suite flaky.
  */
 export async function runConformance(
   provider: BppConformanceProvider,
 ): Promise<ConformanceReport> {
   const ajv = newAjv();
   const seams: SeamResult[] = [];
+  const payloads = new Map<BppSeam, unknown>();
 
   for (const seam of BPP_SEAMS) {
     const validate = ajv.compile(readSchema(schemaFileForSeam(seam)));
     const payload = await payloadForSeam(provider, seam);
+    payloads.set(seam, payload);
     const valid = validate(payload) as boolean;
     seams.push({ seam, valid, errors: valid ? [] : (validate.errors ?? []) });
   }
 
   const forbidden = getForbiddenInternalFieldNames();
-  const validatePayload = await provider.validate('opaque-test-key');
-  const usagePayload = await provider.getUsageIngest();
   const leakedFields = Array.from(
     new Set([
-      ...findLeakedInternalFields(validatePayload, forbidden),
-      ...findLeakedInternalFields(usagePayload, forbidden),
+      ...findLeakedInternalFields(payloads.get('validate'), forbidden),
+      ...findLeakedInternalFields(payloads.get('usage-ingest'), forbidden),
     ]),
   );
 
-  const passed = seams.every((s) => s.valid) && leakedFields.length === 0;
-  return { provider: provider.slug, seams, leakedFields, passed };
+  const accountRefMismatches = checkAccountRefIdentity(payloads.get('account'));
+
+  const passed =
+    seams.every((s) => s.valid) &&
+    leakedFields.length === 0 &&
+    accountRefMismatches.length === 0;
+  return { provider: provider.slug, seams, leakedFields, accountRefMismatches, passed };
 }

--- a/apps/web-next/src/lib/billing/bpp/conformance.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.ts
@@ -1,0 +1,156 @@
+/**
+ * BPP conformance suite (C0).
+ *
+ * Validates a provider's payloads against the JSON Schemas in
+ * `contracts/billing-provider-protocol/`. Any provider (pymthouse, the stub, or
+ * a third party) must pass this. CI runs it so a producer that drifts from the
+ * protocol fails before integration.
+ *
+ * This is test-support code: it reads schema files from disk with ajv and is
+ * imported only by `conformance.test.ts` (never by the app runtime).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020, { type ValidateFunction, type ErrorObject } from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+
+import type { BppConformanceProvider } from './stub-provider';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+/** Repo root is six levels up from src/lib/billing/bpp/. */
+export const CONTRACTS_DIR = path.resolve(
+  HERE,
+  '../../../../../../contracts/billing-provider-protocol',
+);
+
+/** BPP seams the conformance suite exercises against a provider. */
+export const BPP_SEAMS = ['validate', 'plans', 'account', 'usage-ingest', 'curated-list'] as const;
+export type BppSeam = (typeof BPP_SEAMS)[number];
+
+/** All schema files in the contracts dir (includes the non-BPP ⑨ doc). */
+export const ALL_SCHEMA_FILES = [
+  ...BPP_SEAMS.map((s) => `${s}.schema.json`),
+  'discovery.schema.json',
+  'provider-internal-openmeter.schema.json',
+] as const;
+
+function readSchema(fileName: string): Record<string, unknown> {
+  const full = path.join(CONTRACTS_DIR, fileName);
+  return JSON.parse(fs.readFileSync(full, 'utf8')) as Record<string, unknown>;
+}
+
+function newAjv(): Ajv2020 {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+/** Compile every schema file (schema-lint guardrail). Throws on an invalid schema. */
+export function compileAllSchemas(): Record<string, ValidateFunction> {
+  const ajv = newAjv();
+  const out: Record<string, ValidateFunction> = {};
+  for (const file of ALL_SCHEMA_FILES) {
+    out[file] = ajv.compile(readSchema(file));
+  }
+  return out;
+}
+
+/** Provider-internal field names that MUST NOT leak through the BPP seams (⑨). */
+export function getForbiddenInternalFieldNames(): string[] {
+  const schema = readSchema('provider-internal-openmeter.schema.json');
+  const names = schema['x-bpp-forbidden-field-names'];
+  if (!Array.isArray(names)) {
+    throw new Error('provider-internal-openmeter.schema.json missing x-bpp-forbidden-field-names');
+  }
+  return names.map((n) => String(n));
+}
+
+/** Recursively collect every object key present in a payload. */
+function collectKeys(value: unknown, acc: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, acc);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      acc.add(key);
+      collectKeys(child, acc);
+    }
+  }
+}
+
+/** Find any forbidden provider-internal field names present in a payload. */
+export function findLeakedInternalFields(payload: unknown, forbidden: string[]): string[] {
+  const keys = new Set<string>();
+  collectKeys(payload, keys);
+  return forbidden.filter((name) => keys.has(name));
+}
+
+export interface SeamResult {
+  seam: BppSeam;
+  valid: boolean;
+  errors: ErrorObject[];
+}
+
+export interface ConformanceReport {
+  provider: string;
+  seams: SeamResult[];
+  /** Seam-isolation: provider-internal (⑨) names found in ② and ⑥ payloads. */
+  leakedFields: string[];
+  passed: boolean;
+}
+
+function schemaFileForSeam(seam: BppSeam): string {
+  return `${seam}.schema.json`;
+}
+
+async function payloadForSeam(
+  provider: BppConformanceProvider,
+  seam: BppSeam,
+): Promise<unknown> {
+  switch (seam) {
+    case 'validate':
+      return provider.validate('opaque-test-key');
+    case 'plans':
+      return provider.getPlans();
+    case 'account':
+      return provider.getAccount();
+    case 'usage-ingest':
+      return provider.getUsageIngest();
+    case 'curated-list':
+      return provider.getCuratedList();
+  }
+}
+
+/**
+ * Run the BPP conformance suite (② ④ ⑤ ⑥ ⑧) against a provider plus the
+ * seam-isolation assertion on the ② validate and ⑥ usage payloads.
+ */
+export async function runConformance(
+  provider: BppConformanceProvider,
+): Promise<ConformanceReport> {
+  const ajv = newAjv();
+  const seams: SeamResult[] = [];
+
+  for (const seam of BPP_SEAMS) {
+    const validate = ajv.compile(readSchema(schemaFileForSeam(seam)));
+    const payload = await payloadForSeam(provider, seam);
+    const valid = validate(payload) as boolean;
+    seams.push({ seam, valid, errors: valid ? [] : (validate.errors ?? []) });
+  }
+
+  const forbidden = getForbiddenInternalFieldNames();
+  const validatePayload = await provider.validate('opaque-test-key');
+  const usagePayload = await provider.getUsageIngest();
+  const leakedFields = Array.from(
+    new Set([
+      ...findLeakedInternalFields(validatePayload, forbidden),
+      ...findLeakedInternalFields(usagePayload, forbidden),
+    ]),
+  );
+
+  const passed = seams.every((s) => s.valid) && leakedFields.length === 0;
+  return { provider: provider.slug, seams, leakedFields, passed };
+}

--- a/apps/web-next/src/lib/billing/bpp/stub-provider.ts
+++ b/apps/web-next/src/lib/billing/bpp/stub-provider.ts
@@ -1,0 +1,118 @@
+/**
+ * Tiny in-memory **stub billing provider** (C0).
+ *
+ * It is the *second* implementation of the Billing Provider Protocol (after the
+ * reference provider, pymthouse). It exists only to prove the seam is
+ * provider-neutral — it is NOT a real provider. Keep it minimal.
+ *
+ * Every method returns a payload that conforms to the matching BPP schema in
+ * `contracts/billing-provider-protocol/`. The conformance suite validates it.
+ */
+
+export const STUB_PROVIDER_SLUG = 'stub';
+
+/** The provider surface the BPP conformance suite exercises (② ④ ⑤ ⑥ ⑧). */
+export interface BppConformanceProvider {
+  readonly slug: string;
+  /** ② validate */
+  validate(key: string): Promise<unknown>;
+  /** ④ plans */
+  getPlans(): Promise<unknown>;
+  /** ⑤ account + member + billingAccountRef */
+  getAccount(): Promise<unknown>;
+  /** ⑥ usage ingest payload */
+  getUsageIngest(): Promise<unknown>;
+  /** ⑧ curated list (+ optional token bundle) */
+  getCuratedList(): Promise<unknown>;
+}
+
+export function createStubBillingProvider(): BppConformanceProvider {
+  return {
+    slug: STUB_PROVIDER_SLUG,
+
+    async validate(key: string): Promise<unknown> {
+      if (!key || key.length < 1) {
+        return { valid: false };
+      }
+      return {
+        valid: true,
+        user: { sub: 'stub-user-1' },
+        billing_account: {
+          id: 'acct_stub_1',
+          providerSlug: STUB_PROVIDER_SLUG,
+          billingMode: 'delegated',
+        },
+        capabilities: ['text-to-image:sdxl', 'tool:byoc-demo'],
+        quota: { remaining: 1000, resetAt: '2026-12-31T23:59:59.999Z' },
+        // Neutral opaque pointer — never a provider-internal id name.
+        subscriptionRef: 'sub_stub_opaque_1',
+        signerSession: {
+          url: 'https://signer.stub.example/session',
+          headers: { Authorization: 'Bearer stub-signer-token' },
+        },
+      };
+    },
+
+    async getPlans(): Promise<unknown> {
+      return [
+        {
+          id: 'free',
+          name: 'Free',
+          price: { amount: 0, interval: 'month', currency: 'USD' },
+          bundles: [
+            {
+              capability: 'text-to-image:sdxl',
+              sla: { uptime: 0.99, p95Ms: 3000 },
+              maxPriceWeiPerUnit: '500',
+            },
+          ],
+        },
+      ];
+    },
+
+    async getAccount(): Promise<unknown> {
+      return {
+        account: {
+          id: 'acct_stub_1',
+          ownerSub: 'stub-user-1',
+          providerSlug: STUB_PROVIDER_SLUG,
+          planId: 'free',
+          creditBalanceWei: '0',
+          billingMode: 'delegated',
+        },
+        members: [{ accountId: 'acct_stub_1', sub: 'stub-user-1', role: 'admin' }],
+        billingAccountRef: { providerSlug: STUB_PROVIDER_SLUG, accountId: 'acct_stub_1' },
+      };
+    },
+
+    async getUsageIngest(): Promise<unknown> {
+      return {
+        providerSlug: STUB_PROVIDER_SLUG,
+        accountId: 'acct_stub_1',
+        appId: 'app_demo',
+        window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+        sessions: 3,
+        tickets: 12,
+        feeWei: '1000',
+        networkFeeUsdMicros: '5000',
+        byCapability: {
+          'text-to-image:sdxl': { tickets: 12, networkFeeUsdMicros: '5000' },
+        },
+      };
+    },
+
+    async getCuratedList(): Promise<unknown> {
+      return {
+        plan: 'free',
+        version: '2026-06-17T00:00:00.000Z',
+        orchestrators: [
+          {
+            address: 'https://orch.stub.example:8935',
+            capabilities: ['text-to-image:sdxl'],
+            score: 0.9,
+          },
+        ],
+      };
+    },
+  };
+}

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,42 @@
+# Contracts — Billing Provider Protocol (BPP)
+
+This directory holds the **provider-neutral** cross-repo contracts (C0) for the
+NaaP × billing-provider × application integration. They are the *seams* every
+billing provider implements and that NaaP reaches **only** through the
+`BillingProviderAdapter` SPI (NAAP-A).
+
+`pymthouse` is the reference provider; a tiny in-memory **stub provider** is the
+second implementation that proves the abstraction in CI. The
+[conformance test](../apps/web-next/src/lib/billing/bpp/conformance.test.ts)
+validates any provider's payloads against these schemas.
+
+## Files (`billing-provider-protocol/`)
+
+| Seam | File | Direction | Part of BPP? |
+|---|---|---|---|
+| ② `validate` response | `validate.schema.json` | provider → NaaP (via adapter) | ✅ yes |
+| ④ plans + capability bundles | `plans.schema.json` | provider → NaaP | ✅ yes |
+| ⑤ account + member + `billingAccountRef` | `account.schema.json` | provider-internal → NaaP ref | ✅ yes (ref only) |
+| ⑥ usage ingest | `usage-ingest.schema.json` | provider → NaaP `/metrics/ingest` | ✅ yes |
+| ⑦ discovery response | `discovery.schema.json` | NaaP → gateway | ✅ yes |
+| ⑧ curated list + token bundle | `curated-list.schema.json` | NaaP → provider | ✅ yes |
+| ⑨ provider-internal metering (OpenMeter) | `provider-internal-openmeter.schema.json` | **provider-internal** | ❌ **NOT BPP** |
+
+> **Seam isolation (hard rule).** The BPP payloads (② and ⑥ especially) must
+> never carry provider-internal field names from ⑨ (e.g.
+> `openmeter_subscription_id`, raw `network_fee_usd_micros` OM shapes,
+> `source: "openmeter"`). The conformance suite asserts this. If a provider needs
+> to surface a subscription pointer it returns a **neutral opaque**
+> `subscriptionRef` (the provider decides its meaning).
+
+## Schema dialect
+
+All schemas use JSON Schema **2020-12**. They are *additive-only*: never change an
+existing field's meaning — add new optional fields / new schema versions. The
+conformance suite compiles every schema (a schema-lint guardrail) and validates
+the stub provider against them.
+
+## Versioning
+
+These are v1 of the BPP. Breaking changes require a new file
+(`*.v2.schema.json`) so old consumers keep validating against v1.

--- a/contracts/billing-provider-protocol/account.schema.json
+++ b/contracts/billing-provider-protocol/account.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://naap.livepeer.org/contracts/bpp/account.schema.json",
   "title": "BPP ⑤ account + member + billingAccountRef",
   "description": "The billing account is provider-internal; NaaP only ever stores the neutral billingAccountRef pointer. account and account_member are documented so providers expose a consistent shape.",
+  "$comment": "Identity invariant (enforced by the BPP conformance suite, not plain JSON Schema 2020-12): account.id MUST equal billingAccountRef.accountId and account.providerSlug MUST equal billingAccountRef.providerSlug, so the persisted neutral ref can never point at a different account than the one described.",
   "type": "object",
   "required": ["account", "billingAccountRef"],
   "additionalProperties": false,

--- a/contracts/billing-provider-protocol/account.schema.json
+++ b/contracts/billing-provider-protocol/account.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/account.schema.json",
+  "title": "BPP ⑤ account + member + billingAccountRef",
+  "description": "The billing account is provider-internal; NaaP only ever stores the neutral billingAccountRef pointer. account and account_member are documented so providers expose a consistent shape.",
+  "type": "object",
+  "required": ["account", "billingAccountRef"],
+  "additionalProperties": false,
+  "$defs": {
+    "account": {
+      "type": "object",
+      "required": ["id", "ownerSub", "providerSlug", "billingMode"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ownerSub": { "type": "string", "minLength": 1 },
+        "providerSlug": { "type": "string", "minLength": 1 },
+        "planId": { "type": "string" },
+        "creditBalanceWei": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "description": "Decimal wei string."
+        },
+        "billingMode": { "type": "string", "enum": ["delegated", "prepay"] }
+      }
+    },
+    "account_member": {
+      "type": "object",
+      "required": ["accountId", "sub", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "accountId": { "type": "string", "minLength": 1 },
+        "sub": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["admin", "member"] }
+      }
+    },
+    "billingAccountRef": {
+      "type": "object",
+      "description": "Provider-agnostic pointer stored NaaP-side. The ONLY account shape NaaP persists.",
+      "required": ["providerSlug", "accountId"],
+      "additionalProperties": false,
+      "properties": {
+        "providerSlug": { "type": "string", "minLength": 1 },
+        "accountId": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "properties": {
+    "account": { "$ref": "#/$defs/account" },
+    "members": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/account_member" }
+    },
+    "billingAccountRef": { "$ref": "#/$defs/billingAccountRef" }
+  }
+}

--- a/contracts/billing-provider-protocol/curated-list.schema.json
+++ b/contracts/billing-provider-protocol/curated-list.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/curated-list.schema.json",
+  "title": "BPP ⑧ curated list + optional token bundle",
+  "description": "NaaP → provider via adapter.receiveCuratedOrchestrators(plan, list). The token bundle is OPTIONAL and only used for the direct python-gateway path (Option 2). Headers in the token bundle are opaque to apps.",
+  "type": "object",
+  "required": ["plan", "version", "orchestrators"],
+  "additionalProperties": false,
+  "$defs": {
+    "headers": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "tokenBundle": {
+      "type": "object",
+      "required": ["signer", "signer_headers", "discovery", "discovery_headers"],
+      "additionalProperties": false,
+      "properties": {
+        "signer": { "type": "string", "format": "uri" },
+        "signer_headers": { "$ref": "#/$defs/headers" },
+        "discovery": { "type": "string", "format": "uri" },
+        "discovery_headers": { "$ref": "#/$defs/headers" }
+      }
+    }
+  },
+  "properties": {
+    "plan": { "type": "string", "minLength": 1 },
+    "version": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO timestamp identifying this curated revision."
+    },
+    "orchestrators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["address", "capabilities"],
+        "additionalProperties": false,
+        "properties": {
+          "address": { "type": "string", "format": "uri" },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "score": { "type": "number" }
+        }
+      }
+    },
+    "tokenBundle": { "$ref": "#/$defs/tokenBundle" }
+  }
+}

--- a/contracts/billing-provider-protocol/discovery.schema.json
+++ b/contracts/billing-provider-protocol/discovery.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/discovery.schema.json",
+  "title": "BPP ⑦ discovery response",
+  "description": "NaaP → gateway. GET /api/v1/orchestrator-leaderboard/python-gateway?caps=… (auth: Bearer gw_…). The list is already filtered by the plan's capabilities.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["address"],
+    "additionalProperties": false,
+    "properties": {
+      "address": {
+        "type": "string",
+        "format": "uri",
+        "description": "Orchestrator endpoint, e.g. https://orch.example:8935"
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/plans.schema.json
+++ b/contracts/billing-provider-protocol/plans.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/plans.schema.json",
+  "title": "BPP ④ plans + capability bundles",
+  "description": "Provider plan catalogue. Each plan declares the capabilities it enables and their SLA / price ceiling. NaaP enforces key → seat → account → plan → capabilities.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "bundles"],
+    "additionalProperties": false,
+    "properties": {
+      "id": { "type": "string", "minLength": 1 },
+      "name": { "type": "string" },
+      "price": {
+        "type": "object",
+        "required": ["amount", "interval"],
+        "additionalProperties": false,
+        "properties": {
+          "amount": { "type": "number", "minimum": 0 },
+          "interval": { "type": "string", "enum": ["month", "year", "once"] },
+          "currency": { "type": "string", "description": "ISO 4217 code; defaults to USD when omitted." }
+        }
+      },
+      "bundles": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["capability"],
+          "additionalProperties": false,
+          "properties": {
+            "capability": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Generic capability id, e.g. text-to-image:sdxl or tool:byoc-foo."
+            },
+            "sla": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "uptime": { "type": "number", "minimum": 0, "maximum": 1 },
+                "p95Ms": { "type": "number", "minimum": 0 }
+              }
+            },
+            "maxPriceWeiPerUnit": {
+              "type": "string",
+              "pattern": "^[0-9]+$",
+              "description": "Decimal wei string price ceiling per unit."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/plans.schema.json
+++ b/contracts/billing-provider-protocol/plans.schema.json
@@ -18,7 +18,7 @@
         "properties": {
           "amount": { "type": "number", "minimum": 0 },
           "interval": { "type": "string", "enum": ["month", "year", "once"] },
-          "currency": { "type": "string", "description": "ISO 4217 code; defaults to USD when omitted." }
+          "currency": { "type": "string", "pattern": "^[A-Z]{3}$", "description": "ISO 4217 code; defaults to USD when omitted." }
         }
       },
       "bundles": {

--- a/contracts/billing-provider-protocol/provider-internal-openmeter.schema.json
+++ b/contracts/billing-provider-protocol/provider-internal-openmeter.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/provider-internal-openmeter.schema.json",
+  "title": "⑨ Provider-internal metering (OpenMeter) — NOT part of the BPP",
+  "description": "DOCUMENTATION ONLY. This is the reference provider's (pymthouse, PR #133) internal metering shape. NaaP MUST NEVER depend on it — it consumes the neutral ⑥ usage-ingest payload only. The conformance suite uses this file's `x-bpp-forbidden-field-names` to assert these names never leak through the BPP seams (② and ⑥).",
+  "x-bpp": "non-bpp",
+  "x-bpp-forbidden-field-names": [
+    "openmeter_subscription_id",
+    "openmeter_customer_id",
+    "network_fee_usd_micros",
+    "fee_wei",
+    "eth_usd_price",
+    "eth_usd_round_id",
+    "eth_usd_observed_at",
+    "external_user_id",
+    "client_id",
+    "model_id",
+    "gateway_request_id",
+    "specversion"
+  ],
+  "type": "object",
+  "required": ["specversion", "type", "source", "data"],
+  "properties": {
+    "specversion": { "type": "string", "const": "1.0" },
+    "type": { "type": "string", "const": "create_signed_ticket" },
+    "source": { "type": "string", "const": "go-livepeer-remote-signer" },
+    "subject": { "type": "string", "description": "<client_id>:<external_user_id>" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "client_id": { "type": "string" },
+        "external_user_id": { "type": "string" },
+        "network_fee_usd_micros": { "type": "string" },
+        "fee_wei": { "type": "string" },
+        "pixels": { "type": "number" },
+        "pipeline": { "type": "string" },
+        "model_id": { "type": "string" },
+        "gateway_request_id": { "type": "string" },
+        "eth_usd_price": { "type": "string" },
+        "eth_usd_round_id": { "type": "string" },
+        "eth_usd_observed_at": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/usage-ingest.schema.json
+++ b/contracts/billing-provider-protocol/usage-ingest.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/usage-ingest.schema.json",
+  "title": "BPP ⑥ usage ingest",
+  "description": "Neutral usage payload pushed provider → NaaP at POST {NAAP_METRICS_URL}/api/v1/metrics/ingest. The authoritative cross-provider usage path (NOT validate). OM-backed providers must map their internal meters into this shape; raw OpenMeter field names MUST NOT appear here.",
+  "type": "object",
+  "required": ["providerSlug", "accountId", "window"],
+  "additionalProperties": false,
+  "$defs": {
+    "capabilityUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tickets": { "type": "integer", "minimum": 0 },
+        "networkFeeUsdMicros": { "type": "string", "pattern": "^[0-9]+$" }
+      }
+    }
+  },
+  "properties": {
+    "providerSlug": { "type": "string", "minLength": 1 },
+    "accountId": { "type": "string", "minLength": 1 },
+    "appId": { "type": "string", "minLength": 1 },
+    "window": {
+      "type": "object",
+      "required": ["from", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "from": { "type": "string", "format": "date-time" },
+        "to": { "type": "string", "format": "date-time" }
+      }
+    },
+    "sessions": { "type": "integer", "minimum": 0 },
+    "tickets": { "type": "integer", "minimum": 0 },
+    "feeWei": { "type": "string", "pattern": "^[0-9]+$" },
+    "networkFeeUsdMicros": {
+      "type": "string",
+      "pattern": "^[0-9]+$",
+      "description": "USD micros; for OM-backed providers that meter in fiat."
+    },
+    "byCapability": {
+      "type": "object",
+      "description": "Keyed by generic capability id <pipeline>:<model>.",
+      "additionalProperties": { "$ref": "#/$defs/capabilityUsage" }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/validate.schema.json
+++ b/contracts/billing-provider-protocol/validate.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/validate.schema.json",
+  "title": "BPP ② validate response",
+  "description": "Provider-neutral response for resolving an opaque key into identity, capabilities, billing account, and an optional provider-issued signer session. Exercised by NaaP through the BillingProviderAdapter. MUST NOT leak provider-internal metering identifiers (see provider-internal-openmeter.schema.json).",
+  "type": "object",
+  "required": ["valid"],
+  "additionalProperties": false,
+  "properties": {
+    "valid": {
+      "type": "boolean",
+      "description": "Whether the presented key is valid."
+    },
+    "user": {
+      "type": "object",
+      "required": ["sub"],
+      "additionalProperties": false,
+      "properties": {
+        "sub": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable subject identifier for the resolved user."
+        }
+      }
+    },
+    "billing_account": {
+      "type": "object",
+      "required": ["id", "providerSlug", "billingMode"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "providerSlug": { "type": "string", "minLength": 1 },
+        "billingMode": { "type": "string", "enum": ["delegated", "prepay"] }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "Either the wildcard [\"*\"] or a list of generic capability ids in the form <pipeline>:<model> or tool:<name>.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "quota": {
+      "description": "Remaining quota, or null when not metered/unbounded.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["remaining"],
+          "additionalProperties": false,
+          "properties": {
+            "remaining": { "type": "number" },
+            "resetAt": { "type": "string", "format": "date-time" }
+          }
+        },
+        { "type": "null" }
+      ]
+    },
+    "subscriptionRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "OPTIONAL neutral opaque subscription pointer. The provider decides its meaning; it MUST NOT encode a provider-internal identifier name (e.g. openmeter_subscription_id)."
+    },
+    "signerSession": {
+      "type": "object",
+      "required": ["url", "headers"],
+      "additionalProperties": false,
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "headers": {
+          "type": "object",
+          "description": "Opaque-to-apps headers, e.g. { \"Authorization\": \"Bearer <provider-token>\" }.",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/validate.schema.json
+++ b/contracts/billing-provider-protocol/validate.schema.json
@@ -62,17 +62,35 @@
       "description": "OPTIONAL neutral opaque subscription pointer. The provider decides its meaning; it MUST NOT encode a provider-internal identifier name (e.g. openmeter_subscription_id)."
     },
     "signerSession": {
-      "type": "object",
-      "required": ["url", "headers"],
-      "additionalProperties": false,
-      "properties": {
-        "url": { "type": "string", "format": "uri" },
-        "headers": {
+      "description": "OPTIONAL provider-issued signer session, opaque to apps. A provider returns EXACTLY ONE of two neutral forms: (a) a fetchable endpoint {url, headers}, or (b) a token bundle {accessToken, tokenType?, expiresIn?, scope?} (the shape the BillingProviderAdapter / NAAP-C front door return). Each form forbids additional properties, so the two are mutually exclusive.",
+      "oneOf": [
+        {
           "type": "object",
-          "description": "Opaque-to-apps headers, e.g. { \"Authorization\": \"Bearer <provider-token>\" }.",
-          "additionalProperties": { "type": "string" }
+          "title": "Endpoint form",
+          "required": ["url", "headers"],
+          "additionalProperties": false,
+          "properties": {
+            "url": { "type": "string", "format": "uri" },
+            "headers": {
+              "type": "object",
+              "description": "Opaque-to-apps headers, e.g. { \"Authorization\": \"Bearer <provider-token>\" }.",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "Token-bundle form",
+          "required": ["accessToken"],
+          "additionalProperties": false,
+          "properties": {
+            "accessToken": { "type": "string", "minLength": 1 },
+            "tokenType": { "type": "string", "minLength": 1 },
+            "expiresIn": { "type": "integer", "minimum": 0 },
+            "scope": { "type": "string" }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,8 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.0.18",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^2.1.1",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.16.0",
         "eslint-config-next": "15.5.12",


### PR DESCRIPTION
**DO NOT MERGE — gated by D0 (preview→staging→main + INV-1).**

## Cross-repo coordination
| Field | Value |
|---|---|
| **PR id** | C0 |
| **Repo** | NaaP |
| **Depends-on** | — (none; foundational contracts) |
| **Feature flag** | n/a — pure additive contracts + test-only code (no runtime wiring) |
| **Default** | OFF (nothing imported into runtime paths) |

## What
Adds the **Billing Provider Protocol (BPP)** JSON Schemas, a stub provider, and an ajv-based conformance suite.

- `contracts/billing-provider-protocol/*.schema.json` — account, plans, usage-ingest, discovery, curated-list, validate, provider-internal-openmeter
- `contracts/README.md`
- `apps/web-next/src/lib/billing/bpp/{conformance.ts,stub-provider.ts,conformance.test.ts}`

## Merge-safety
- **Additive only** — new contract files + test-only TS; no existing runtime code modified.
- **Flag-OFF no-op for other repos** — schemas are not imported by any shipping route.
- **INV-1 green** — conformance suite validates the stub provider against the schemas.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Billing Provider Protocol (BPP) JSON Schemas, including validate, plans, account, usage ingest, discovery, and curated list (with optional token bundle).
  * Extended BPP conformance to verify `signerSession` shape rules and detect internal-field leakage across seams.
  * Added identity checks to ensure billing account references match account payloads.
* **Tests**
  * Expanded conformance test coverage with new negative-case scenarios.
* **Documentation**
  * Updated BPP documentation with seam isolation rules and schema evolution/versioning guidance.
* **Chores**
  * Added JSON Schema validation tooling to support conformance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->