### PR TITLE
feat(billing): pymthouse provider env/seed verifier (NAAP-0)

### DIFF
--- a/apps/web-next/.env.local.example
+++ b/apps/web-next/.env.local.example
@@ -165,7 +165,7 @@ FACADE_USE_STUBS=true
 # PYMTHOUSE_PUBLIC_CLIENT_ID=app_...
 # PYMTHOUSE_M2M_CLIENT_ID=m2m_...
 # PYMTHOUSE_M2M_CLIENT_SECRET=...
-# PYMTHOUSE_BASE_URL=http://localhost:3001   # optional; marketplace link origin when unset elsewhere
+# PMTHOUSE_BASE_URL=http://localhost:3001   # optional; marketplace link origin when unset elsewhere
 #
 # Staging (pymthouse) reference — issuer origin https://staging.pymthouse.com.
 # Issuer URL is the OIDC mount; the SDK resolves …/.well-known/openid-configuration from it.
@@ -180,7 +180,7 @@ FACADE_USE_STUBS=true
 #   {NEXT_PUBLIC_APP_URL}/login
 # PymtHouse redirects here with ?iss=&target_link_uri=&login_hint= ; NAAP validates iss/origin and
 # returns the user to PymtHouse /oidc/device after sign-in. Requires PYMTHOUSE_ISSUER_URL (and
-# PYMTHOUSE_BASE_URL only if you need a separate site origin from the issuer for marketplace URLs).
+# PMTHOUSE_BASE_URL only if you need a separate site origin from the issuer for marketplace URLs).
 
 # ─── Playwright E2E (optional) ───────────────────────────────────────────
 # Used by tests/auth.setup.ts and tests/auth-flows.spec.ts for logged-in journeys.

--- a/apps/web-next/.env.local.example
+++ b/apps/web-next/.env.local.example
@@ -167,6 +167,15 @@ FACADE_USE_STUBS=true
 # PYMTHOUSE_M2M_CLIENT_SECRET=...
 # PYMTHOUSE_BASE_URL=http://localhost:3001   # optional; marketplace link origin when unset elsewhere
 #
+# Staging (pymthouse) reference — issuer origin https://staging.pymthouse.com.
+# Issuer URL is the OIDC mount; the SDK resolves …/.well-known/openid-configuration from it.
+# The public + M2M client id are the same public app_… id. The M2M client SECRET is
+# provided ONLY via the PYMTHOUSE_M2M_CLIENT_SECRET env/secret store — NEVER commit it.
+# PYMTHOUSE_ISSUER_URL=https://staging.pymthouse.com/api/v1/oidc
+# PYMTHOUSE_PUBLIC_CLIENT_ID=app_2d89999406f9be57dd0233de
+# PYMTHOUSE_M2M_CLIENT_ID=app_2d89999406f9be57dd0233de
+# PYMTHOUSE_M2M_CLIENT_SECRET=   # set in the secret store only — do not write the value here
+#
 # Device-flow third-party initiate login: register initiate_login_uri in PymtHouse app settings as
 #   {NEXT_PUBLIC_APP_URL}/login
 # PymtHouse redirects here with ?iss=&target_link_uri=&login_hint= ; NAAP validates iss/origin and

--- a/apps/web-next/src/lib/billing/provider-config.test.ts
+++ b/apps/web-next/src/lib/billing/provider-config.test.ts
@@ -1,0 +1,92 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { BILLING_PROVIDERS } from '../../../../../packages/database/src/billing-providers';
+import {
+  PYMTHOUSE_PROVIDER_SLUG,
+  PYMTHOUSE_STAGING_ISSUER_ORIGIN,
+  PYMTHOUSE_STAGING_CLIENT_ID,
+  PYMTHOUSE_ENV_VARS,
+  verifyPymthouseEnv,
+  logPymthouseEnvStatus,
+  findPymthouseSeed,
+  isPymthouseSeedEnabled,
+} from './provider-config';
+
+describe('NAAP-0 — BillingProvider seed verify', () => {
+  it('seeds BillingProvider{slug:pymthouse, enabled:true}', () => {
+    const seed = findPymthouseSeed(BILLING_PROVIDERS);
+    expect(seed).toBeDefined();
+    expect(seed?.slug).toBe(PYMTHOUSE_PROVIDER_SLUG);
+    expect(seed?.enabled).toBe(true);
+    expect(isPymthouseSeedEnabled(BILLING_PROVIDERS)).toBe(true);
+  });
+});
+
+describe('NAAP-0 — PYMTHOUSE_* env wiring', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const name of PYMTHOUSE_ENV_VARS) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of PYMTHOUSE_ENV_VARS) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  });
+
+  it('reports all vars missing and not configured when env is empty', () => {
+    const status = verifyPymthouseEnv();
+    expect(status.configured).toBe(false);
+    expect(status.missing).toEqual([...PYMTHOUSE_ENV_VARS]);
+    expect(Object.values(status.present).every((v) => v === false)).toBe(true);
+  });
+
+  it('reports configured + staging match for valid staging wiring', () => {
+    process.env.PYMTHOUSE_ISSUER_URL = `${PYMTHOUSE_STAGING_ISSUER_ORIGIN}/api/v1/oidc`;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_SECRET = 'test-only-secret-not-real';
+
+    const status = verifyPymthouseEnv();
+    expect(status.configured).toBe(true);
+    expect(status.missing).toEqual([]);
+    expect(status.issuerMatchesStaging).toBe(true);
+    expect(status.clientIdMatchesStaging).toBe(true);
+  });
+
+  it('flags only the missing secret when the rest is present', () => {
+    process.env.PYMTHOUSE_ISSUER_URL = `${PYMTHOUSE_STAGING_ISSUER_ORIGIN}/api/v1/oidc`;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+
+    const status = verifyPymthouseEnv();
+    expect(status.configured).toBe(false);
+    expect(status.missing).toEqual(['PYMTHOUSE_M2M_CLIENT_SECRET']);
+    expect(status.present.PYMTHOUSE_M2M_CLIENT_SECRET).toBe(false);
+  });
+
+  it('NEVER leaks the secret value via the structured log line', () => {
+    const secret = 'super-secret-value-should-never-appear';
+    process.env.PYMTHOUSE_ISSUER_URL = `${PYMTHOUSE_STAGING_ISSUER_ORIGIN}/api/v1/oidc`;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_SECRET = secret;
+
+    const lines: string[] = [];
+    const status = logPymthouseEnvStatus({ info: (m) => lines.push(m) }, 'test-correlation-id');
+
+    expect(status.configured).toBe(true);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('test-correlation-id');
+    expect(lines[0]).toContain('"present"');
+    // The secret value must NOT appear anywhere in the emitted log line.
+    expect(lines[0]).not.toContain(secret);
+  });
+});

--- a/apps/web-next/src/lib/billing/provider-config.ts
+++ b/apps/web-next/src/lib/billing/provider-config.ts
@@ -3,8 +3,8 @@
  *
  * Server-only. Reports the *presence* of the `PYMTHOUSE_*` env vars and whether
  * the configured issuer/client match the staging reference values. It NEVER
- * reads, returns, or logs the M2M client secret value — only a boolean
- * indicating whether it is set.
+ * returns or logs the M2M client secret value (presence is computed without
+ * exposing it) — only a boolean indicating whether it is set.
  */
 
 import 'server-only';

--- a/apps/web-next/src/lib/billing/provider-config.ts
+++ b/apps/web-next/src/lib/billing/provider-config.ts
@@ -1,0 +1,141 @@
+/**
+ * NAAP-0 — pymthouse BillingProvider env wiring + seed verification.
+ *
+ * Server-only. Reports the *presence* of the `PYMTHOUSE_*` env vars and whether
+ * the configured issuer/client match the staging reference values. It NEVER
+ * reads, returns, or logs the M2M client secret value — only a boolean
+ * indicating whether it is set.
+ */
+
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import {
+  isPymthouseConfigured,
+  getPymthouseIssuerUrlFromEnv,
+  getPymthousePublicClientIdFromEnv,
+} from '@pymthouse/builder-sdk/config';
+
+export const PYMTHOUSE_PROVIDER_SLUG = 'pymthouse';
+
+/**
+ * Public (non-secret) staging reference values from the execution handover.
+ * The OIDC issuer origin and the public/M2M client id are NOT secrets. The M2M
+ * client *secret* is provided ONLY via `PYMTHOUSE_M2M_CLIENT_SECRET` and is never
+ * stored here.
+ */
+export const PYMTHOUSE_STAGING_ISSUER_ORIGIN = 'https://staging.pymthouse.com';
+export const PYMTHOUSE_STAGING_CLIENT_ID = 'app_2d89999406f9be57dd0233de';
+
+/** Env vars the pymthouse adapter requires (secret listed last, never logged). */
+export const PYMTHOUSE_ENV_VARS = [
+  'PYMTHOUSE_ISSUER_URL',
+  'PYMTHOUSE_PUBLIC_CLIENT_ID',
+  'PYMTHOUSE_M2M_CLIENT_ID',
+  'PYMTHOUSE_M2M_CLIENT_SECRET',
+] as const;
+export type PymthouseEnvVar = (typeof PYMTHOUSE_ENV_VARS)[number];
+
+export interface PymthouseEnvStatus {
+  /** True when all required vars are present (delegates to the SDK). */
+  configured: boolean;
+  /** Presence booleans only — values (especially the secret) are never exposed. */
+  present: Record<PymthouseEnvVar, boolean>;
+  /** Names of the missing required vars. */
+  missing: PymthouseEnvVar[];
+  /** Configured issuer origin matches the staging reference. */
+  issuerMatchesStaging: boolean;
+  /** Configured public client id matches the staging reference. */
+  clientIdMatchesStaging: boolean;
+}
+
+function isPresent(name: PymthouseEnvVar): boolean {
+  const value = process.env[name];
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** Inspect `PYMTHOUSE_*` env wiring without ever touching the secret value. */
+export function verifyPymthouseEnv(): PymthouseEnvStatus {
+  const present = PYMTHOUSE_ENV_VARS.reduce(
+    (acc, name) => {
+      acc[name] = isPresent(name);
+      return acc;
+    },
+    {} as Record<PymthouseEnvVar, boolean>,
+  );
+
+  const missing = PYMTHOUSE_ENV_VARS.filter((name) => !present[name]);
+
+  let issuerMatchesStaging = false;
+  const issuer = getPymthouseIssuerUrlFromEnv();
+  if (issuer) {
+    try {
+      issuerMatchesStaging = new URL(issuer).origin === PYMTHOUSE_STAGING_ISSUER_ORIGIN;
+    } catch {
+      issuerMatchesStaging = false;
+    }
+  }
+
+  const clientIdMatchesStaging =
+    getPymthousePublicClientIdFromEnv() === PYMTHOUSE_STAGING_CLIENT_ID;
+
+  return {
+    configured: isPymthouseConfigured(),
+    present,
+    missing,
+    issuerMatchesStaging,
+    clientIdMatchesStaging,
+  };
+}
+
+/** Minimal structured logger surface (console satisfies it). */
+export interface StructuredLogger {
+  info?: (message: string) => void;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Emit a single structured log line describing the pymthouse env wiring.
+ * Logs presence booleans only — never the secret value. Returns the status so
+ * callers (e.g. a CI presence check) can assert on it.
+ */
+export function logPymthouseEnvStatus(
+  logger: StructuredLogger = console,
+  correlationId: string = randomUUID(),
+): PymthouseEnvStatus {
+  const status = verifyPymthouseEnv();
+  const line = JSON.stringify({
+    level: status.configured ? 'info' : 'warn',
+    event: 'billing.provider.pymthouse.env_verify',
+    correlationId,
+    configured: status.configured,
+    present: status.present,
+    missing: status.missing,
+    issuerMatchesStaging: status.issuerMatchesStaging,
+    clientIdMatchesStaging: status.clientIdMatchesStaging,
+  });
+  const emit = status.configured
+    ? (logger.info ?? logger.log)
+    : (logger.warn ?? logger.log);
+  emit?.call(logger, line);
+  return status;
+}
+
+/** Minimal shape of a seeded `BillingProvider` row (from `@naap/database`). */
+export interface SeedProviderLike {
+  readonly slug: string;
+  readonly enabled: boolean;
+}
+
+/** Find the pymthouse entry in a seed/catalog list. */
+export function findPymthouseSeed(
+  providers: readonly SeedProviderLike[],
+): SeedProviderLike | undefined {
+  return providers.find((p) => p.slug === PYMTHOUSE_PROVIDER_SLUG);
+}
+
+/** True when the seed declares `BillingProvider{slug:pymthouse, enabled:true}`. */
+export function isPymthouseSeedEnabled(providers: readonly SeedProviderLike[]): boolean {
+  return findPymthouseSeed(providers)?.enabled === true;
+}


### PR DESCRIPTION
**DO NOT MERGE — gated by D0 (preview→staging→main + INV-1).**

## Cross-repo coordination
| Field | Value |
|---|---|
| **PR id** | NAAP-0 |
| **Repo** | NaaP |
| **Depends-on** | — (none) |
| **Feature flag** | n/a — config/verification helper + test-only; not wired into runtime paths |
| **Default** | OFF |

## What
Verifies the **pymthouse `BillingProvider`** environment wiring + seed configuration.

- `apps/web-next/src/lib/billing/provider-config.ts` — env/seed verifier
- `apps/web-next/src/lib/billing/provider-config.test.ts`
- `apps/web-next/.env.local.example` — documents required pymthouse env vars

## Merge-safety
- **Additive only** — new verifier + test; `.env.local.example` is documentation.
- **Flag-OFF no-op for other repos** — no shipping route imports this verifier.
- **INV-1 green** — unit tests cover env/seed validation.

Made with [Cursor](https://cursor.com)