### PR TITLE
feat(billing): billing provider adapter SPI + registry (NAAP-A)

### DIFF
--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.test.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.test.ts
@@ -1,0 +1,188 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { AuthUser } from '@naap/types';
+
+import { GET, POST } from './route';
+import { AdapterNotImplementedError } from '@/lib/billing/adapter';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+}));
+
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({
+  validateSession: (...a: unknown[]) => validateSession(...a),
+}));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
+
+function authUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'u@example.com',
+    displayName: null,
+    avatarUrl: null,
+    address: null,
+    roles: [],
+    permissions: [],
+    ...overrides,
+  };
+}
+
+function makeAdapter(overrides: Record<string, unknown> = {}) {
+  return {
+    slug: 'pymthouse',
+    isConfigured: vi.fn(() => true),
+    validate: vi.fn(),
+    getPlans: vi.fn(),
+    getUsageForExternalUser: vi.fn(async () => ({ requestCount: 1 })),
+    getAppUsage: vi.fn(async () => ({ totals: { requestCount: 0 } })),
+    mintSignerSession: vi.fn(async () => ({
+      accessToken: 'tok-abc',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      scope: 'sign:job',
+    })),
+    receiveCuratedOrchestrators: vi.fn(),
+    getCapabilityManifest: vi.fn(),
+    ...overrides,
+  };
+}
+
+function req(
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+): NextRequest {
+  return new NextRequest(url, {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', ...(init?.headers ?? {}) },
+  });
+}
+
+function params(provider: string, path: string[]) {
+  return { params: Promise.resolve({ provider, path }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue(authUser());
+  getBillingProviderAdapter.mockReturnValue(makeAdapter());
+});
+
+describe('generic /api/v1/billing/{provider}/* — flag OFF (zero regression)', () => {
+  it('is a no-op 404 when provider_adapters is OFF', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(404);
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+    expect(validateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('generic billing route — flag ON', () => {
+  it('404s for an unknown provider', async () => {
+    getBillingProviderAdapter.mockReturnValue(undefined);
+    const res = await GET(
+      req('http://localhost/api/v1/billing/nope/usage'),
+      params('nope', ['usage']),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('404s for an invalid provider slug', async () => {
+    const res = await GET(
+      req('http://localhost/api/v1/billing/Bad_Slug/usage'),
+      params('Bad_Slug', ['usage']),
+    );
+    expect(res.status).toBe(404);
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+  });
+
+  it('401 without an auth token', async () => {
+    const res = await GET(
+      new NextRequest('http://localhost/api/v1/billing/pymthouse/usage'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('delegates usage scope=me to the adapter', async () => {
+    const adapter = makeAdapter();
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage?scope=me'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(200);
+    expect(adapter.getUsageForExternalUser).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'user-1' }),
+    );
+  });
+
+  it('403 for app scope when not system:admin', async () => {
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage?scope=app'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('delegates token mint to the adapter and returns the session', async () => {
+    const adapter = makeAdapter();
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await POST(
+      req('http://localhost/api/v1/billing/pymthouse/token', { method: 'POST' }),
+      params('pymthouse', ['token']),
+    );
+    expect(res.status).toBe(200);
+    expect(adapter.mintSignerSession).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'user-1' }),
+    );
+    const json = await res.json();
+    expect(json.data.access_token).toBe('tok-abc');
+  });
+
+  it('maps AdapterNotImplementedError to 501', async () => {
+    const adapter = makeAdapter({
+      mintSignerSession: vi.fn(async () => {
+        throw new AdapterNotImplementedError('pymthouse', 'mintSignerSession');
+      }),
+    });
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await POST(
+      req('http://localhost/api/v1/billing/pymthouse/token', { method: 'POST' }),
+      params('pymthouse', ['token']),
+    );
+    expect(res.status).toBe(501);
+  });
+
+  it('404s for an unsupported operation', async () => {
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/unknown-op'),
+      params('pymthouse', ['unknown-op']),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('400 when the provider is not configured', async () => {
+    getBillingProviderAdapter.mockReturnValue(makeAdapter({ isConfigured: vi.fn(() => false) }));
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
@@ -68,11 +68,19 @@ function stripCryptoUnitFields(value: unknown): unknown {
   return out;
 }
 
-/** Strict YYYY-MM-DD or ISO 8601 date; returns null when invalid/empty. */
+/**
+ * Strict calendar-date (YYYY-MM-DD) or ISO 8601 date-time; returns null when
+ * invalid/empty. The explicit format gate rejects the permissive/ambiguous
+ * inputs `Date.parse` would otherwise accept, keeping filtering consistent
+ * across clients and environments.
+ */
+const ISO_DATE_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
 function parseDateParam(raw: string | null): string | null {
   if (raw == null) return null;
   const v = raw.trim();
   if (v === '') return null;
+  if (!ISO_DATE_RE.test(v)) return null;
   const ts = Date.parse(v);
   if (Number.isNaN(ts)) return null;
   return v;
@@ -96,8 +104,8 @@ function mapAdapterError(
     log('warn', event, { provider, correlationId, reason: 'not_implemented', method: e.method });
     return error('NOT_IMPLEMENTED', 'Operation not supported by this provider', 501);
   }
-  const message = e instanceof Error ? e.message : 'Unknown error';
-  log('error', event, { provider, correlationId, message });
+  const errorType = e instanceof Error ? e.name : 'UnknownError';
+  log('error', event, { provider, correlationId, errorType });
   return errors.serviceUnavailable('Billing provider request failed');
 }
 
@@ -257,7 +265,7 @@ async function resolve(
   } catch (err) {
     log('error', 'billing.adapter.unexpected', {
       correlationId,
-      message: err instanceof Error ? err.message : 'unknown',
+      errorType: err instanceof Error ? err.name : 'UnknownError',
     });
     return noStore(errors.internal('Billing request failed'));
   }

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
@@ -240,14 +240,18 @@ async function resolve(
       log('warn', 'billing.adapter.unknown_provider', { provider, correlationId });
       return noStore(errors.notFound('Provider'));
     }
-    if (!adapter.isConfigured()) {
-      return noStore(errors.badRequest(`Provider "${provider}" is not configured`));
-    }
 
+    // Authenticate before probing provider configuration so unauthenticated
+    // callers cannot distinguish "configured" from "not configured" (avoids
+    // leaking provider config state and doing work before rejecting).
     const token = getAuthToken(request);
     if (!token) return noStore(errors.unauthorized('No auth token provided'));
     const sessionUser = await validateSession(token);
     if (!sessionUser) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    if (!adapter.isConfigured()) {
+      return noStore(errors.badRequest(`Provider "${provider}" is not configured`));
+    }
 
     const op = (path?.[0] ?? '').toLowerCase();
     const routeCtx: RouteCtx = {

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
@@ -1,0 +1,272 @@
+/**
+ * Generic billing provider routing (NAAP-A).
+ *
+ *   GET  /api/v1/billing/{provider}/usage
+ *   POST /api/v1/billing/{provider}/token
+ *
+ * Delegates to the BillingProviderAdapter registry instead of any hardcoded
+ * provider. Gated behind the `provider_adapters` flag (default OFF): when OFF this
+ * route is a no-op (404), so the existing /api/v1/billing/pymthouse/* routes are
+ * the only billing surface and their behavior is unchanged. Zero regression.
+ *
+ * Never logs secrets/tokens/PII — only request metadata + correlation id.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { validateSession } from '@/lib/api/auth';
+import { validateCSRF } from '@/lib/api/csrf';
+import { enforceRateLimit } from '@/lib/api/rate-limit';
+import { error, errors, getAuthToken, success } from '@/lib/api/response';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { AdapterNotImplementedError, type BillingProviderAdapter } from '@/lib/billing/adapter';
+import { getBillingProviderAdapter } from '@/lib/billing/registry';
+
+const PROVIDER_ADAPTERS_FLAG = 'provider_adapters';
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_PER_USER = 30;
+const PROVIDER_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+type Params = { params: Promise<{ provider: string; path?: string[] }> };
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(
+  level: 'info' | 'warn' | 'error',
+  event: string,
+  fields: Record<string, unknown>,
+): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function isSystemAdmin(roles: string[] | undefined): boolean {
+  return Boolean(roles?.includes('system:admin'));
+}
+
+/** Drop crypto-unit fields (wei/eth/gwei) so raw on-chain amounts are not exposed. */
+function stripCryptoUnitFields(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripCryptoUnitFields);
+  if (!value || typeof value !== 'object') return value;
+  const units = ['wei', 'eth', 'gwei'];
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const lower = key.toLowerCase();
+    if (units.some((u) => lower === u || lower.endsWith(u))) continue;
+    out[key] = stripCryptoUnitFields(entry);
+  }
+  return out;
+}
+
+/** Strict YYYY-MM-DD or ISO 8601 date; returns null when invalid/empty. */
+function parseDateParam(raw: string | null): string | null {
+  if (raw == null) return null;
+  const v = raw.trim();
+  if (v === '') return null;
+  const ts = Date.parse(v);
+  if (Number.isNaN(ts)) return null;
+  return v;
+}
+
+/** Current UTC calendar-month [from, to] as ISO strings. */
+function currentUtcMonthBounds(): { startDate: string; endDate: string } {
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}
+
+function mapAdapterError(
+  e: unknown,
+  provider: string,
+  correlationId: string,
+  event: string,
+): NextResponse {
+  if (e instanceof AdapterNotImplementedError) {
+    log('warn', event, { provider, correlationId, reason: 'not_implemented', method: e.method });
+    return error('NOT_IMPLEMENTED', 'Operation not supported by this provider', 501);
+  }
+  const message = e instanceof Error ? e.message : 'Unknown error';
+  log('error', event, { provider, correlationId, message });
+  return errors.serviceUnavailable('Billing provider request failed');
+}
+
+interface RouteCtx {
+  request: NextRequest;
+  provider: string;
+  adapter: BillingProviderAdapter;
+  correlationId: string;
+  user: { id: string; email?: string | null; roles?: string[] };
+}
+
+async function handleUsage(ctx: RouteCtx): Promise<NextResponse> {
+  const { request, provider, adapter, correlationId, user } = ctx;
+  const sp = request.nextUrl.searchParams;
+
+  const scope = (sp.get('scope') ?? 'me').trim().toLowerCase();
+  if (scope !== 'me' && scope !== 'app') {
+    return noStore(errors.badRequest('Invalid scope; use me or app'));
+  }
+
+  const startRaw = sp.get('startDate');
+  const endRaw = sp.get('endDate');
+  const hasStart = startRaw != null && startRaw.trim() !== '';
+  const hasEnd = endRaw != null && endRaw.trim() !== '';
+  if (hasStart !== hasEnd) {
+    return noStore(errors.badRequest('startDate and endDate must both be set or both omitted'));
+  }
+
+  let startDate: string;
+  let endDate: string;
+  if (hasStart) {
+    const s = parseDateParam(startRaw);
+    const e = parseDateParam(endRaw);
+    if (!s || !e) return noStore(errors.badRequest('Invalid startDate or endDate'));
+    if (Date.parse(s) > Date.parse(e)) {
+      return noStore(errors.badRequest('startDate must be <= endDate'));
+    }
+    startDate = s;
+    endDate = e;
+  } else {
+    ({ startDate, endDate } = currentUtcMonthBounds());
+  }
+
+  if (scope === 'me') {
+    try {
+      const body = await adapter.getUsageForExternalUser({
+        externalUserId: user.id,
+        startDate,
+        endDate,
+      });
+      log('info', 'billing.adapter.usage', { provider, correlationId, scope, status: 200 });
+      return noStore(success(stripCryptoUnitFields(body)));
+    } catch (e) {
+      return noStore(mapAdapterError(e, provider, correlationId, 'billing.adapter.usage'));
+    }
+  }
+
+  if (!isSystemAdmin(user.roles)) {
+    return noStore(errors.forbidden('App-wide usage requires system:admin'));
+  }
+
+  const groupByRaw = sp.get('groupBy')?.trim();
+  let groupBy: 'none' | 'user' | undefined;
+  if (groupByRaw) {
+    if (groupByRaw !== 'none' && groupByRaw !== 'user') {
+      return noStore(errors.badRequest('groupBy must be none or user'));
+    }
+    groupBy = groupByRaw;
+  }
+  const userId = sp.get('userId')?.trim() || undefined;
+
+  try {
+    const usage = await adapter.getAppUsage({ startDate, endDate, groupBy, userId });
+    log('info', 'billing.adapter.usage', { provider, correlationId, scope, status: 200 });
+    return noStore(success(stripCryptoUnitFields(usage)));
+  } catch (e) {
+    return noStore(mapAdapterError(e, provider, correlationId, 'billing.adapter.usage'));
+  }
+}
+
+async function handleToken(ctx: RouteCtx): Promise<NextResponse> {
+  const { request, provider, adapter, correlationId, user } = ctx;
+
+  const csrfError = validateCSRF(request);
+  if (csrfError) return csrfError;
+
+  const rateLimited = enforceRateLimit(request, {
+    keyPrefix: `billing-token:${provider}:${user.id}`,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    maxRequests: RATE_LIMIT_MAX_PER_USER,
+  });
+  if (rateLimited) return rateLimited;
+
+  try {
+    const session = await adapter.mintSignerSession({
+      externalUserId: user.id,
+      email: user.email ?? undefined,
+    });
+    log('info', 'billing.adapter.token', { provider, correlationId, status: 200 });
+    return noStore(
+      success({
+        access_token: session.accessToken,
+        token_type: session.tokenType,
+        expires_in: session.expiresIn,
+        scope: session.scope,
+      }),
+    );
+  } catch (e) {
+    return noStore(mapAdapterError(e, provider, correlationId, 'billing.adapter.token'));
+  }
+}
+
+async function resolve(
+  request: NextRequest,
+  ctx: Params,
+  method: 'GET' | 'POST',
+): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    // Flag OFF → behave as if this route does not exist (no-op; zero regression).
+    if (!(await isFeatureEnabled(PROVIDER_ADAPTERS_FLAG))) {
+      return noStore(errors.notFound('Resource'));
+    }
+
+    const { provider, path } = await ctx.params;
+    if (!PROVIDER_SLUG_RE.test(provider)) {
+      return noStore(errors.notFound('Provider'));
+    }
+
+    const adapter = getBillingProviderAdapter(provider);
+    if (!adapter) {
+      log('warn', 'billing.adapter.unknown_provider', { provider, correlationId });
+      return noStore(errors.notFound('Provider'));
+    }
+    if (!adapter.isConfigured()) {
+      return noStore(errors.badRequest(`Provider "${provider}" is not configured`));
+    }
+
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const sessionUser = await validateSession(token);
+    if (!sessionUser) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    const op = (path?.[0] ?? '').toLowerCase();
+    const routeCtx: RouteCtx = {
+      request,
+      provider,
+      adapter,
+      correlationId,
+      user: { id: sessionUser.id, email: sessionUser.email, roles: sessionUser.roles },
+    };
+
+    if (method === 'GET' && op === 'usage') return handleUsage(routeCtx);
+    if (method === 'POST' && op === 'token') return handleToken(routeCtx);
+
+    return noStore(errors.notFound('Billing operation'));
+  } catch (err) {
+    log('error', 'billing.adapter.unexpected', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Billing request failed'));
+  }
+}
+
+export async function GET(request: NextRequest, ctx: Params): Promise<NextResponse> {
+  return resolve(request, ctx, 'GET');
+}
+
+export async function POST(request: NextRequest, ctx: Params): Promise<NextResponse> {
+  return resolve(request, ctx, 'POST');
+}

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -26,11 +26,27 @@ export interface ValidateResult {
   signerSession?: SignerSession;
 }
 
-/** Provider-issued signer session, opaque to applications. */
-export interface SignerSession {
-  url?: string;
-  headers?: Record<string, string>;
-  accessToken?: string;
+/**
+ * Provider-issued signer session, opaque to applications.
+ *
+ * Mirrors the C0 `validate.schema.json` `signerSession` oneOf: a provider returns
+ * EXACTLY ONE of two neutral forms — an endpoint to fetch, or a token bundle.
+ * Modelling them as a discriminated union (rather than one bag of optional
+ * fields) keeps the two mutually exclusive, so a value that type-checks here also
+ * passes BPP conformance. The token-bundle form is what the reference provider
+ * (pymthouse) and the NAAP-C validation front door return.
+ */
+export type SignerSession = SignerSessionEndpoint | SignerSessionToken;
+
+/** Endpoint form: a fetchable URL plus opaque-to-apps headers. */
+export interface SignerSessionEndpoint {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/** Token-bundle form: a provider-issued access token (the shape NAAP-C returns). */
+export interface SignerSessionToken {
+  accessToken: string;
   tokenType?: string;
   expiresIn?: number;
   scope?: string;
@@ -102,8 +118,11 @@ export interface BillingProviderAdapter {
   /** BPP usage/telemetry — app-wide usage (admin scope). */
   getAppUsage(input: AppUsageInput): Promise<unknown>;
 
-  /** BPP mintSignerSession — provider-issued, opaque to apps. */
-  mintSignerSession(input: MintSignerSessionInput): Promise<SignerSession>;
+  /**
+   * BPP mintSignerSession — provider-issued, opaque to apps. Always the
+   * token-bundle form (the `/token` endpoint serializes its fields directly).
+   */
+  mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken>;
 
   /** BPP ⑧ — receive a curated orchestrator list for a plan. */
   receiveCuratedOrchestrators(plan: string, list: CuratedOrchestrator[]): Promise<void>;

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -1,0 +1,125 @@
+/**
+ * Billing Provider Adapter SPI (NAAP-A).
+ *
+ * NaaP reaches every billing provider ONLY through this interface + the registry
+ * (`registry.ts`). NaaP code must never import a provider client directly — the
+ * reference provider (pymthouse) is wrapped by `PymthouseAdapter` behind this
+ * SPI. This is the NaaP-side surface of the Billing Provider Protocol (BPP, C0).
+ *
+ * Methods that a given provider has not implemented yet throw
+ * `AdapterNotImplementedError` (HTTP 501-equivalent) rather than guessing.
+ */
+
+/** BPP ② validate result (provider-neutral; mirrors validate.schema.json). */
+export interface ValidateResult {
+  valid: boolean;
+  user?: { sub: string };
+  billing_account?: {
+    id: string;
+    providerSlug: string;
+    billingMode: 'delegated' | 'prepay';
+  };
+  capabilities?: string[];
+  quota?: { remaining: number; resetAt?: string } | null;
+  /** Neutral opaque subscription pointer — never a provider-internal id name. */
+  subscriptionRef?: string;
+  signerSession?: SignerSession;
+}
+
+/** Provider-issued signer session, opaque to applications. */
+export interface SignerSession {
+  url?: string;
+  headers?: Record<string, string>;
+  accessToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  scope?: string;
+}
+
+/** BPP ④ plan. */
+export interface Plan {
+  id: string;
+  name?: string;
+  price?: { amount: number; interval: string; currency?: string };
+  bundles: Array<{
+    capability: string;
+    sla?: { uptime?: number; p95Ms?: number };
+    maxPriceWeiPerUnit?: string;
+  }>;
+}
+
+/** BPP capability manifest entry. */
+export interface Capability {
+  id: string;
+  description?: string;
+}
+
+/** Curated orchestrator (BPP ⑧). */
+export interface CuratedOrchestrator {
+  address: string;
+  capabilities: string[];
+  score?: number;
+}
+
+export interface UsageForExternalUserInput {
+  externalUserId: string;
+  startDate: string;
+  endDate: string;
+  maxEndUserIds?: number;
+}
+
+export interface AppUsageInput {
+  startDate: string;
+  endDate: string;
+  groupBy?: 'none' | 'user';
+  userId?: string;
+}
+
+export interface MintSignerSessionInput {
+  externalUserId: string;
+  email?: string;
+}
+
+/**
+ * The provider-neutral adapter SPI. Every method maps to a BPP seam.
+ */
+export interface BillingProviderAdapter {
+  /** Provider slug, e.g. "pymthouse" | "stub". */
+  readonly slug: string;
+
+  /** Whether this provider has the configuration it needs to serve requests. */
+  isConfigured(): boolean;
+
+  /** BPP ② — resolve an opaque key into identity + capabilities + signer session. */
+  validate(key: string): Promise<ValidateResult>;
+
+  /** BPP ④ — plan catalogue. */
+  getPlans(): Promise<Plan[]>;
+
+  /** BPP usage/telemetry — per-user usage rollup for one external user. */
+  getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown>;
+
+  /** BPP usage/telemetry — app-wide usage (admin scope). */
+  getAppUsage(input: AppUsageInput): Promise<unknown>;
+
+  /** BPP mintSignerSession — provider-issued, opaque to apps. */
+  mintSignerSession(input: MintSignerSessionInput): Promise<SignerSession>;
+
+  /** BPP ⑧ — receive a curated orchestrator list for a plan. */
+  receiveCuratedOrchestrators(plan: string, list: CuratedOrchestrator[]): Promise<void>;
+
+  /** BPP capability manifest — what this provider can enable. */
+  getCapabilityManifest(): Promise<Capability[]>;
+}
+
+/** Thrown when a provider has not implemented a BPP method yet. */
+export class AdapterNotImplementedError extends Error {
+  readonly providerSlug: string;
+  readonly method: string;
+  constructor(providerSlug: string, method: string) {
+    super(`Adapter "${providerSlug}" does not implement "${method}"`);
+    this.name = 'AdapterNotImplementedError';
+    this.providerSlug = providerSlug;
+    this.method = method;
+  }
+}

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -66,7 +66,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
   async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken> {
     const session = await getPmtHouseServerClient().mintSignerSessionForExternalUser({
       externalUserId: input.externalUserId,
-      email: input.email,
+      ...(input.email != null ? { email: input.email } : {}),
     });
     return {
       accessToken: session.accessToken,

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -21,7 +21,7 @@ import {
   type CuratedOrchestrator,
   type MintSignerSessionInput,
   type Plan,
-  type SignerSession,
+  type SignerSessionToken,
   type UsageForExternalUserInput,
   type ValidateResult,
 } from './adapter';
@@ -63,7 +63,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     });
   }
 
-  async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSession> {
+  async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken> {
     const session = await getPmtHouseServerClient().mintSignerSessionForExternalUser({
       externalUserId: input.externalUserId,
       email: input.email,

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Reference billing provider adapter: pymthouse (NAAP-A).
+ *
+ * Wraps the existing `getPmtHouseServerClient()` BEHIND the BillingProviderAdapter
+ * SPI. This is the ONLY place that may import the pymthouse client; all other NaaP
+ * code goes through the adapter + registry. Methods the NaaP side does not yet
+ * support (BPP validate/plans/curation/manifest — PYMT-3/5/7 pending) throw
+ * AdapterNotImplementedError rather than fabricating a response.
+ */
+
+import 'server-only';
+
+import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
+
+import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import {
+  AdapterNotImplementedError,
+  type AppUsageInput,
+  type BillingProviderAdapter,
+  type Capability,
+  type CuratedOrchestrator,
+  type MintSignerSessionInput,
+  type Plan,
+  type SignerSession,
+  type UsageForExternalUserInput,
+  type ValidateResult,
+} from './adapter';
+
+export const PYMTHOUSE_ADAPTER_SLUG = 'pymthouse';
+
+export class PymthouseAdapter implements BillingProviderAdapter {
+  readonly slug = PYMTHOUSE_ADAPTER_SLUG;
+
+  isConfigured(): boolean {
+    return isPymthouseConfigured();
+  }
+
+  async validate(_key: string): Promise<ValidateResult> {
+    // BPP ② validate is provider-side (PYMT-3) and not yet C0-shaped on the NaaP
+    // side; do not fabricate identity/capabilities here.
+    throw new AdapterNotImplementedError(this.slug, 'validate');
+  }
+
+  async getPlans(): Promise<Plan[]> {
+    throw new AdapterNotImplementedError(this.slug, 'getPlans');
+  }
+
+  async getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown> {
+    return getPmtHouseServerClient().fetchUsageForExternalUser({
+      externalUserId: input.externalUserId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      ...(input.maxEndUserIds != null ? { maxEndUserIds: input.maxEndUserIds } : {}),
+    });
+  }
+
+  async getAppUsage(input: AppUsageInput): Promise<unknown> {
+    return getPmtHouseServerClient().getUsage({
+      startDate: input.startDate,
+      endDate: input.endDate,
+      ...(input.groupBy ? { groupBy: input.groupBy } : {}),
+      ...(input.userId ? { userId: input.userId } : {}),
+    });
+  }
+
+  async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSession> {
+    const session = await getPmtHouseServerClient().mintSignerSessionForExternalUser({
+      externalUserId: input.externalUserId,
+      email: input.email,
+    });
+    return {
+      accessToken: session.accessToken,
+      tokenType: session.tokenType,
+      expiresIn: session.expiresIn,
+      scope: session.scope,
+    };
+  }
+
+  async receiveCuratedOrchestrators(
+    _plan: string,
+    _list: CuratedOrchestrator[],
+  ): Promise<void> {
+    throw new AdapterNotImplementedError(this.slug, 'receiveCuratedOrchestrators');
+  }
+
+  async getCapabilityManifest(): Promise<Capability[]> {
+    throw new AdapterNotImplementedError(this.slug, 'getCapabilityManifest');
+  }
+}

--- a/apps/web-next/src/lib/billing/registry.test.ts
+++ b/apps/web-next/src/lib/billing/registry.test.ts
@@ -1,0 +1,63 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import type { BillingProviderAdapter } from './adapter';
+import {
+  getBillingProviderAdapter,
+  hasBillingProviderAdapter,
+  listBillingProviderSlugs,
+  registerBillingProviderAdapter,
+  resetBillingProviderRegistryForTests,
+} from './registry';
+
+afterEach(() => resetBillingProviderRegistryForTests());
+
+describe('NAAP-A — billing provider adapter registry', () => {
+  it('resolves the pymthouse + stub reference adapters (≥2 providers)', () => {
+    expect(hasBillingProviderAdapter('pymthouse')).toBe(true);
+    expect(hasBillingProviderAdapter('stub')).toBe(true);
+    expect(getBillingProviderAdapter('pymthouse')?.slug).toBe('pymthouse');
+    expect(getBillingProviderAdapter('stub')?.slug).toBe('stub');
+    expect(listBillingProviderSlugs().length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns undefined for an unknown provider', () => {
+    expect(getBillingProviderAdapter('does-not-exist')).toBeUndefined();
+    expect(hasBillingProviderAdapter('does-not-exist')).toBe(false);
+  });
+
+  it('accepts any object satisfying the SPI (provider-neutral)', () => {
+    const fake: BillingProviderAdapter = {
+      slug: 'fake',
+      isConfigured: () => true,
+      validate: async () => ({ valid: true }),
+      getPlans: async () => [],
+      getUsageForExternalUser: async () => ({}),
+      getAppUsage: async () => ({}),
+      mintSignerSession: async () => ({ accessToken: 'x' }),
+      receiveCuratedOrchestrators: async () => {},
+      getCapabilityManifest: async () => [],
+    };
+    registerBillingProviderAdapter(fake);
+    expect(getBillingProviderAdapter('fake')).toBe(fake);
+  });
+
+  it('reset restores the default registry', () => {
+    registerBillingProviderAdapter({
+      slug: 'temp',
+      isConfigured: () => true,
+      validate: async () => ({ valid: true }),
+      getPlans: async () => [],
+      getUsageForExternalUser: async () => ({}),
+      getAppUsage: async () => ({}),
+      mintSignerSession: async () => ({}),
+      receiveCuratedOrchestrators: async () => {},
+      getCapabilityManifest: async () => [],
+    });
+    expect(hasBillingProviderAdapter('temp')).toBe(true);
+    resetBillingProviderRegistryForTests();
+    expect(hasBillingProviderAdapter('temp')).toBe(false);
+    expect(hasBillingProviderAdapter('pymthouse')).toBe(true);
+  });
+});

--- a/apps/web-next/src/lib/billing/registry.test.ts
+++ b/apps/web-next/src/lib/billing/registry.test.ts
@@ -51,7 +51,7 @@ describe('NAAP-A — billing provider adapter registry', () => {
       getPlans: async () => [],
       getUsageForExternalUser: async () => ({}),
       getAppUsage: async () => ({}),
-      mintSignerSession: async () => ({}),
+      mintSignerSession: async () => ({ accessToken: 'x' }),
       receiveCuratedOrchestrators: async () => {},
       getCapabilityManifest: async () => [],
     });

--- a/apps/web-next/src/lib/billing/registry.ts
+++ b/apps/web-next/src/lib/billing/registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Billing provider adapter registry (NAAP-A).
+ *
+ * Resolves a provider slug → its `BillingProviderAdapter`. NaaP code looks up a
+ * provider here instead of importing a provider client directly.
+ *
+ * Keyed by provider slug. (The plan's `BillingProvider.adapterType` column is a
+ * later refinement; until then `adapterType` defaults to the slug, so the
+ * registry is keyed by slug and resolves the same adapter.)
+ */
+
+import type { BillingProviderAdapter } from './adapter';
+import { PymthouseAdapter } from './pymthouse-adapter';
+import { StubAdapter } from './stub-adapter';
+
+function buildDefaultRegistry(): Map<string, BillingProviderAdapter> {
+  const adapters: BillingProviderAdapter[] = [new PymthouseAdapter(), new StubAdapter()];
+  const map = new Map<string, BillingProviderAdapter>();
+  for (const adapter of adapters) {
+    map.set(adapter.slug, adapter);
+  }
+  return map;
+}
+
+let registry: Map<string, BillingProviderAdapter> = buildDefaultRegistry();
+
+/** Resolve an adapter by provider slug, or `undefined` if none is registered. */
+export function getBillingProviderAdapter(slug: string): BillingProviderAdapter | undefined {
+  return registry.get(slug);
+}
+
+/** True when an adapter is registered for the slug. */
+export function hasBillingProviderAdapter(slug: string): boolean {
+  return registry.has(slug);
+}
+
+/** The slugs of all registered adapters. */
+export function listBillingProviderSlugs(): string[] {
+  return Array.from(registry.keys());
+}
+
+/**
+ * Register (or override) an adapter. Primarily for tests / future dynamic
+ * registration; production uses the default registry.
+ */
+export function registerBillingProviderAdapter(adapter: BillingProviderAdapter): void {
+  registry.set(adapter.slug, adapter);
+}
+
+/** Reset the registry to its defaults (test isolation). */
+export function resetBillingProviderRegistryForTests(): void {
+  registry = buildDefaultRegistry();
+}

--- a/apps/web-next/src/lib/billing/stub-adapter.ts
+++ b/apps/web-next/src/lib/billing/stub-adapter.ts
@@ -1,0 +1,91 @@
+/**
+ * In-memory stub billing provider adapter (NAAP-A).
+ *
+ * The second adapter in the registry — it proves the SPI is provider-neutral
+ * (the Phase 0 gate requires the registry to resolve ≥2 providers). Tiny and
+ * canned by design; it is NOT a real provider.
+ */
+
+import {
+  type AppUsageInput,
+  type BillingProviderAdapter,
+  type Capability,
+  type CuratedOrchestrator,
+  type MintSignerSessionInput,
+  type Plan,
+  type SignerSession,
+  type UsageForExternalUserInput,
+  type ValidateResult,
+} from './adapter';
+
+export const STUB_ADAPTER_SLUG = 'stub';
+
+export class StubAdapter implements BillingProviderAdapter {
+  readonly slug = STUB_ADAPTER_SLUG;
+
+  isConfigured(): boolean {
+    return true;
+  }
+
+  async validate(key: string): Promise<ValidateResult> {
+    if (!key) return { valid: false };
+    return {
+      valid: true,
+      user: { sub: 'stub-user-1' },
+      billing_account: {
+        id: 'acct_stub_1',
+        providerSlug: this.slug,
+        billingMode: 'delegated',
+      },
+      capabilities: ['text-to-image:sdxl'],
+      quota: { remaining: 1000, resetAt: '2026-12-31T23:59:59.999Z' },
+      subscriptionRef: 'sub_stub_opaque_1',
+    };
+  }
+
+  async getPlans(): Promise<Plan[]> {
+    return [
+      {
+        id: 'free',
+        name: 'Free',
+        price: { amount: 0, interval: 'month', currency: 'USD' },
+        bundles: [{ capability: 'text-to-image:sdxl' }],
+      },
+    ];
+  }
+
+  async getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown> {
+    return {
+      externalUserId: input.externalUserId,
+      period: { start: input.startDate, end: input.endDate },
+      requestCount: 0,
+    };
+  }
+
+  async getAppUsage(input: AppUsageInput): Promise<unknown> {
+    return {
+      period: { start: input.startDate, end: input.endDate },
+      totals: { requestCount: 0 },
+    };
+  }
+
+  async mintSignerSession(_input: MintSignerSessionInput): Promise<SignerSession> {
+    return {
+      accessToken: 'stub-signer-token',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      scope: 'sign:job',
+    };
+  }
+
+  async receiveCuratedOrchestrators(
+    _plan: string,
+    _list: CuratedOrchestrator[],
+  ): Promise<void> {
+    // no-op for the in-memory stub
+  }
+
+  async getCapabilityManifest(): Promise<Capability[]> {
+    return [{ id: 'text-to-image:sdxl', description: 'Stub capability' }];
+  }
+}

--- a/apps/web-next/src/lib/billing/stub-adapter.ts
+++ b/apps/web-next/src/lib/billing/stub-adapter.ts
@@ -13,7 +13,7 @@ import {
   type CuratedOrchestrator,
   type MintSignerSessionInput,
   type Plan,
-  type SignerSession,
+  type SignerSessionToken,
   type UsageForExternalUserInput,
   type ValidateResult,
 } from './adapter';
@@ -69,7 +69,7 @@ export class StubAdapter implements BillingProviderAdapter {
     };
   }
 
-  async mintSignerSession(_input: MintSignerSessionInput): Promise<SignerSession> {
+  async mintSignerSession(_input: MintSignerSessionInput): Promise<SignerSessionToken> {
     return {
       accessToken: 'stub-signer-token',
       tokenType: 'Bearer',

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -35,11 +35,16 @@ export const KNOWN_FLAGS: KnownFlag[] = [
  * exist yet, so a flag defaulting OFF is a no-op until an admin enables it.
  */
 export async function isFeatureEnabled(key: string): Promise<boolean> {
-  const flag = await prisma.featureFlag.findUnique({
-    where: { key },
-    select: { enabled: true },
-  });
-  if (flag) return flag.enabled;
+  try {
+    const flag = await prisma.featureFlag.findUnique({
+      where: { key },
+      select: { enabled: true },
+    });
+    if (flag) return flag.enabled;
+  } catch {
+    // Transient DB lookup failures must not break callers: fall through to the
+    // static KNOWN_FLAGS default so a flag defaulting OFF stays a safe no-op.
+  }
   return KNOWN_FLAGS.find((f) => f.key === key)?.enabled ?? false;
 }
 

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -21,7 +21,27 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: true,
     description: 'Enable teams collaboration feature (team creation, team switching, team pages)',
   },
+  {
+    key: 'provider_adapters',
+    enabled: false,
+    description:
+      'Route billing requests through the generic BillingProviderAdapter registry (/api/v1/billing/{provider}/*). OFF = legacy /billing/pymthouse/* behavior only.',
+  },
 ];
+
+/**
+ * Read a single feature flag's effective state without writing to the DB.
+ * Falls back to the KNOWN_FLAGS default (or `false`) when the flag row does not
+ * exist yet, so a flag defaulting OFF is a no-op until an admin enables it.
+ */
+export async function isFeatureEnabled(key: string): Promise<boolean> {
+  const flag = await prisma.featureFlag.findUnique({
+    where: { key },
+    select: { enabled: true },
+  });
+  if (flag) return flag.enabled;
+  return KNOWN_FLAGS.find((f) => f.key === key)?.enabled ?? false;
+}
 
 /**
  * Ensure all known flags exist in the database.


### PR DESCRIPTION
**DO NOT MERGE — gated by D0 (preview→staging→main + INV-1).**

## Cross-repo coordination
| Field | Value |
|---|---|
| **PR id** | NAAP-A |
| **Repo** | NaaP |
| **Depends-on** | C0 (BPP contracts), NAAP-0 (pymthouse provider config) |
| **Feature flag** | `provider_adapters` |
| **Default** | **OFF** |

## What
Adds the **`BillingProviderAdapter` SPI**, a provider **registry**, and a generic flag-gated route `/api/v1/billing/{provider}/*`.

- `apps/web-next/src/lib/billing/adapter.ts` — SPI
- `apps/web-next/src/lib/billing/registry.ts` (+ test) — provider registry
- `apps/web-next/src/lib/billing/{pymthouse-adapter.ts,stub-adapter.ts}`
- `apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts` (+ test) — generic route
- `apps/web-next/src/lib/feature-flags.ts` — adds `provider_adapters` (default OFF)

## Merge-safety
- **Flag-OFF no-op** — the generic route is gated behind `provider_adapters` (default OFF); when OFF it is a no-op and other repos are unaffected.
- **Additive** — new SPI/registry/adapters/route; only `feature-flags.ts` is modified (adds a new default-OFF flag).
- **INV-1 green** — registry + route unit tests pass.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adapter-based architecture for billing provider operations, enabling support for multiple billing providers
  * Introduced `provider_adapters` feature flag to control the new billing system (currently disabled by default)

* **Tests**
  * Added test coverage for billing provider registry and API routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->