### PR TITLE
feat(gateway): discovery-scoped gw_ service key mint (NAAP-4)

### DIFF
--- a/apps/web-next/src/lib/gateway/__tests__/service-key.test.ts
+++ b/apps/web-next/src/lib/gateway/__tests__/service-key.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for discovery-scoped service keys (NAAP-4).
+ *
+ * Covers minting a `gw_` service key scoped to discovery, the scope helper, and
+ * that a minted key resolves through `authorize()` (so the discovery endpoint
+ * accepts it) — without changing behavior of existing unscoped keys.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHash } from 'crypto';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    gatewayApiKey: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    gatewayMasterKey: { findUnique: vi.fn() },
+    teamMember: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/api/auth', () => ({ validateSession: vi.fn() }));
+vi.mock('@/lib/api/response', () => ({
+  getAuthToken: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+vi.mock('@naap/cache', () => ({
+  createRateLimiter: () => ({
+    consume: vi.fn().mockResolvedValue({ allowed: true }),
+  }),
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  DISCOVERY_ENDPOINT,
+  keyAllowsDiscovery,
+  mintServiceDiscoveryKey,
+} from '../service-key';
+import { authorize } from '../authorize';
+
+const mockCreate = prisma.gatewayApiKey.create as ReturnType<typeof vi.fn>;
+const mockFindUnique = prisma.gatewayApiKey.findUnique as ReturnType<typeof vi.fn>;
+
+describe('keyAllowsDiscovery', () => {
+  it('allows when allowlist is empty (all endpoints) — existing keys unchanged', () => {
+    expect(keyAllowsDiscovery(undefined)).toBe(true);
+    expect(keyAllowsDiscovery([])).toBe(true);
+  });
+
+  it('allows when discovery endpoint is in the allowlist', () => {
+    expect(keyAllowsDiscovery([DISCOVERY_ENDPOINT])).toBe(true);
+    expect(keyAllowsDiscovery(['/other', DISCOVERY_ENDPOINT])).toBe(true);
+  });
+
+  it('rejects when allowlist is set but excludes discovery', () => {
+    expect(keyAllowsDiscovery(['/api/v1/gw/some-connector'])).toBe(false);
+  });
+});
+
+describe('mintServiceDiscoveryKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: 'key-1',
+      keyPrefix: data.keyPrefix,
+    }));
+  });
+
+  it('mints a gw_ key scoped to discovery for a team', async () => {
+    const result = await mintServiceDiscoveryKey({
+      name: 'sdk-service',
+      createdBy: 'user-1',
+      teamId: 'team-1',
+    });
+
+    expect(result.rawKey.startsWith('gw_')).toBe(true);
+    expect(result.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT]);
+    expect(result.keyPrefix).toBe(result.rawKey.slice(0, 11));
+
+    const createArg = mockCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createArg.data.teamId).toBe('team-1');
+    expect(createArg.data.ownerUserId).toBeUndefined();
+    expect(createArg.data.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT]);
+    // Only the SHA-256 hash is persisted, never the raw key.
+    expect(createArg.data.keyHash).toBe(
+      createHash('sha256').update(result.rawKey).digest('hex'),
+    );
+    expect(Object.values(createArg.data)).not.toContain(result.rawKey);
+  });
+
+  it('merges additional endpoints without duplicating discovery', async () => {
+    const result = await mintServiceDiscoveryKey({
+      name: 'sdk-service',
+      createdBy: 'user-1',
+      ownerUserId: 'user-1',
+      additionalEndpoints: ['/api/v1/gw/catalog', DISCOVERY_ENDPOINT],
+    });
+    expect(result.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT, '/api/v1/gw/catalog']);
+  });
+
+  it('requires exactly one of teamId / ownerUserId', async () => {
+    await expect(
+      mintServiceDiscoveryKey({ name: 'x', createdBy: 'u' }),
+    ).rejects.toThrow(/exactly one/);
+    await expect(
+      mintServiceDiscoveryKey({ name: 'x', createdBy: 'u', teamId: 't', ownerUserId: 'u' }),
+    ).rejects.toThrow(/exactly one/);
+  });
+});
+
+describe('authorize() accepts a minted discovery service key', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('resolves a gw_ service key and surfaces its discovery scope', async () => {
+    const rawKey = 'gw_' + 'a'.repeat(64);
+    const keyHash = createHash('sha256').update(rawKey).digest('hex');
+    mockFindUnique.mockResolvedValue({
+      id: 'key-1',
+      teamId: 'team-1',
+      ownerUserId: null,
+      connectorId: null,
+      status: 'active',
+      expiresAt: null,
+      planId: null,
+      createdBy: 'user-1',
+      allowedEndpoints: [DISCOVERY_ENDPOINT],
+      allowedIPs: [],
+      plan: null,
+    });
+
+    const request = new Request('https://naap.test' + DISCOVERY_ENDPOINT, {
+      headers: { authorization: `Bearer ${rawKey}` },
+    });
+    const auth = await authorize(request);
+
+    expect(auth).not.toBeNull();
+    expect(auth?.callerType).toBe('apiKey');
+    expect(auth?.teamId).toBe('team-1');
+    expect(keyAllowsDiscovery(auth?.allowedEndpoints)).toBe(true);
+    expect(mockFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { keyHash } }),
+    );
+  });
+});

--- a/apps/web-next/src/lib/gateway/__tests__/service-key.test.ts
+++ b/apps/web-next/src/lib/gateway/__tests__/service-key.test.ts
@@ -98,15 +98,22 @@ describe('mintServiceDiscoveryKey', () => {
       additionalEndpoints: ['/api/v1/gw/catalog', DISCOVERY_ENDPOINT],
     });
     expect(result.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT, '/api/v1/gw/catalog']);
+
+    const createArg = mockCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createArg.data.ownerUserId).toBe('user-1');
+    expect(createArg.data.teamId).toBeUndefined();
   });
 
   it('requires exactly one of teamId / ownerUserId', async () => {
     await expect(
       mintServiceDiscoveryKey({ name: 'x', createdBy: 'u' }),
     ).rejects.toThrow(/exactly one/);
+    expect(mockCreate).not.toHaveBeenCalled();
+
     await expect(
       mintServiceDiscoveryKey({ name: 'x', createdBy: 'u', teamId: 't', ownerUserId: 'u' }),
     ).rejects.toThrow(/exactly one/);
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 });
 
@@ -138,6 +145,7 @@ describe('authorize() accepts a minted discovery service key', () => {
     expect(auth).not.toBeNull();
     expect(auth?.callerType).toBe('apiKey');
     expect(auth?.teamId).toBe('team-1');
+    expect(auth?.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT]);
     expect(keyAllowsDiscovery(auth?.allowedEndpoints)).toBe(true);
     expect(mockFindUnique).toHaveBeenCalledWith(
       expect.objectContaining({ where: { keyHash } }),

--- a/apps/web-next/src/lib/gateway/service-key.ts
+++ b/apps/web-next/src/lib/gateway/service-key.ts
@@ -1,0 +1,99 @@
+/**
+ * Service Gateway — Discovery-scoped service keys (NAAP-4).
+ *
+ * Mints a service-level `gw_` key that the SDK service (and other infra
+ * consumers) use to reach NaaP discovery
+ * (`GET /api/v1/orchestrator-leaderboard/python-gateway`).
+ *
+ * The key is a normal `gatewayApiKey` row — `authorize()` already accepts
+ * `gw_` keys — but it is scoped to the discovery endpoint via `allowedEndpoints`.
+ * Existing keys carry an empty `allowedEndpoints` ("all endpoints"), so minting a
+ * scoped service key is purely additive and changes no existing key's behavior
+ * (zero regression). The `keyAllowsDiscovery` helper is exported for downstream
+ * scope enforcement (e.g. INFRA-2) without coupling it to the live route here.
+ */
+
+import { randomBytes, createHash } from 'crypto';
+import { prisma } from '@/lib/db';
+
+/** Canonical discovery endpoint a service key is scoped to (BPP ⑦). */
+export const DISCOVERY_ENDPOINT = '/api/v1/orchestrator-leaderboard/python-gateway';
+
+export interface MintServiceDiscoveryKeyInput {
+  /** Human-readable label for the key. */
+  name: string;
+  /** Acting user id (audit: who created the key). */
+  createdBy: string;
+  /** Team-scoped key owner. Provide exactly one of teamId / ownerUserId. */
+  teamId?: string;
+  /** Personal-scoped key owner. Provide exactly one of teamId / ownerUserId. */
+  ownerUserId?: string;
+  /** Optional extra endpoints the service key may reach, in addition to discovery. */
+  additionalEndpoints?: string[];
+  /** Optional expiry. */
+  expiresAt?: Date | null;
+}
+
+export interface MintedServiceDiscoveryKey {
+  id: string;
+  keyPrefix: string;
+  /** Raw key — returned exactly ONCE, never persisted in plaintext. */
+  rawKey: string;
+  allowedEndpoints: string[];
+}
+
+/**
+ * True when a key's `allowedEndpoints` permit the discovery endpoint.
+ *
+ * An empty allowlist means "all endpoints" (current behavior for every existing
+ * key), so it always permits discovery — keeping enforcement a no-op until a key
+ * is explicitly minted with a non-empty scope.
+ */
+export function keyAllowsDiscovery(allowedEndpoints: string[] | undefined): boolean {
+  if (!allowedEndpoints || allowedEndpoints.length === 0) return true;
+  return allowedEndpoints.includes(DISCOVERY_ENDPOINT);
+}
+
+/**
+ * Mint a service-level `gw_` key scoped to discovery for an SDK service.
+ *
+ * The scope is recorded as `allowedEndpoints`; the raw key is returned once and
+ * only its SHA-256 hash is stored.
+ */
+export async function mintServiceDiscoveryKey(
+  input: MintServiceDiscoveryKeyInput,
+): Promise<MintedServiceDiscoveryKey> {
+  const hasTeam = Boolean(input.teamId);
+  const hasOwner = Boolean(input.ownerUserId);
+  if (hasTeam === hasOwner) {
+    throw new Error('mintServiceDiscoveryKey: provide exactly one of teamId or ownerUserId');
+  }
+
+  const allowedEndpoints = Array.from(
+    new Set([DISCOVERY_ENDPOINT, ...(input.additionalEndpoints ?? [])]),
+  );
+
+  const rawKey = `gw_${randomBytes(32).toString('hex')}`;
+  const keyHash = createHash('sha256').update(rawKey).digest('hex');
+  const keyPrefix = rawKey.slice(0, 11);
+
+  const ownerData = hasTeam
+    ? { teamId: input.teamId! }
+    : { ownerUserId: input.ownerUserId! };
+
+  const created = await prisma.gatewayApiKey.create({
+    data: {
+      ...ownerData,
+      createdBy: input.createdBy,
+      name: input.name,
+      keyHash,
+      keyPrefix,
+      allowedEndpoints,
+      allowedIPs: [],
+      expiresAt: input.expiresAt ?? null,
+    },
+    select: { id: true, keyPrefix: true },
+  });
+
+  return { id: created.id, keyPrefix: created.keyPrefix, rawKey, allowedEndpoints };
+}


### PR DESCRIPTION
## Coordination
```
Plan PR ID:   NAAP-4
Repo:         NaaP (../NaaP)
Depends-on:   none (catalog: "none")
Blocks:       INFRA-2, NAAP-9 (discovery reachable via gw_)
Feature flag: none (purely additive)
Merge-safety: With every OTHER repo at current main, this PR is a no-op — it adds
              a mint helper + scope helper + tests; authorize() already accepts
              gw_ keys and existing keys (empty allowedEndpoints = "all") are
              unaffected. INV-1 green.
Base:         main
```

## What (NAAP-4 catalog row)
Mint a service-level `gw_` key scoped (via `allowedEndpoints`) to NaaP discovery
(`GET /api/v1/orchestrator-leaderboard/python-gateway`, BPP ⑦) for the SDK
service, and confirm the discovery endpoint accepts it.

- `src/lib/gateway/service-key.ts` — `mintServiceDiscoveryKey()` (SHA-256 hash
  only, raw key returned once), `keyAllowsDiscovery()` scope helper, exported for
  downstream enforcement (INFRA-2) without touching the live discovery route.
- `DISCOVERY_ENDPOINT` constant.

## Tests
- scope helper (empty=all → allow; in-list; excluded → deny)
- mint (team + personal, hash-only persistence, no raw-key leak, dedupe, XOR owner)
- `authorize()` resolves a minted `gw_` key and surfaces its discovery scope

## Zero-regression
Additive only; no flag needed because the live discovery route is untouched and
existing keys keep working. Lint + targeted unit green; repo-wide typecheck has
pre-existing baseline failures unrelated to these files.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced discovery-scoped gateway service keys for SDK services with secure cryptographic key generation and hash-based storage.
  * Added key validation and authorization mechanisms for controlling discovery endpoint access.

* **Tests**
  * Added comprehensive test coverage for service key minting, scoping, and authorization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->