### PR TITLE
feat(discovery): [NAAP-9] Storyboard default-plan discovery parity (Daydream parity)

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.test.ts
@@ -18,14 +18,36 @@ vi.mock('@/lib/orchestrator-leaderboard/provider-restrictions', () => ({
   normalizeBillingProviderSlug: vi.fn((slug?: string | null) => slug?.trim().toLowerCase() || null),
 }));
 
+vi.mock('@/lib/orchestrator-leaderboard/storyboard-default-plan', () => ({
+  STORYBOARD_DEFAULT_PLAN_ID: 'storyboard-default',
+  isStoryboardDefaultDiscoveryEnabled: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/storyboard-default-discovery', () => ({
+  buildStoryboardDefaultDiscovery: vi.fn(),
+}));
+
+vi.mock('@/lib/pymthouse-manifest', () => ({
+  DISCOVERY_RESPONSE_CACHE_CONTROL: 'no-store',
+  ensurePymthouseManifestFresh: vi.fn(),
+}));
+
 import { authorize } from '@/lib/gateway/authorize';
 import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
 import { isCapabilityAllowedForProvider } from '@/lib/orchestrator-leaderboard/provider-restrictions';
+import { isStoryboardDefaultDiscoveryEnabled } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+import { buildStoryboardDefaultDiscovery } from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
 
 describe('GET /api/v1/orchestrator-leaderboard/python-gateway', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (isCapabilityAllowedForProvider as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (isStoryboardDefaultDiscoveryEnabled as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    (buildStoryboardDefaultDiscovery as ReturnType<typeof vi.fn>).mockResolvedValue({
+      addresses: ['https://orch-a.test'],
+      byKind: { scope: ['https://orch-a.test'], byoc: [], tool: [] },
+      meta: { staticFleetInjected: 0, fromCache: true, cacheAgeMs: 0 },
+    });
     (authorize as ReturnType<typeof vi.fn>).mockResolvedValue({
       authenticated: true,
       teamId: 'personal:user-1',
@@ -98,5 +120,64 @@ describe('GET /api/v1/orchestrator-leaderboard/python-gateway', () => {
     const req = new NextRequest('http://localhost/api/v1/orchestrator-leaderboard/python-gateway');
     const res = await GET(req);
     expect(res.status).toBe(401);
+  });
+
+  it('delegates to storyboard-default discovery when plan=storyboard-default and the flag is enabled', async () => {
+    (isStoryboardDefaultDiscoveryEnabled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(
+      'http://localhost/api/v1/orchestrator-leaderboard/python-gateway?plan=storyboard-default&billingProvider=pymthouse',
+      { headers: { Authorization: 'Bearer gw_test' } },
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(buildStoryboardDefaultDiscovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingProviderSlug: 'pymthouse',
+        fetchCapabilityAddresses: expect.any(Function),
+      }),
+    );
+    // Delegation path does not run the per-capability leaderboard loop directly.
+    expect(fetchLeaderboard).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual([{ address: 'https://orch-a.test' }]);
+  });
+
+  it('sets the X-Discovery-Mode: storyboard-default header on the delegated response', async () => {
+    (isStoryboardDefaultDiscoveryEnabled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(
+      'http://localhost/api/v1/orchestrator-leaderboard/python-gateway?plan=storyboard-default',
+      { headers: { Authorization: 'Bearer gw_test' } },
+    );
+
+    const res = await GET(req);
+
+    expect(res.headers.get('X-Discovery-Mode')).toBe('storyboard-default');
+  });
+
+  it('falls through to per-capability behavior when the storyboard-default flag is disabled', async () => {
+    (isStoryboardDefaultDiscoveryEnabled as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(
+      'http://localhost/api/v1/orchestrator-leaderboard/python-gateway?plan=storyboard-default&caps=live-video-to-video/streamdiffusion-sdxl',
+      { headers: { Authorization: 'Bearer gw_test' } },
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(buildStoryboardDefaultDiscovery).not.toHaveBeenCalled();
+    expect(fetchLeaderboard).toHaveBeenCalledWith(
+      'streamdiffusion-sdxl',
+      'gw_test',
+      req.url,
+      null,
+    );
+    expect(res.headers.get('X-Discovery-Mode')).not.toBe('storyboard-default');
   });
 });

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.ts
@@ -22,6 +22,14 @@ import {
   DISCOVERY_RESPONSE_CACHE_CONTROL,
   ensurePymthouseManifestFresh,
 } from '@/lib/pymthouse-manifest';
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
+import {
+  isStoryboardDefaultDiscoveryEnabled,
+  STORYBOARD_DEFAULT_PLAN_ID,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
 
 const DEFAULT_CAPABILITY = 'noop';
 const DEFAULT_TOP_N = 100;
@@ -66,6 +74,70 @@ function resolveTopN(url: URL): number {
   return parsed;
 }
 
+async function handleStoryboardDefaultPlan(
+  request: NextRequest,
+  billingProviderSlug: ReturnType<typeof normalizeBillingProviderSlug>,
+  authToken: string,
+): Promise<Response> {
+  const cookieHeader = request.headers.get('cookie');
+
+  const fetchCapabilityAddresses = async (
+    leaderboardCap: string,
+  ): Promise<CapabilityFetchResult> => {
+    const result = await fetchLeaderboard(leaderboardCap, authToken, request.url, cookieHeader);
+    const addresses: string[] = [];
+    for (const row of result.rows) {
+      const address = row.orch_uri?.trim();
+      if (address) {
+        addresses.push(address);
+      }
+    }
+    return { addresses, fromCache: result.fromCache, cachedAt: result.cachedAt };
+  };
+
+  try {
+    if (billingProviderSlug === 'pymthouse') {
+      await ensurePymthouseManifestFresh();
+    }
+
+    const { addresses, byKind, meta } = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses,
+      billingProviderSlug,
+    });
+
+    console.info(
+      '[python-gateway] storyboard-default plan served',
+      JSON.stringify({
+        billingProviderSlug: billingProviderSlug ?? 'default',
+        total: addresses.length,
+        scope: byKind.scope.length,
+        byocCaps: byKind.byoc.length,
+        toolCaps: byKind.tool.length,
+        staticFleetInjected: meta.staticFleetInjected,
+        fromCache: meta.fromCache,
+      }),
+    );
+
+    return NextResponse.json(
+      addresses.map((address) => ({ address })),
+      {
+        headers: {
+          'Cache-Control': DISCOVERY_RESPONSE_CACHE_CONTROL,
+          'X-Cache': meta.fromCache ? 'HIT' : 'MISS',
+          'X-Cache-Age': String(meta.cacheAgeMs),
+          'X-Discovery-Mode': 'storyboard-default',
+        },
+      },
+    );
+  } catch (err) {
+    console.error('[python-gateway] storyboard-default plan failed', err);
+    return new NextResponse('Internal server error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}
+
 export async function GET(request: NextRequest): Promise<Response> {
   const auth = await authorize(request);
   if (!auth) {
@@ -83,6 +155,17 @@ export async function GET(request: NextRequest): Promise<Response> {
   const capabilityPairs = resolveCapabilityPairs(url);
   const topN = resolveTopN(url);
   const authToken = getAuthToken(request) || '';
+
+  // NAAP-9: `?plan=storyboard-default` selects the fixed default-plan bundle
+  // (static-fleet merge for scope). Gated OFF by default → falls through to the
+  // existing per-cap behavior so the Daydream path stays authoritative.
+  const planParam = url.searchParams.get('plan')?.trim();
+  if (
+    planParam === STORYBOARD_DEFAULT_PLAN_ID &&
+    isStoryboardDefaultDiscoveryEnabled()
+  ) {
+    return handleStoryboardDefaultPlan(request, billingProvider, authToken);
+  }
 
   try {
     if (billingProvider === 'pymthouse') {

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__snapshots__/golden-set.json
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__snapshots__/golden-set.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "NAAP-9 golden set (Daydream parity). Per Decision D7 this is snapshotted empirically from the live Daydream path: scope addresses from signer.daydream.live/discovery/staging.json + orch-staging-3 from simple-infra fleet.yaml; byoc/tool caps from sdk.daydream.monster/capabilities. The committed values below are the staging baseline to reconcile against. The parity test asserts the storyboard-default bundle returns EXACTLY this set (bidirectional: no missing, no extra).",
+  "scope": [
+    "https://orch-staging-1.daydream.monster:8935",
+    "https://orch-staging-2.daydream.monster:8935",
+    "https://orch-staging-3.daydream.monster:8935"
+  ],
+  "byoc": [
+    "nano-banana",
+    "recraft-v4",
+    "flux-schnell",
+    "flux-dev",
+    "ltx-t2v",
+    "ltx-i2v",
+    "kontext-edit",
+    "bg-remove",
+    "topaz-upscale",
+    "chatterbox-tts",
+    "gemini-image",
+    "gemini-text"
+  ],
+  "tool": [
+    "ffmpeg-concat",
+    "ffmpeg-trim",
+    "ffmpeg-overlay",
+    "ffmpeg-export",
+    "ffmpeg-audio-mix",
+    "ffmpeg-loop",
+    "ffmpeg-burn-subtitles",
+    "ffmpeg-grid",
+    "ffmpeg-mux",
+    "pillow-resize",
+    "pillow-watermark",
+    "pillow-format",
+    "pillow-palette",
+    "pillow-grid",
+    "obscura-extract-text",
+    "obscura-extract-markdown",
+    "obscura-extract-links",
+    "hyperframes-caption",
+    "hyperframes-lower-third",
+    "hyperframes-render",
+    "yolo-detect",
+    "yolo-segment",
+    "cad-render",
+    "cad-validate"
+  ]
+}

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__tests__/golden-set.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__tests__/golden-set.test.ts
@@ -1,0 +1,154 @@
+/**
+ * NAAP-9 — Golden-set parity test.
+ *
+ * "Storyboard default discovery returns the golden BYOC + tool + scope
+ * orchestrator set." Guards a non-disruptive Daydream→NaaP discovery switch:
+ * the bundle must return ⊇ AND ⊆ the live Daydream set (no orchestrator/cap
+ * silently dropped, none silently added). The negative tests prove the assert
+ * is bidirectional (catches both missing and extra).
+ *
+ * Per Decision D7 the golden fixture is snapshotted from the live Daydream path
+ * (committed baseline here). fetchLeaderboard is mocked per capability; the
+ * scope mock intentionally omits orch-staging-3 to prove the static-fleet
+ * fallback re-injects it (catching the staging.json drift).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
+import {
+  STORYBOARD_DEFAULT_PLAN,
+  type StoryboardDefaultPlan,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+import goldenJson from '../__snapshots__/golden-set.json';
+
+interface GoldenSet {
+  scope: string[];
+  byoc: string[];
+  tool: string[];
+}
+
+const golden: GoldenSet = {
+  scope: goldenJson.scope,
+  byoc: goldenJson.byoc,
+  tool: goldenJson.tool,
+};
+
+const BYOC_TOOL_STATIC_HOST = 'https://byoc-staging-1.daydream.monster:8935';
+
+/**
+ * Mock leaderboard fetch. Scope caps deliberately return only staging-1/2 (the
+ * staging.json drift) so the static fleet must re-add staging-3. byoc/tool caps
+ * return the BYOC tool host.
+ */
+function goldenFetch(scopeAddresses: string[]): (cap: string) => Promise<CapabilityFetchResult> {
+  return async (_cap: string): Promise<CapabilityFetchResult> => {
+    // We can't tell category from the short cap here, so return a benign host
+    // for non-scope caps and the (drifted) scope set for the scope cap.
+    void _cap;
+    const isScope = _cap === 'scope';
+    return {
+      addresses: isScope ? scopeAddresses : [BYOC_TOOL_STATIC_HOST],
+      fromCache: true,
+      cachedAt: Date.now(),
+    };
+  };
+}
+
+const SORT = (xs: string[]) => [...xs].sort((a, b) => a.localeCompare(b));
+
+describe('NAAP-9 storyboard-default golden-set parity', () => {
+  it('returns the golden scope addresses, byoc caps, and tool caps (bidirectional)', async () => {
+    const result = await buildStoryboardDefaultDiscovery({
+      // scope mock omits orch-staging-3 → static fleet must re-inject it
+      fetchCapabilityAddresses: goldenFetch([
+        'https://orch-staging-1.daydream.monster:8935',
+        'https://orch-staging-2.daydream.monster:8935',
+      ]),
+      billingProviderSlug: 'daydream',
+    });
+
+    expect(SORT(result.byKind.scope)).toEqual(SORT(golden.scope));
+    expect(SORT(result.byKind.byoc)).toEqual(SORT(golden.byoc));
+    expect(SORT(result.byKind.tool)).toEqual(SORT(golden.tool));
+
+    // Static-fleet fallback re-injected orch-staging-3 (the drift).
+    expect(result.meta.staticFleetInjected).toBeGreaterThanOrEqual(1);
+
+    // The flattened payload contains the golden scope orchestrators.
+    for (const addr of golden.scope) {
+      expect(result.addresses).toContain(addr);
+    }
+  });
+
+  it('keeps parity even when ClickHouse returns the full scope set (no drift)', async () => {
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([...golden.scope]),
+      billingProviderSlug: 'daydream',
+    });
+    expect(SORT(result.byKind.scope)).toEqual(SORT(golden.scope));
+    expect(result.meta.staticFleetInjected).toBe(0);
+  });
+
+  it('fails parity if a golden scope address is removed from both live and static fleet (catches missing)', async () => {
+    const planMissingScope: StoryboardDefaultPlan = {
+      ...STORYBOARD_DEFAULT_PLAN,
+      scope: {
+        capabilities: STORYBOARD_DEFAULT_PLAN.scope.capabilities,
+        staticOrchestrators: STORYBOARD_DEFAULT_PLAN.scope.staticOrchestrators.filter(
+          (a) => !a.includes('orch-staging-3'),
+        ),
+      },
+    };
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([
+        'https://orch-staging-1.daydream.monster:8935',
+        'https://orch-staging-2.daydream.monster:8935',
+      ]),
+      billingProviderSlug: 'daydream',
+      plan: planMissingScope,
+    });
+    expect(SORT(result.byKind.scope)).not.toEqual(SORT(golden.scope));
+  });
+
+  it('fails parity if a golden byoc cap is removed (catches missing)', async () => {
+    const planMissingCap: StoryboardDefaultPlan = {
+      ...STORYBOARD_DEFAULT_PLAN,
+      byoc: {
+        capabilities: STORYBOARD_DEFAULT_PLAN.byoc.capabilities.filter((c) => c !== 'nano-banana'),
+        staticOrchestrators: STORYBOARD_DEFAULT_PLAN.byoc.staticOrchestrators,
+      },
+    };
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([...golden.scope]),
+      billingProviderSlug: 'daydream',
+      plan: planMissingCap,
+    });
+    expect(SORT(result.byKind.byoc)).not.toEqual(SORT(golden.byoc));
+  });
+
+  it('fails parity if an extra byoc cap is added (catches extra)', async () => {
+    const planExtraCap: StoryboardDefaultPlan = {
+      ...STORYBOARD_DEFAULT_PLAN,
+      byoc: {
+        capabilities: [...STORYBOARD_DEFAULT_PLAN.byoc.capabilities, 'rogue-model'],
+        staticOrchestrators: STORYBOARD_DEFAULT_PLAN.byoc.staticOrchestrators,
+      },
+    };
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([...golden.scope]),
+      billingProviderSlug: 'daydream',
+      plan: planExtraCap,
+    });
+    expect(SORT(result.byKind.byoc)).not.toEqual(SORT(golden.byoc));
+  });
+
+  it('the committed plan baseline matches the golden fixture', () => {
+    expect(SORT([...STORYBOARD_DEFAULT_PLAN.byoc.capabilities])).toEqual(SORT(golden.byoc));
+    expect(SORT([...STORYBOARD_DEFAULT_PLAN.tool.capabilities])).toEqual(SORT(golden.tool));
+    expect(SORT([...STORYBOARD_DEFAULT_PLAN.scope.staticOrchestrators])).toEqual(SORT(golden.scope));
+  });
+});

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from 'next/server';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/gateway/authorize', () => ({
+  authorize: vi.fn(),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/query', () => ({
+  fetchLeaderboard: vi.fn(),
+}));
+
+import { authorize } from '@/lib/gateway/authorize';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { STORYBOARD_DEFAULT_DISCOVERY_FLAG } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+
+const FLAG = STORYBOARD_DEFAULT_DISCOVERY_FLAG;
+
+function makeRequest(qs = '') {
+  return new NextRequest(
+    `http://localhost/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway${qs}`,
+    { headers: { Authorization: 'Bearer gw_test' } },
+  );
+}
+
+describe('GET storyboard-default/python-gateway', () => {
+  const prev = process.env[FLAG];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (authorize as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: true,
+      teamId: 'personal:user-1',
+      callerType: 'apiKey',
+      callerId: 'user-1',
+    });
+    (fetchLeaderboard as ReturnType<typeof vi.fn>).mockImplementation(async (cap: string) => ({
+      rows:
+        cap === 'scope'
+          ? [
+              { orch_uri: 'https://orch-staging-1.daydream.monster:8935' },
+              { orch_uri: 'https://orch-staging-2.daydream.monster:8935' },
+            ]
+          : [{ orch_uri: 'https://byoc-staging-1.daydream.monster:8935' }],
+      fromCache: true,
+      cachedAt: Date.now(),
+    }));
+  });
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env[FLAG];
+    } else {
+      process.env[FLAG] = prev;
+    }
+  });
+
+  it('returns 404 when the flag is OFF (default) — Daydream path stays authoritative', async () => {
+    delete process.env[FLAG];
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+    expect(fetchLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated even with the flag ON', async () => {
+    process.env[FLAG] = 'true';
+    (authorize as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the bundle with static-fleet scope orchestrators when the flag is ON', async () => {
+    process.env[FLAG] = 'true';
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Discovery-Mode')).toBe('storyboard-default');
+
+    const body = (await res.json()) as { address: string }[];
+    const addresses = body.map((o) => o.address);
+    // orch-staging-3 was NOT returned by ClickHouse but the static fleet adds it.
+    expect(addresses).toContain('https://orch-staging-3.daydream.monster:8935');
+    expect(addresses).toContain('https://orch-staging-1.daydream.monster:8935');
+    expect(addresses).toContain('https://byoc-staging-1.daydream.monster:8935');
+  });
+});

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.ts
@@ -1,0 +1,102 @@
+/**
+ * GET /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway
+ *
+ * NAAP-9 — the Storyboard Default discovery bundle (Daydream parity). Returns
+ * the fixed default-plan orchestrator/capability set (scope staging + BYOC +
+ * tool) with a static-fleet fallback merged into the tier shuffle, so the
+ * Daydream→NaaP discovery switch is non-disruptive.
+ *
+ * Gated by `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default OFF): when OFF the
+ * endpoint is disabled (404) and the Daydream path stays authoritative.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authorize } from '@/lib/gateway/authorize';
+import { getAuthToken } from '@/lib/api/response';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { normalizeBillingProviderSlug } from '@/lib/orchestrator-leaderboard/provider-restrictions';
+import { DISCOVERY_RESPONSE_CACHE_CONTROL } from '@/lib/orchestrator-leaderboard/discovery-constants';
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
+import { isStoryboardDefaultDiscoveryEnabled } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+
+export async function GET(request: NextRequest): Promise<Response> {
+  if (!isStoryboardDefaultDiscoveryEnabled()) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const auth = await authorize(request);
+  if (!auth) {
+    return new NextResponse('Unauthorized', {
+      status: 401,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const url = new URL(request.url);
+  const billingProviderSlug = normalizeBillingProviderSlug(
+    url.searchParams.get('billingProviderSlug') ?? url.searchParams.get('billingProvider'),
+  );
+  const authToken = getAuthToken(request) || '';
+  const cookieHeader = request.headers.get('cookie');
+
+  const fetchCapabilityAddresses = async (
+    leaderboardCap: string,
+  ): Promise<CapabilityFetchResult> => {
+    const result = await fetchLeaderboard(leaderboardCap, authToken, request.url, cookieHeader);
+    const addresses: string[] = [];
+    for (const row of result.rows) {
+      const address = row.orch_uri?.trim();
+      if (address) {
+        addresses.push(address);
+      }
+    }
+    return { addresses, fromCache: result.fromCache, cachedAt: result.cachedAt };
+  };
+
+  try {
+    const { addresses, byKind, meta } = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses,
+      billingProviderSlug,
+    });
+
+    const out = addresses.map((address) => ({ address }));
+
+    // Structured logging — counts only, no addresses/keys/PII.
+    console.info(
+      '[storyboard-default-discovery] served',
+      JSON.stringify({
+        billingProviderSlug: billingProviderSlug ?? 'default',
+        total: out.length,
+        scope: byKind.scope.length,
+        byocCaps: byKind.byoc.length,
+        toolCaps: byKind.tool.length,
+        staticFleetInjected: meta.staticFleetInjected,
+        fromCache: meta.fromCache,
+      }),
+    );
+
+    return NextResponse.json(out, {
+      headers: {
+        'Cache-Control': DISCOVERY_RESPONSE_CACHE_CONTROL,
+        'X-Cache': meta.fromCache ? 'HIT' : 'MISS',
+        'X-Cache-Age': String(meta.cacheAgeMs),
+        'X-Discovery-Mode': 'storyboard-default',
+      },
+    });
+  } catch (err) {
+    console.error('[storyboard-default-discovery] failed to build bundle', err);
+    return new NextResponse('Internal server error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/static-fleet.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/static-fleet.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { mergeStaticFleet, staticFleetGaps } from '../static-fleet';
+
+describe('mergeStaticFleet', () => {
+  it('keeps discovered order first, appends only missing static fallbacks', () => {
+    const merged = mergeStaticFleet(
+      ['https://a:8935', 'https://b:8935'],
+      ['https://b:8935', 'https://c:8935'],
+    );
+    expect(merged).toEqual(['https://a:8935', 'https://b:8935', 'https://c:8935']);
+  });
+
+  it('de-duplicates and trims (first occurrence wins)', () => {
+    const merged = mergeStaticFleet([' https://a:8935 ', 'https://a:8935'], ['https://a:8935', '']);
+    expect(merged).toEqual(['https://a:8935']);
+  });
+
+  it('returns the full static fleet when nothing was discovered (fallback)', () => {
+    const merged = mergeStaticFleet([], ['https://x:8935', 'https://y:8935']);
+    expect(merged).toEqual(['https://x:8935', 'https://y:8935']);
+  });
+});
+
+describe('staticFleetGaps', () => {
+  it('reports static fallbacks missing from the discovered set', () => {
+    expect(
+      staticFleetGaps(['https://a:8935'], ['https://a:8935', 'https://b:8935', 'https://b:8935']),
+    ).toEqual(['https://b:8935']);
+  });
+
+  it('reports no gaps when the discovered set already covers the fleet', () => {
+    expect(staticFleetGaps(['https://a:8935', 'https://b:8935'], ['https://a:8935'])).toEqual([]);
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.test.ts
@@ -4,6 +4,7 @@ import {
   effectiveDiscoveryTierCount,
   tierIndexRanges,
   tieredShuffleDiscoveryAddresses,
+  tieredShuffleWithStaticFallback,
 } from './discovery-order';
 
 describe('effectiveDiscoveryTierCount', () => {
@@ -69,5 +70,23 @@ describe('tieredShuffleDiscoveryAddresses', () => {
     });
     expect(new Set(out)).toEqual(new Set(input));
     expect(out).not.toEqual(input);
+  });
+});
+
+describe('tieredShuffleWithStaticFallback', () => {
+  it('includes static fallback addresses missing from the discovered set', () => {
+    const out = tieredShuffleWithStaticFallback(
+      ['https://a', 'https://b'],
+      ['https://b', 'https://c'],
+      { random: () => 0.999999 },
+    );
+    expect(new Set(out)).toEqual(new Set(['https://a', 'https://b', 'https://c']));
+  });
+
+  it('returns the static fleet when discovery is empty (fallback joins the shuffle)', () => {
+    const out = tieredShuffleWithStaticFallback([], ['https://x', 'https://y'], {
+      random: () => 0,
+    });
+    expect(new Set(out)).toEqual(new Set(['https://x', 'https://y']));
   });
 });

--- a/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.ts
@@ -93,3 +93,19 @@ export function tieredShuffleDiscoveryAddresses(
 
   return unique;
 }
+
+/**
+ * Tiered shuffle where a static-fleet fallback joins the shuffle (NAAP-9).
+ *
+ * Live-ranked `discovered` addresses keep their order and are tiered first;
+ * `staticFallback` addresses not already discovered are appended so they land
+ * in the lowest tier — present (never silently dropped) but not displacing
+ * live-ranked orchestrators. De-duplication is first-occurrence wins.
+ */
+export function tieredShuffleWithStaticFallback(
+  discovered: string[],
+  staticFallback: string[],
+  options?: TieredShuffleDiscoveryOptions,
+): string[] {
+  return tieredShuffleDiscoveryAddresses([...discovered, ...staticFallback], options);
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.ts
@@ -107,5 +107,21 @@ export function tieredShuffleWithStaticFallback(
   staticFallback: string[],
   options?: TieredShuffleDiscoveryOptions,
 ): string[] {
-  return tieredShuffleDiscoveryAddresses([...discovered, ...staticFallback], options);
+  // Tier the live-ranked discovered set first so it owns the top tiers, then
+  // append static-fallback addresses (not already discovered) shuffled among
+  // themselves. This keeps fallback in the lowest tier — present but never
+  // displacing live-ranked orchestrators via within-tier shuffling.
+  const shuffledDiscovered = tieredShuffleDiscoveryAddresses([...discovered], options);
+
+  const seen = new Set(shuffledDiscovered.map((a) => a.trim()).filter(Boolean));
+  const staticOnly: string[] = [];
+  for (const raw of staticFallback) {
+    const a = raw.trim();
+    if (!a || seen.has(a)) continue;
+    seen.add(a);
+    staticOnly.push(a);
+  }
+
+  const shuffledStatic = tieredShuffleDiscoveryAddresses(staticOnly, options);
+  return [...shuffledDiscovered, ...shuffledStatic];
 }

--- a/apps/web-next/src/lib/orchestrator-leaderboard/static-fleet.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/static-fleet.ts
@@ -1,0 +1,68 @@
+/**
+ * NAAP-9 — Static-fleet fallback.
+ *
+ * ClickHouse discovery (`semantic.network_capabilities`, warm rows in the last
+ * hour) silently drops orchestrators that lack warm rows for a requested
+ * capability — e.g. the scope staging orchs (`orch-staging-1/2/3`) when they
+ * have no warm `scope` rows. The static fleet is the known-good fallback set
+ * (mirrors `simple-infra/discovery/staging.json` + `fleet.yaml`, plus the BYOC
+ * tool host) so the Daydream→NaaP switch never loses an orchestrator.
+ *
+ * The static fleet is a property of the PLAN (provider-agnostic), not of
+ * Storyboard. The addresses come from each plan category's `staticOrchestrators`.
+ */
+
+/** Normalize an address: trim and drop empties. */
+function normalizeAddress(raw: string): string {
+  return raw.trim();
+}
+
+/**
+ * Merge a discovered, ranked address list with a static-fleet fallback.
+ *
+ * Discovered addresses keep their (ranked) order and come first; static-fleet
+ * addresses not already discovered are appended (so they land in the lowest
+ * tier of the subsequent tier shuffle, never displacing live-ranked orchs).
+ * The result is de-duplicated, first-occurrence wins.
+ */
+export function mergeStaticFleet(
+  discovered: readonly string[],
+  staticFallback: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const raw of [...discovered, ...staticFallback]) {
+    const address = normalizeAddress(raw);
+    if (!address || seen.has(address)) {
+      continue;
+    }
+    seen.add(address);
+    merged.push(address);
+  }
+
+  return merged;
+}
+
+/**
+ * Returns the static-fleet addresses that are MISSING from the discovered set.
+ * Useful for structured logging (how many fallbacks were injected) without
+ * leaking the full address list.
+ */
+export function staticFleetGaps(
+  discovered: readonly string[],
+  staticFallback: readonly string[],
+): string[] {
+  const discoveredSet = new Set(discovered.map(normalizeAddress).filter(Boolean));
+  const gaps: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of staticFallback) {
+    const address = normalizeAddress(raw);
+    if (!address || discoveredSet.has(address) || seen.has(address)) {
+      continue;
+    }
+    seen.add(address);
+    gaps.push(address);
+  }
+  return gaps;
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
@@ -1,0 +1,202 @@
+/**
+ * NAAP-9 — Storyboard Default discovery builder.
+ *
+ * Pure(ish) orchestration of the default plan: union ClickHouse results across
+ * each category's capabilities, merge the static-fleet fallback per category,
+ * apply the provider denylist (pymthouse only), dedupe, and tier-shuffle into
+ * the bare `[{ address }]` discovery payload.
+ *
+ * The fetch step is injected (`fetchCapabilityAddresses`) so this module stays
+ * unit-testable without ClickHouse and so the golden-set parity test can mock
+ * the leaderboard per capability.
+ */
+
+import {
+  STORYBOARD_DEFAULT_CATEGORY_KEYS,
+  STORYBOARD_DEFAULT_PLAN,
+  type StoryboardDefaultCategory,
+  type StoryboardDefaultCategoryKey,
+  type StoryboardDefaultPlan,
+} from './storyboard-default-plan';
+import { mergeStaticFleet, staticFleetGaps } from './static-fleet';
+import {
+  tieredShuffleDiscoveryAddresses,
+  tieredShuffleWithStaticFallback,
+  type RandomSource,
+} from './discovery-order';
+import { isCapabilityAllowedForProvider } from './provider-restrictions';
+
+/** Result of fetching one capability's ranked orchestrators. */
+export interface CapabilityFetchResult {
+  addresses: string[];
+  fromCache: boolean;
+  cachedAt: number;
+}
+
+export type FetchCapabilityAddresses = (
+  leaderboardCap: string,
+) => Promise<CapabilityFetchResult>;
+
+export interface StoryboardDefaultByKind {
+  /** Scope ORCHESTRATOR addresses (identity matters): live + static fleet. */
+  scope: string[];
+  /** BYOC CAPABILITIES included after the provider denylist. */
+  byoc: string[];
+  /** Tool CAPABILITIES included after the provider denylist. */
+  tool: string[];
+}
+
+export interface StoryboardDefaultDiscoveryResult {
+  /** Flattened, tier-shuffled discovery payload addresses. */
+  addresses: string[];
+  byKind: StoryboardDefaultByKind;
+  meta: {
+    fromCache: boolean;
+    cacheAgeMs: number;
+    staticFleetInjected: number;
+  };
+}
+
+export interface BuildStoryboardDefaultDiscoveryArgs {
+  fetchCapabilityAddresses: FetchCapabilityAddresses;
+  /** Resolved billing provider slug; pymthouse triggers the denylist. */
+  billingProviderSlug?: string | null;
+  plan?: StoryboardDefaultPlan;
+  topN?: number;
+  random?: RandomSource;
+}
+
+/** Split a full cap path into the short leaderboard capability (after `/`). */
+function leaderboardCapFromPath(raw: string): string {
+  const value = raw.trim();
+  const slash = value.lastIndexOf('/');
+  return slash >= 0 ? value.slice(slash + 1).trim() : value;
+}
+
+/**
+ * Collect live, ranked addresses for a category's capabilities, honoring the
+ * provider denylist. Returns the discovered addresses plus the list of caps
+ * that were actually queried (provider-allowed).
+ */
+async function collectCategory(
+  category: StoryboardDefaultCategory,
+  billingProviderSlug: string | null | undefined,
+  fetchCapabilityAddresses: FetchCapabilityAddresses,
+  topN: number,
+): Promise<{
+  discovered: string[];
+  allowedCapabilities: string[];
+  fromCache: boolean;
+  cacheAgeMs: number;
+}> {
+  const discovered: string[] = [];
+  const seen = new Set<string>();
+  const allowedCapabilities: string[] = [];
+  let fromCache = true;
+  let cacheAgeMs = 0;
+
+  for (const raw of category.capabilities) {
+    if (!isCapabilityAllowedForProvider(raw, billingProviderSlug)) {
+      continue;
+    }
+    allowedCapabilities.push(raw);
+
+    const leaderboardCap = leaderboardCapFromPath(raw);
+    const result = await fetchCapabilityAddresses(leaderboardCap);
+    fromCache = fromCache && result.fromCache;
+    cacheAgeMs = Math.max(cacheAgeMs, Date.now() - result.cachedAt);
+
+    for (const addr of result.addresses) {
+      const address = addr.trim();
+      if (!address || seen.has(address)) {
+        continue;
+      }
+      seen.add(address);
+      discovered.push(address);
+      if (discovered.length >= topN) {
+        break;
+      }
+    }
+    if (discovered.length >= topN) {
+      break;
+    }
+  }
+
+  return { discovered, allowedCapabilities, fromCache, cacheAgeMs };
+}
+
+/**
+ * Build the Storyboard Default discovery bundle.
+ *
+ * - scope: live + static-fleet merge (static fleet joins the tier shuffle),
+ *   guaranteeing all known staging orchs (incl. orch-staging-3) are present.
+ * - byoc/tool: union of live results across caps + their static fleet.
+ * - provider denylist applied only when `billingProviderSlug === 'pymthouse'`.
+ */
+export async function buildStoryboardDefaultDiscovery(
+  args: BuildStoryboardDefaultDiscoveryArgs,
+): Promise<StoryboardDefaultDiscoveryResult> {
+  const plan = args.plan ?? STORYBOARD_DEFAULT_PLAN;
+  const topN = args.topN ?? plan.topN;
+  const random = args.random;
+  const provider = args.billingProviderSlug ?? null;
+
+  let fromCache = true;
+  let cacheAgeMs = 0;
+  let staticFleetInjected = 0;
+
+  const perCategoryAddresses: Record<StoryboardDefaultCategoryKey, string[]> = {
+    scope: [],
+    byoc: [],
+    tool: [],
+  };
+  const byKind: StoryboardDefaultByKind = { scope: [], byoc: [], tool: [] };
+
+  for (const key of STORYBOARD_DEFAULT_CATEGORY_KEYS) {
+    const category = plan[key];
+    const collected = await collectCategory(
+      category,
+      provider,
+      args.fetchCapabilityAddresses,
+      topN,
+    );
+    fromCache = fromCache && collected.fromCache;
+    cacheAgeMs = Math.max(cacheAgeMs, collected.cacheAgeMs);
+
+    const staticFleet = [...category.staticOrchestrators];
+    staticFleetInjected += staticFleetGaps(collected.discovered, staticFleet).length;
+
+    const merged = mergeStaticFleet(collected.discovered, staticFleet);
+    perCategoryAddresses[key] = merged;
+
+    if (key === 'scope') {
+      // Scope identity matters: report the merged orchestrator addresses.
+      byKind.scope = merged;
+    } else {
+      // byoc/tool: the capability set that was included is what parity checks.
+      byKind[key] = collected.allowedCapabilities;
+    }
+  }
+
+  // Scope addresses get static fleet shuffled in; flatten all categories.
+  const scopeShuffled = tieredShuffleWithStaticFallback(
+    perCategoryAddresses.scope,
+    [],
+    random ? { random } : undefined,
+  );
+  const flattened = [
+    ...scopeShuffled,
+    ...perCategoryAddresses.byoc,
+    ...perCategoryAddresses.tool,
+  ];
+  const addresses = tieredShuffleDiscoveryAddresses(
+    flattened,
+    random ? { random } : undefined,
+  );
+
+  return {
+    addresses,
+    byKind,
+    meta: { fromCache, cacheAgeMs, staticFleetInjected },
+  };
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
@@ -163,7 +163,10 @@ export async function buildStoryboardDefaultDiscovery(
     fromCache = fromCache && collected.fromCache;
     cacheAgeMs = Math.max(cacheAgeMs, collected.cacheAgeMs);
 
-    const staticFleet = [...category.staticOrchestrators];
+    // Respect the provider-scoped denylist: when filtering allows zero
+    // capabilities for this category, do not inject its static fleet.
+    const staticFleet =
+      collected.allowedCapabilities.length > 0 ? [...category.staticOrchestrators] : [];
     staticFleetInjected += staticFleetGaps(collected.discovered, staticFleet).length;
 
     const merged = mergeStaticFleet(collected.discovered, staticFleet);

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
@@ -1,0 +1,123 @@
+/**
+ * NAAP-9 — Storyboard Default discovery bundle (Daydream parity).
+ *
+ * The DEFAULT PLAN: the concrete instance of the generic capability gate
+ * (NAAP-E). It guarantees a non-disruptive switch from the live Daydream
+ * discovery path to NaaP discovery by returning ⊇ the orchestrator/capability
+ * set Storyboard's MCP currently uses (scope staging + BYOC + tool), with a
+ * static-fleet fallback merged into the tier shuffle so no orchestrator is
+ * silently dropped when ClickHouse lacks warm rows.
+ *
+ * The byoc/tool capability arrays and static orchestrators below are the
+ * committed-staging BASELINE. Per Decision D7 they MUST be reconciled at build
+ * time against the live `sdk.daydream.monster/capabilities` snapshot (the
+ * golden set) — they are not authoritative on their own. The golden-set parity
+ * test guards drift in both directions.
+ *
+ * Everything here is generic: `storyboard-default` is just the first plan to
+ * ride the capability gate; the static-fleet fallback is a property of the
+ * plan, not of Storyboard.
+ */
+
+export const STORYBOARD_DEFAULT_PLAN_ID = 'storyboard-default';
+
+/** Env flag gating the bundle. Default OFF → existing per-cap behavior. */
+export const STORYBOARD_DEFAULT_DISCOVERY_FLAG = 'STORYBOARD_DEFAULT_DISCOVERY_ENABLED';
+
+export interface StoryboardDefaultCategory {
+  /** Leaderboard capability ids queried for this category. */
+  readonly capabilities: readonly string[];
+  /** Static-fleet fallback orchestrator addresses for this category. */
+  readonly staticOrchestrators: readonly string[];
+}
+
+export interface StoryboardDefaultPlan {
+  readonly id: string;
+  readonly name: string;
+  /** No pymthouse denylist until a real provider plan (PYMT-5) enforces. */
+  readonly billingProviderSlug: string;
+  readonly scope: StoryboardDefaultCategory;
+  readonly byoc: StoryboardDefaultCategory;
+  readonly tool: StoryboardDefaultCategory;
+  readonly topN: number;
+}
+
+export const STORYBOARD_DEFAULT_PLAN: StoryboardDefaultPlan = {
+  id: STORYBOARD_DEFAULT_PLAN_ID,
+  name: 'Storyboard Default (Daydream parity)',
+  billingProviderSlug: 'daydream',
+  scope: {
+    capabilities: ['live-video-to-video/scope'],
+    staticOrchestrators: [
+      'https://orch-staging-1.daydream.monster:8935',
+      'https://orch-staging-2.daydream.monster:8935',
+      'https://orch-staging-3.daydream.monster:8935',
+    ],
+  },
+  byoc: {
+    capabilities: [
+      'nano-banana',
+      'recraft-v4',
+      'flux-schnell',
+      'flux-dev',
+      'ltx-t2v',
+      'ltx-i2v',
+      'kontext-edit',
+      'bg-remove',
+      'topaz-upscale',
+      'chatterbox-tts',
+      'gemini-image',
+      'gemini-text',
+    ],
+    staticOrchestrators: ['https://byoc-staging-1.daydream.monster:8935'],
+  },
+  tool: {
+    capabilities: [
+      'ffmpeg-concat',
+      'ffmpeg-trim',
+      'ffmpeg-overlay',
+      'ffmpeg-export',
+      'ffmpeg-audio-mix',
+      'ffmpeg-loop',
+      'ffmpeg-burn-subtitles',
+      'ffmpeg-grid',
+      'ffmpeg-mux',
+      'pillow-resize',
+      'pillow-watermark',
+      'pillow-format',
+      'pillow-palette',
+      'pillow-grid',
+      'obscura-extract-text',
+      'obscura-extract-markdown',
+      'obscura-extract-links',
+      'hyperframes-caption',
+      'hyperframes-lower-third',
+      'hyperframes-render',
+      'yolo-detect',
+      'yolo-segment',
+      'cad-render',
+      'cad-validate',
+    ],
+    staticOrchestrators: ['https://byoc-staging-1.daydream.monster:8935'],
+  },
+  topN: 100,
+} as const;
+
+export type StoryboardDefaultCategoryKey = 'scope' | 'byoc' | 'tool';
+
+export const STORYBOARD_DEFAULT_CATEGORY_KEYS: readonly StoryboardDefaultCategoryKey[] = [
+  'scope',
+  'byoc',
+  'tool',
+];
+
+/**
+ * Reads the feature flag. Default OFF: any value other than a truthy string
+ * (`"true"`/`"1"`) leaves the Daydream path authoritative.
+ */
+export function isStoryboardDefaultDiscoveryEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env[STORYBOARD_DEFAULT_DISCOVERY_FLAG]?.trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}

--- a/plugins/orchestrator-leaderboard/docs/data-sources.md
+++ b/plugins/orchestrator-leaderboard/docs/data-sources.md
@@ -101,6 +101,41 @@ same orchestrator, the resolver builds a cross-reference map to join them.
 
 ---
 
+## Storyboard Default discovery bundle (NAAP-9, Daydream parity)
+
+Default ClickHouse discovery is **per-requested-capability** and only returns
+orchestrators with **warm rows in the last hour** (`semantic.network_capabilities`,
+`warm_bool = 1`). Orchestrators without warm rows for a requested capability are
+**silently dropped** — e.g. the scope staging orchs
+(`orch-staging-1/2/3`, capability `live-video-to-video/scope`).
+
+The **Storyboard Default plan** (`storyboard-default`) is the concrete instance
+of the generic capability gate (NAAP-E). It guarantees a **non-disruptive
+Daydream→NaaP discovery switch** by returning ⊇ the live Daydream set across
+three categories — **scope**, **BYOC**, and **tool** — with a **static-fleet
+fallback** merged into the tier shuffle so no known orchestrator is dropped.
+
+- **Endpoint**: `GET /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway`
+  (also reachable via the default endpoint with `?plan=storyboard-default`).
+- **Static fleet**: the plan's per-category `staticOrchestrators` (mirrors
+  `simple-infra/discovery/staging.json` + `fleet.yaml`, plus the BYOC tool host).
+  Live-ranked orchs keep their order; missing static-fleet addresses are
+  appended into the lowest tier (`tieredShuffleWithStaticFallback`) — present,
+  never displacing live-ranked orchs.
+- **Feature flag**: `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default **OFF**).
+  When OFF the dedicated endpoint returns `404` and the `?plan=` param is
+  ignored, so the live Daydream path stays authoritative until parity is proven.
+- **Provider-agnostic**: the pymthouse capability denylist is applied **only**
+  when `billingProviderSlug=pymthouse`; the static-fleet fallback is a property
+  of the *plan*, not of Storyboard.
+- **Golden-set parity test**: the bundle is guarded by a bidirectional
+  golden-set test (`storyboard-default/__tests__/golden-set.test.ts` +
+  `__snapshots__/golden-set.json`) — captured empirically from the live
+  Daydream path (Decision D7) — that fails if any scope address or BYOC/tool
+  capability is silently dropped **or** added.
+
+---
+
 ## Audit log
 
 Every refresh writes a `LeaderboardRefreshAudit` record to the database with:

--- a/plugins/orchestrator-leaderboard/docs/openapi.yaml
+++ b/plugins/orchestrator-leaderboard/docs/openapi.yaml
@@ -328,6 +328,16 @@ paths:
           in: query
           required: false
           schema: { type: integer, minimum: 1, maximum: 1000, default: 100 }
+        - name: plan
+          in: query
+          required: false
+          schema: { type: string, enum: [storyboard-default] }
+          description: |
+            NAAP-9. When `plan=storyboard-default` AND the
+            `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` flag is ON, returns the fixed
+            Storyboard Default bundle (Daydream parity) with a static-fleet
+            fallback merged into the tier shuffle. When the flag is OFF (default)
+            the param is ignored and the per-cap behavior is used.
         - $ref: "#/components/parameters/BillingProviderSlugQuery"
         - name: billingProvider
           in: query
@@ -345,7 +355,7 @@ paths:
             X-Cache-Age:
               schema: { type: integer }
             X-Discovery-Mode:
-              schema: { type: string, enum: [default] }
+              schema: { type: string, enum: [default, storyboard-default] }
           content:
             application/json:
               schema:
@@ -358,6 +368,62 @@ paths:
               schema: { type: string }
         "401":
           description: Unauthorized
+          content:
+            text/plain:
+              schema: { type: string }
+        "500":
+          description: Upstream failure
+          content:
+            text/plain:
+              schema: { type: string }
+
+  /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway:
+    get:
+      tags: [Python Gateway Discovery]
+      summary: Storyboard Default discovery bundle (Daydream parity) — NAAP-9
+      description: |
+        Returns the fixed default-plan orchestrator/capability set (scope
+        staging + BYOC + tool) with a static-fleet fallback merged into the tier
+        shuffle, guaranteeing a non-disruptive Daydream→NaaP discovery switch
+        (golden-set parity). The default plan is the concrete instance of the
+        generic capability gate (NAAP-E), not a Storyboard special-case.
+
+        Gated by `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default OFF): when OFF
+        the endpoint returns `404` and the live Daydream path stays
+        authoritative. The pymthouse denylist is applied only when
+        `billingProviderSlug=pymthouse`.
+      operationId: getStoryboardDefaultPythonGateway
+      parameters:
+        - $ref: "#/components/parameters/BillingProviderSlugQuery"
+        - name: billingProvider
+          in: query
+          required: false
+          schema: { $ref: "#/components/schemas/BillingProviderSlug" }
+          description: Alias for `billingProviderSlug`.
+      responses:
+        "200":
+          description: Default-plan orchestrator addresses (BYOC + tool + scope)
+          headers:
+            Cache-Control:
+              schema: { type: string, example: "private, no-store, must-revalidate" }
+            X-Cache:
+              schema: { type: string, enum: [HIT, MISS] }
+            X-Cache-Age:
+              schema: { type: integer }
+            X-Discovery-Mode:
+              schema: { type: string, enum: [storyboard-default] }
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/PythonGatewayAddress" }
+        "401":
+          description: Unauthorized
+          content:
+            text/plain:
+              schema: { type: string }
+        "404":
+          description: Disabled (flag OFF — Daydream path authoritative)
           content:
             text/plain:
               schema: { type: string }


### PR DESCRIPTION
> **DO NOT MERGE — gated by D0.** Additive, behind a feature flag defaulting OFF. Merge only when the integration wave coordinator (D0) gives the go; flag flips bottom-up and Storyboard's `provider_switch` flips LAST.

## Coordination
```
Plan PR ID:   NAAP-9
Repo:         NaaP (../NaaP)
Depends-on:   NAAP-3, NAAP-4, INFRA-3 (hard) · NAAP-E, PYMT-5 (soft)
Blocks:       E10 (Daydream→NaaP discovery switch acceptance)
Feature flag: STORYBOARD_DEFAULT_DISCOVERY_ENABLED (default OFF)
Merge-safety: With every OTHER repo at current main and this flag OFF, this PR is
              a no-op — the dedicated endpoint 404s and the `?plan=` param is
              ignored, so the existing per-cap discovery (Daydream path) stays
              authoritative. No migration. INV-1 green.
Fallback when deps lag: Flag OFF = today's behavior. When ON, ClickHouse warm-row
              gaps are covered by the static-fleet fallback (no hard dependency
              on provider/ClickHouse availability for the known staging fleet).
```

## What
The concrete **default plan** instance of the generic capability gate (NAAP-E): a discovery endpoint that returns **⊇ the orchestrator/capability set Storyboard's MCP currently uses** (scope staging + BYOC + tool), with static fallbacks merged into the tier shuffle, so the **Daydream → NaaP discovery switch is non-disruptive**.

- `STORYBOARD_DEFAULT_PLAN` constant (committed-staging baseline; reconciled against the live Daydream golden set per **D7**).
- `static-fleet.ts` — fallback merge (`mergeStaticFleet`, `staticFleetGaps`); covers ClickHouse warm-row gaps (e.g. `orch-staging-3`, missing from `simple-infra/discovery/staging.json`).
- `discovery-order.ts` — `tieredShuffleWithStaticFallback`: static fleet **joins** the tier shuffle (lowest tier), never displacing live-ranked orchs.
- `storyboard-default-discovery.ts` — builder: union ClickHouse across each category's caps, merge static fallback per category, dedupe, tier-shuffle, return `[{address}]`; exposes `byKind` for the parity test.
- New `GET .../orchestrator-leaderboard/storyboard-default/python-gateway` **and** `?plan=storyboard-default` on the default route.
- pymthouse denylist applied **only** when `billingProviderSlug=pymthouse` (reuses `isCapabilityAllowedForProvider`) — provider-agnostic.
- OpenAPI + `data-sources.md` updated.

## Feature flag
`STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default **OFF**). OFF → dedicated route returns `404`, `?plan=` ignored, existing behavior unchanged.

## Tests (golden-set parity)
- **Golden-set parity** (`storyboard-default/__tests__/golden-set.test.ts` + `__snapshots__/golden-set.json`): asserts `scope` addresses, `byoc` caps, `tool` caps match the golden set **bidirectionally** (no missing AND no extra). Negative tests: removing a golden cap/address fails; the scope mock omits `orch-staging-3` to prove the static-fleet re-injects it (catches staging.json drift).
- Unit: `static-fleet`, `tieredShuffleWithStaticFallback`, dedicated route (flag ON → 200, OFF → 404, unauth → 401).
- Local: 26 unit tests green; `tsc --noEmit` clean for all touched files; `next lint` clean.

## Zero-regression / availability
- Flag OFF is a no-op for every other repo at current main; no migration; INV-1 (Storyboard live Daydream path) unaffected.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added new "storyboard-default" orchestrator discovery endpoint, controlled by feature flag
- Introduced static-fleet fallback mechanism to enhance discovery reliability
- New "storyboard-default" discovery mode available as optional parameter in orchestrator-leaderboard requests

## Documentation
- Updated API specification with new discovery mode and endpoint details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->