### PR TITLE
chore(integration): NaaP Phase-2 integration — DO NOT MERGE

### DIFF
--- a/apps/web-next/.env.local.example
+++ b/apps/web-next/.env.local.example
@@ -167,6 +167,15 @@ FACADE_USE_STUBS=true
 # PYMTHOUSE_M2M_CLIENT_SECRET=...
 # PYMTHOUSE_BASE_URL=http://localhost:3001   # optional; marketplace link origin when unset elsewhere
 #
+# Staging (pymthouse) reference — issuer origin https://staging.pymthouse.com.
+# Issuer URL is the OIDC mount; the SDK resolves …/.well-known/openid-configuration from it.
+# The public + M2M client id are the same public app_… id. The M2M client SECRET is
+# provided ONLY via the PYMTHOUSE_M2M_CLIENT_SECRET env/secret store — NEVER commit it.
+# PYMTHOUSE_ISSUER_URL=https://staging.pymthouse.com/api/v1/oidc
+# PYMTHOUSE_PUBLIC_CLIENT_ID=app_2d89999406f9be57dd0233de
+# PYMTHOUSE_M2M_CLIENT_ID=app_2d89999406f9be57dd0233de
+# PYMTHOUSE_M2M_CLIENT_SECRET=   # set in the secret store only — do not write the value here
+#
 # Device-flow third-party initiate login: register initiate_login_uri in PymtHouse app settings as
 #   {NEXT_PUBLIC_APP_URL}/login
 # PymtHouse redirects here with ?iss=&target_link_uri=&login_hint= ; NAAP validates iss/origin and

--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -78,6 +78,8 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.0.18",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^2.1.1",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.16.0",
     "eslint-config-next": "15.5.12",

--- a/apps/web-next/src/app/api/v1/apps/[id]/route.ts
+++ b/apps/web-next/src/app/api/v1/apps/[id]/route.ts
@@ -1,0 +1,101 @@
+/**
+ * Application / service registry — single app (NAAP-D).
+ *
+ *   GET    /api/v1/apps/{id}  — fetch one app (own scope)
+ *   PATCH  /api/v1/apps/{id}  — update name/type/scopes/capabilities/status
+ *   DELETE /api/v1/apps/{id}  — remove an app
+ *
+ * Gated behind the `app_registry` flag (default OFF) → 404 when OFF.
+ * Returns 404 (not 403) for other scopes' apps to prevent enumeration.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { prisma } from '@/lib/db';
+import { success, successNoContent, errors } from '@/lib/api/response';
+import { getAdminContext, isErrorResponse } from '@/lib/gateway/admin/team-guard';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { APP_REGISTRY_FLAG, APP_SCOPES, APP_TYPES } from '@/lib/apps/registry';
+
+type Params = { params: Promise<{ id: string }> };
+
+const updateAppSchema = z
+  .object({
+    name: z.string().min(1).max(128).optional(),
+    type: z.enum(APP_TYPES).optional(),
+    allowedScopes: z.array(z.enum(APP_SCOPES)).optional(),
+    allowedCapabilities: z.array(z.string().min(1).max(128)).optional(),
+    status: z.enum(['active', 'disabled']).optional(),
+  })
+  .refine((d) => Object.keys(d).length > 0, { message: 'No fields to update' });
+
+function ownerWhere(ctx: { teamId: string; userId: string; isPersonal: boolean }) {
+  return ctx.isPersonal ? { ownerUserId: ctx.userId } : { teamId: ctx.teamId };
+}
+
+export async function GET(request: NextRequest, { params }: Params) {
+  if (!(await isFeatureEnabled(APP_REGISTRY_FLAG))) return errors.notFound('Resource');
+
+  const ctx = await getAdminContext(request);
+  if (isErrorResponse(ctx)) return ctx;
+
+  const { id } = await params;
+  const app = await prisma.application.findFirst({ where: { id, ...ownerWhere(ctx) } });
+  if (!app) return errors.notFound('Application');
+  return success(app);
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  if (!(await isFeatureEnabled(APP_REGISTRY_FLAG))) return errors.notFound('Resource');
+
+  const ctx = await getAdminContext(request);
+  if (isErrorResponse(ctx)) return ctx;
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errors.badRequest('Invalid JSON body');
+  }
+
+  const parsed = updateAppSchema.safeParse(body);
+  if (!parsed.success) {
+    return errors.validationError(
+      Object.fromEntries(parsed.error.errors.map((e) => [e.path.join('.'), e.message])),
+    );
+  }
+
+  const existing = await prisma.application.findFirst({
+    where: { id, ...ownerWhere(ctx) },
+    select: { id: true },
+  });
+  if (!existing) return errors.notFound('Application');
+
+  const app = await prisma.application.update({
+    where: { id },
+    data: parsed.data,
+  });
+  return success(app);
+}
+
+export async function DELETE(request: NextRequest, { params }: Params) {
+  if (!(await isFeatureEnabled(APP_REGISTRY_FLAG))) return errors.notFound('Resource');
+
+  const ctx = await getAdminContext(request);
+  if (isErrorResponse(ctx)) return ctx;
+
+  const { id } = await params;
+  const existing = await prisma.application.findFirst({
+    where: { id, ...ownerWhere(ctx) },
+    select: { id: true },
+  });
+  if (!existing) return errors.notFound('Application');
+
+  await prisma.application.delete({ where: { id } });
+  return successNoContent();
+}

--- a/apps/web-next/src/app/api/v1/apps/route.test.ts
+++ b/apps/web-next/src/app/api/v1/apps/route.test.ts
@@ -1,0 +1,114 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, POST } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  APP_REGISTRY_FLAG: 'app_registry',
+}));
+
+const getAdminContext = vi.fn();
+vi.mock('@/lib/gateway/admin/team-guard', () => ({
+  getAdminContext: (...a: unknown[]) => getAdminContext(...a),
+  isErrorResponse: (r: unknown) => r instanceof Response,
+}));
+
+const create = vi.fn();
+const findUnique = vi.fn();
+const findMany = vi.fn();
+const count = vi.fn();
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    application: {
+      create: (...a: unknown[]) => create(...a),
+      findUnique: (...a: unknown[]) => findUnique(...a),
+      findMany: (...a: unknown[]) => findMany(...a),
+      count: (...a: unknown[]) => count(...a),
+    },
+  },
+}));
+
+function req(body?: unknown): NextRequest {
+  return new NextRequest('https://naap.test/api/v1/apps', {
+    method: body === undefined ? 'GET' : 'POST',
+    headers: { 'content-type': 'application/json', 'x-team-id': 'team-1' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const teamCtx = { userId: 'user-1', teamId: 'team-1', token: 't', isPersonal: false };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAdminContext.mockResolvedValue(teamCtx);
+});
+
+describe('app_registry flag OFF → no-op', () => {
+  it('GET returns 404 when the flag is off', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+    expect(getAdminContext).not.toHaveBeenCalled();
+  });
+
+  it('POST returns 404 when the flag is off', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(req({ slug: 'x', name: 'X' }));
+    expect(res.status).toBe(404);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('app_registry flag ON', () => {
+  beforeEach(() => isFeatureEnabled.mockResolvedValue(true));
+
+  it('registers an app scoped to the caller team', async () => {
+    findUnique.mockResolvedValue(null);
+    create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: 'app-new',
+      ...data,
+    }));
+
+    const res = await POST(
+      req({ slug: 'naap-cli', name: 'NaaP CLI', type: 'cli', allowedScopes: ['discovery'] }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.slug).toBe('naap-cli');
+
+    const arg = create.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(arg.data.teamId).toBe('team-1');
+    expect(arg.data.ownerUserId).toBeUndefined();
+    expect(arg.data.allowedScopes).toEqual(['discovery']);
+  });
+
+  it('rejects a duplicate slug with 409', async () => {
+    findUnique.mockResolvedValue({ id: 'existing' });
+    const res = await POST(req({ slug: 'storyboard', name: 'Storyboard' }));
+    expect(res.status).toBe(409);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown scope with a validation error', async () => {
+    const res = await POST(req({ slug: 'x-app', name: 'X', allowedScopes: ['bogus'] }));
+    expect(res.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('lists apps in the caller scope', async () => {
+    findMany.mockResolvedValue([{ id: 'app-1', slug: 'storyboard' }]);
+    count.mockResolvedValue(1);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toHaveLength(1);
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { teamId: 'team-1' } }),
+    );
+  });
+});

--- a/apps/web-next/src/app/api/v1/apps/route.ts
+++ b/apps/web-next/src/app/api/v1/apps/route.ts
@@ -1,0 +1,120 @@
+/**
+ * Application / service registry (NAAP-D).
+ *
+ *   GET  /api/v1/apps   — list apps in the caller's scope
+ *   POST /api/v1/apps   — register a new app/service
+ *
+ * Gated behind the `app_registry` flag (default OFF): when OFF this route is a
+ * no-op (404), so registering apps is dormant until an admin enables it. Zero
+ * regression — no existing surface changes.
+ *
+ * Never logs secrets/PII — only request metadata + correlation id.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+import { prisma } from '@/lib/db';
+import { success, errors, parsePagination, successPaginated } from '@/lib/api/response';
+import { getAdminContext, isErrorResponse } from '@/lib/gateway/admin/team-guard';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { APP_REGISTRY_FLAG, APP_SCOPES, APP_TYPES } from '@/lib/apps/registry';
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
+
+const createAppSchema = z.object({
+  slug: z.string().regex(SLUG_RE, 'slug must be lowercase alphanumeric/hyphen, 2-63 chars'),
+  name: z.string().min(1).max(128),
+  type: z.enum(APP_TYPES).default('app'),
+  allowedScopes: z.array(z.enum(APP_SCOPES)).default([]),
+  allowedCapabilities: z.array(z.string().min(1).max(128)).default([]),
+});
+
+function ownerWhere(ctx: { teamId: string; userId: string; isPersonal: boolean }) {
+  return ctx.isPersonal ? { ownerUserId: ctx.userId } : { teamId: ctx.teamId };
+}
+
+function correlationId(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(event: string, fields: Record<string, unknown>): void {
+  console.info(JSON.stringify({ level: 'info', event, ...fields }));
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await isFeatureEnabled(APP_REGISTRY_FLAG))) return errors.notFound('Resource');
+
+  const ctx = await getAdminContext(request);
+  if (isErrorResponse(ctx)) return ctx;
+
+  const { page, pageSize, skip } = parsePagination(request.nextUrl.searchParams);
+  const where = ownerWhere(ctx);
+
+  const [apps, total] = await Promise.all([
+    prisma.application.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take: pageSize,
+    }),
+    prisma.application.count({ where }),
+  ]);
+
+  return successPaginated(apps, { page, pageSize, total });
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await isFeatureEnabled(APP_REGISTRY_FLAG))) return errors.notFound('Resource');
+
+  const ctx = await getAdminContext(request);
+  if (isErrorResponse(ctx)) return ctx;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errors.badRequest('Invalid JSON body');
+  }
+
+  const parsed = createAppSchema.safeParse(body);
+  if (!parsed.success) {
+    return errors.validationError(
+      Object.fromEntries(parsed.error.errors.map((e) => [e.path.join('.'), e.message])),
+    );
+  }
+
+  const existing = await prisma.application.findUnique({
+    where: { slug: parsed.data.slug },
+    select: { id: true },
+  });
+  if (existing) return errors.conflict('An application with this slug already exists');
+
+  const ownerData = ctx.isPersonal
+    ? { ownerUserId: ctx.userId }
+    : { teamId: ctx.teamId };
+
+  const app = await prisma.application.create({
+    data: {
+      ...ownerData,
+      createdBy: ctx.userId,
+      slug: parsed.data.slug,
+      name: parsed.data.name,
+      type: parsed.data.type,
+      allowedScopes: parsed.data.allowedScopes,
+      allowedCapabilities: parsed.data.allowedCapabilities,
+    },
+  });
+
+  log('app.register', {
+    correlationId: correlationId(request),
+    appId: app.id,
+    slug: app.slug,
+    scope: ctx.isPersonal ? 'personal' : 'team',
+  });
+
+  return success(app);
+}

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.test.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.test.ts
@@ -1,0 +1,188 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { AuthUser } from '@naap/types';
+
+import { GET, POST } from './route';
+import { AdapterNotImplementedError } from '@/lib/billing/adapter';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+}));
+
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({
+  validateSession: (...a: unknown[]) => validateSession(...a),
+}));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
+
+function authUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: 'user-1',
+    email: 'u@example.com',
+    displayName: null,
+    avatarUrl: null,
+    address: null,
+    roles: [],
+    permissions: [],
+    ...overrides,
+  };
+}
+
+function makeAdapter(overrides: Record<string, unknown> = {}) {
+  return {
+    slug: 'pymthouse',
+    isConfigured: vi.fn(() => true),
+    validate: vi.fn(),
+    getPlans: vi.fn(),
+    getUsageForExternalUser: vi.fn(async () => ({ requestCount: 1 })),
+    getAppUsage: vi.fn(async () => ({ totals: { requestCount: 0 } })),
+    mintSignerSession: vi.fn(async () => ({
+      accessToken: 'tok-abc',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      scope: 'sign:job',
+    })),
+    receiveCuratedOrchestrators: vi.fn(),
+    getCapabilityManifest: vi.fn(),
+    ...overrides,
+  };
+}
+
+function req(
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+): NextRequest {
+  return new NextRequest(url, {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', ...(init?.headers ?? {}) },
+  });
+}
+
+function params(provider: string, path: string[]) {
+  return { params: Promise.resolve({ provider, path }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue(authUser());
+  getBillingProviderAdapter.mockReturnValue(makeAdapter());
+});
+
+describe('generic /api/v1/billing/{provider}/* — flag OFF (zero regression)', () => {
+  it('is a no-op 404 when provider_adapters is OFF', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(404);
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+    expect(validateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('generic billing route — flag ON', () => {
+  it('404s for an unknown provider', async () => {
+    getBillingProviderAdapter.mockReturnValue(undefined);
+    const res = await GET(
+      req('http://localhost/api/v1/billing/nope/usage'),
+      params('nope', ['usage']),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('404s for an invalid provider slug', async () => {
+    const res = await GET(
+      req('http://localhost/api/v1/billing/Bad_Slug/usage'),
+      params('Bad_Slug', ['usage']),
+    );
+    expect(res.status).toBe(404);
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+  });
+
+  it('401 without an auth token', async () => {
+    const res = await GET(
+      new NextRequest('http://localhost/api/v1/billing/pymthouse/usage'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('delegates usage scope=me to the adapter', async () => {
+    const adapter = makeAdapter();
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage?scope=me'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(200);
+    expect(adapter.getUsageForExternalUser).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'user-1' }),
+    );
+  });
+
+  it('403 for app scope when not system:admin', async () => {
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage?scope=app'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('delegates token mint to the adapter and returns the session', async () => {
+    const adapter = makeAdapter();
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await POST(
+      req('http://localhost/api/v1/billing/pymthouse/token', { method: 'POST' }),
+      params('pymthouse', ['token']),
+    );
+    expect(res.status).toBe(200);
+    expect(adapter.mintSignerSession).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'user-1' }),
+    );
+    const json = await res.json();
+    expect(json.data.access_token).toBe('tok-abc');
+  });
+
+  it('maps AdapterNotImplementedError to 501', async () => {
+    const adapter = makeAdapter({
+      mintSignerSession: vi.fn(async () => {
+        throw new AdapterNotImplementedError('pymthouse', 'mintSignerSession');
+      }),
+    });
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await POST(
+      req('http://localhost/api/v1/billing/pymthouse/token', { method: 'POST' }),
+      params('pymthouse', ['token']),
+    );
+    expect(res.status).toBe(501);
+  });
+
+  it('404s for an unsupported operation', async () => {
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/unknown-op'),
+      params('pymthouse', ['unknown-op']),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('400 when the provider is not configured', async () => {
+    getBillingProviderAdapter.mockReturnValue(makeAdapter({ isConfigured: vi.fn(() => false) }));
+    const res = await GET(
+      req('http://localhost/api/v1/billing/pymthouse/usage'),
+      params('pymthouse', ['usage']),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.test.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.test.ts
@@ -12,10 +12,22 @@ vi.mock('@/lib/feature-flags', () => ({
   isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
 }));
 
-const getBillingProviderAdapter = vi.fn();
-vi.mock('@/lib/billing/registry', () => ({
-  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+// NAAP-A-db: the route resolves adapters via the DB-driven resolver, which
+// falls back to the static registry when the flag is OFF. Mock the resolver and
+// return the static-source shape so these tests stay registry-agnostic.
+const resolveBillingProviderAdapterDetailed = vi.fn();
+vi.mock('@/lib/billing/registry-db', () => ({
+  resolveBillingProviderAdapterDetailed: (...a: unknown[]) =>
+    resolveBillingProviderAdapterDetailed(...a),
 }));
+
+function setResolvedAdapter(adapter: unknown): void {
+  resolveBillingProviderAdapterDetailed.mockResolvedValue({
+    adapter,
+    source: 'static',
+    adapterType: null,
+  });
+}
 
 const validateSession = vi.fn();
 vi.mock('@/lib/api/auth', () => ({
@@ -76,7 +88,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   isFeatureEnabled.mockResolvedValue(true);
   validateSession.mockResolvedValue(authUser());
-  getBillingProviderAdapter.mockReturnValue(makeAdapter());
+  setResolvedAdapter(makeAdapter());
 });
 
 describe('generic /api/v1/billing/{provider}/* — flag OFF (zero regression)', () => {
@@ -87,14 +99,14 @@ describe('generic /api/v1/billing/{provider}/* — flag OFF (zero regression)', 
       params('pymthouse', ['usage']),
     );
     expect(res.status).toBe(404);
-    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+    expect(resolveBillingProviderAdapterDetailed).not.toHaveBeenCalled();
     expect(validateSession).not.toHaveBeenCalled();
   });
 });
 
 describe('generic billing route — flag ON', () => {
   it('404s for an unknown provider', async () => {
-    getBillingProviderAdapter.mockReturnValue(undefined);
+    setResolvedAdapter(undefined);
     const res = await GET(
       req('http://localhost/api/v1/billing/nope/usage'),
       params('nope', ['usage']),
@@ -108,7 +120,7 @@ describe('generic billing route — flag ON', () => {
       params('Bad_Slug', ['usage']),
     );
     expect(res.status).toBe(404);
-    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+    expect(resolveBillingProviderAdapterDetailed).not.toHaveBeenCalled();
   });
 
   it('401 without an auth token', async () => {
@@ -121,7 +133,7 @@ describe('generic billing route — flag ON', () => {
 
   it('delegates usage scope=me to the adapter', async () => {
     const adapter = makeAdapter();
-    getBillingProviderAdapter.mockReturnValue(adapter);
+    setResolvedAdapter(adapter);
     const res = await GET(
       req('http://localhost/api/v1/billing/pymthouse/usage?scope=me'),
       params('pymthouse', ['usage']),
@@ -142,7 +154,7 @@ describe('generic billing route — flag ON', () => {
 
   it('delegates token mint to the adapter and returns the session', async () => {
     const adapter = makeAdapter();
-    getBillingProviderAdapter.mockReturnValue(adapter);
+    setResolvedAdapter(adapter);
     const res = await POST(
       req('http://localhost/api/v1/billing/pymthouse/token', { method: 'POST' }),
       params('pymthouse', ['token']),
@@ -161,7 +173,7 @@ describe('generic billing route — flag ON', () => {
         throw new AdapterNotImplementedError('pymthouse', 'mintSignerSession');
       }),
     });
-    getBillingProviderAdapter.mockReturnValue(adapter);
+    setResolvedAdapter(adapter);
     const res = await POST(
       req('http://localhost/api/v1/billing/pymthouse/token', { method: 'POST' }),
       params('pymthouse', ['token']),
@@ -178,7 +190,7 @@ describe('generic billing route — flag ON', () => {
   });
 
   it('400 when the provider is not configured', async () => {
-    getBillingProviderAdapter.mockReturnValue(makeAdapter({ isConfigured: vi.fn(() => false) }));
+    setResolvedAdapter(makeAdapter({ isConfigured: vi.fn(() => false) }));
     const res = await GET(
       req('http://localhost/api/v1/billing/pymthouse/usage'),
       params('pymthouse', ['usage']),

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
@@ -1,0 +1,272 @@
+/**
+ * Generic billing provider routing (NAAP-A).
+ *
+ *   GET  /api/v1/billing/{provider}/usage
+ *   POST /api/v1/billing/{provider}/token
+ *
+ * Delegates to the BillingProviderAdapter registry instead of any hardcoded
+ * provider. Gated behind the `provider_adapters` flag (default OFF): when OFF this
+ * route is a no-op (404), so the existing /api/v1/billing/pymthouse/* routes are
+ * the only billing surface and their behavior is unchanged. Zero regression.
+ *
+ * Never logs secrets/tokens/PII — only request metadata + correlation id.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { validateSession } from '@/lib/api/auth';
+import { validateCSRF } from '@/lib/api/csrf';
+import { enforceRateLimit } from '@/lib/api/rate-limit';
+import { error, errors, getAuthToken, success } from '@/lib/api/response';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { AdapterNotImplementedError, type BillingProviderAdapter } from '@/lib/billing/adapter';
+import { getBillingProviderAdapter } from '@/lib/billing/registry';
+
+const PROVIDER_ADAPTERS_FLAG = 'provider_adapters';
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_PER_USER = 30;
+const PROVIDER_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+type Params = { params: Promise<{ provider: string; path?: string[] }> };
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(
+  level: 'info' | 'warn' | 'error',
+  event: string,
+  fields: Record<string, unknown>,
+): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function isSystemAdmin(roles: string[] | undefined): boolean {
+  return Boolean(roles?.includes('system:admin'));
+}
+
+/** Drop crypto-unit fields (wei/eth/gwei) so raw on-chain amounts are not exposed. */
+function stripCryptoUnitFields(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripCryptoUnitFields);
+  if (!value || typeof value !== 'object') return value;
+  const units = ['wei', 'eth', 'gwei'];
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const lower = key.toLowerCase();
+    if (units.some((u) => lower === u || lower.endsWith(u))) continue;
+    out[key] = stripCryptoUnitFields(entry);
+  }
+  return out;
+}
+
+/** Strict YYYY-MM-DD or ISO 8601 date; returns null when invalid/empty. */
+function parseDateParam(raw: string | null): string | null {
+  if (raw == null) return null;
+  const v = raw.trim();
+  if (v === '') return null;
+  const ts = Date.parse(v);
+  if (Number.isNaN(ts)) return null;
+  return v;
+}
+
+/** Current UTC calendar-month [from, to] as ISO strings. */
+function currentUtcMonthBounds(): { startDate: string; endDate: string } {
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}
+
+function mapAdapterError(
+  e: unknown,
+  provider: string,
+  correlationId: string,
+  event: string,
+): NextResponse {
+  if (e instanceof AdapterNotImplementedError) {
+    log('warn', event, { provider, correlationId, reason: 'not_implemented', method: e.method });
+    return error('NOT_IMPLEMENTED', 'Operation not supported by this provider', 501);
+  }
+  const message = e instanceof Error ? e.message : 'Unknown error';
+  log('error', event, { provider, correlationId, message });
+  return errors.serviceUnavailable('Billing provider request failed');
+}
+
+interface RouteCtx {
+  request: NextRequest;
+  provider: string;
+  adapter: BillingProviderAdapter;
+  correlationId: string;
+  user: { id: string; email?: string | null; roles?: string[] };
+}
+
+async function handleUsage(ctx: RouteCtx): Promise<NextResponse> {
+  const { request, provider, adapter, correlationId, user } = ctx;
+  const sp = request.nextUrl.searchParams;
+
+  const scope = (sp.get('scope') ?? 'me').trim().toLowerCase();
+  if (scope !== 'me' && scope !== 'app') {
+    return noStore(errors.badRequest('Invalid scope; use me or app'));
+  }
+
+  const startRaw = sp.get('startDate');
+  const endRaw = sp.get('endDate');
+  const hasStart = startRaw != null && startRaw.trim() !== '';
+  const hasEnd = endRaw != null && endRaw.trim() !== '';
+  if (hasStart !== hasEnd) {
+    return noStore(errors.badRequest('startDate and endDate must both be set or both omitted'));
+  }
+
+  let startDate: string;
+  let endDate: string;
+  if (hasStart) {
+    const s = parseDateParam(startRaw);
+    const e = parseDateParam(endRaw);
+    if (!s || !e) return noStore(errors.badRequest('Invalid startDate or endDate'));
+    if (Date.parse(s) > Date.parse(e)) {
+      return noStore(errors.badRequest('startDate must be <= endDate'));
+    }
+    startDate = s;
+    endDate = e;
+  } else {
+    ({ startDate, endDate } = currentUtcMonthBounds());
+  }
+
+  if (scope === 'me') {
+    try {
+      const body = await adapter.getUsageForExternalUser({
+        externalUserId: user.id,
+        startDate,
+        endDate,
+      });
+      log('info', 'billing.adapter.usage', { provider, correlationId, scope, status: 200 });
+      return noStore(success(stripCryptoUnitFields(body)));
+    } catch (e) {
+      return noStore(mapAdapterError(e, provider, correlationId, 'billing.adapter.usage'));
+    }
+  }
+
+  if (!isSystemAdmin(user.roles)) {
+    return noStore(errors.forbidden('App-wide usage requires system:admin'));
+  }
+
+  const groupByRaw = sp.get('groupBy')?.trim();
+  let groupBy: 'none' | 'user' | undefined;
+  if (groupByRaw) {
+    if (groupByRaw !== 'none' && groupByRaw !== 'user') {
+      return noStore(errors.badRequest('groupBy must be none or user'));
+    }
+    groupBy = groupByRaw;
+  }
+  const userId = sp.get('userId')?.trim() || undefined;
+
+  try {
+    const usage = await adapter.getAppUsage({ startDate, endDate, groupBy, userId });
+    log('info', 'billing.adapter.usage', { provider, correlationId, scope, status: 200 });
+    return noStore(success(stripCryptoUnitFields(usage)));
+  } catch (e) {
+    return noStore(mapAdapterError(e, provider, correlationId, 'billing.adapter.usage'));
+  }
+}
+
+async function handleToken(ctx: RouteCtx): Promise<NextResponse> {
+  const { request, provider, adapter, correlationId, user } = ctx;
+
+  const csrfError = validateCSRF(request);
+  if (csrfError) return csrfError;
+
+  const rateLimited = enforceRateLimit(request, {
+    keyPrefix: `billing-token:${provider}:${user.id}`,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    maxRequests: RATE_LIMIT_MAX_PER_USER,
+  });
+  if (rateLimited) return rateLimited;
+
+  try {
+    const session = await adapter.mintSignerSession({
+      externalUserId: user.id,
+      email: user.email ?? undefined,
+    });
+    log('info', 'billing.adapter.token', { provider, correlationId, status: 200 });
+    return noStore(
+      success({
+        access_token: session.accessToken,
+        token_type: session.tokenType,
+        expires_in: session.expiresIn,
+        scope: session.scope,
+      }),
+    );
+  } catch (e) {
+    return noStore(mapAdapterError(e, provider, correlationId, 'billing.adapter.token'));
+  }
+}
+
+async function resolve(
+  request: NextRequest,
+  ctx: Params,
+  method: 'GET' | 'POST',
+): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    // Flag OFF → behave as if this route does not exist (no-op; zero regression).
+    if (!(await isFeatureEnabled(PROVIDER_ADAPTERS_FLAG))) {
+      return noStore(errors.notFound('Resource'));
+    }
+
+    const { provider, path } = await ctx.params;
+    if (!PROVIDER_SLUG_RE.test(provider)) {
+      return noStore(errors.notFound('Provider'));
+    }
+
+    const adapter = getBillingProviderAdapter(provider);
+    if (!adapter) {
+      log('warn', 'billing.adapter.unknown_provider', { provider, correlationId });
+      return noStore(errors.notFound('Provider'));
+    }
+    if (!adapter.isConfigured()) {
+      return noStore(errors.badRequest(`Provider "${provider}" is not configured`));
+    }
+
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const sessionUser = await validateSession(token);
+    if (!sessionUser) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    const op = (path?.[0] ?? '').toLowerCase();
+    const routeCtx: RouteCtx = {
+      request,
+      provider,
+      adapter,
+      correlationId,
+      user: { id: sessionUser.id, email: sessionUser.email, roles: sessionUser.roles },
+    };
+
+    if (method === 'GET' && op === 'usage') return handleUsage(routeCtx);
+    if (method === 'POST' && op === 'token') return handleToken(routeCtx);
+
+    return noStore(errors.notFound('Billing operation'));
+  } catch (err) {
+    log('error', 'billing.adapter.unexpected', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Billing request failed'));
+  }
+}
+
+export async function GET(request: NextRequest, ctx: Params): Promise<NextResponse> {
+  return resolve(request, ctx, 'GET');
+}
+
+export async function POST(request: NextRequest, ctx: Params): Promise<NextResponse> {
+  return resolve(request, ctx, 'POST');
+}

--- a/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/[provider]/[...path]/route.ts
@@ -21,7 +21,7 @@ import { enforceRateLimit } from '@/lib/api/rate-limit';
 import { error, errors, getAuthToken, success } from '@/lib/api/response';
 import { isFeatureEnabled } from '@/lib/feature-flags';
 import { AdapterNotImplementedError, type BillingProviderAdapter } from '@/lib/billing/adapter';
-import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import { resolveBillingProviderAdapterDetailed } from '@/lib/billing/registry-db';
 
 const PROVIDER_ADAPTERS_FLAG = 'provider_adapters';
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -227,11 +227,24 @@ async function resolve(
       return noStore(errors.notFound('Provider'));
     }
 
-    const adapter = getBillingProviderAdapter(provider);
+    // NAAP-A-db: DB-driven resolution when `db_adapter_registry` is ON; falls
+    // back to the static slug→adapter map otherwise (zero-regression).
+    const resolution = await resolveBillingProviderAdapterDetailed(provider);
+    const adapter = resolution.adapter;
     if (!adapter) {
-      log('warn', 'billing.adapter.unknown_provider', { provider, correlationId });
+      log('warn', 'billing.adapter.unknown_provider', {
+        provider,
+        correlationId,
+        source: resolution.source,
+      });
       return noStore(errors.notFound('Provider'));
     }
+    log('info', 'billing.adapter.resolved', {
+      provider,
+      correlationId,
+      source: resolution.source,
+      adapterType: resolution.adapterType,
+    });
     if (!adapter.isConfigured()) {
       return noStore(errors.badRequest(`Provider "${provider}" is not configured`));
     }

--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/billing/registry', () => ({
 const prisma = vi.hoisted(() => ({
   devApiKey: { findUnique: vi.fn(), update: vi.fn() },
   team: { findUnique: vi.fn() },
+  application: { findFirst: vi.fn() },
 }));
 vi.mock('@/lib/db', () => ({ prisma }));
 
@@ -65,6 +66,18 @@ beforeEach(() => {
     billingAccountId: 'acct_om_1',
   });
   prisma.devApiKey.update.mockResolvedValue({});
+  // NAAP-D app registry: default to a team-scoped app with a wildcard grant so
+  // the integrated front door (app_registry ON in these tests) resolves it.
+  prisma.application.findFirst.mockResolvedValue({
+    id: 'storyboard',
+    slug: 'storyboard',
+    type: 'app',
+    teamId: 'team-1',
+    ownerUserId: null,
+    allowedScopes: ['gateway', 'llm'],
+    allowedCapabilities: ['*'],
+    status: 'active',
+  });
   getBillingProviderAdapter.mockReturnValue(adapterMock());
 });
 
@@ -116,11 +129,59 @@ describe('resolution (provider-agnostic, BPP ③)', () => {
     const d = json.data;
     expect(d.valid).toBe(true);
     expect(d.user).toEqual({ sub: 'user-1' });
-    expect(d.app).toEqual({ id: 'storyboard' });
+    // App registry resolved: scopes attached; wildcard grant passes caps through.
+    expect(d.app).toEqual({ id: 'storyboard', scopes: ['gateway', 'llm'] });
     expect(d.billingAccount).toEqual({ id: 'acct_om_1', providerSlug: 'pymthouse' });
     expect(d.capabilities).toEqual(['text-to-image:sdxl']);
     expect(d.quota).toEqual({ remaining: 9 });
     expect(d.signerSession.accessToken).toBe('signer-tok');
+  });
+
+  it('registry-checks the app: 403 for an unregistered X-App-Id (NAAP-C↔NAAP-D)', async () => {
+    prisma.application.findFirst.mockResolvedValue(null);
+    const res = await POST(req(rawKey, { 'x-app-id': 'ghost-app' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('403 when the app is owned by a different team scope', async () => {
+    prisma.application.findFirst.mockResolvedValue({
+      id: 'other', slug: 'other', type: 'app', teamId: 'team-OTHER', ownerUserId: null,
+      allowedScopes: ['gateway'], allowedCapabilities: ['*'], status: 'active',
+    });
+    const res = await POST(req(rawKey, { 'x-app-id': 'other' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('gates capabilities to the app grant (intersection with provider caps)', async () => {
+    prisma.application.findFirst.mockResolvedValue({
+      id: 'app2', slug: 'app2', type: 'cli', teamId: 'team-1', ownerUserId: null,
+      allowedScopes: ['gateway'], allowedCapabilities: ['tool:byoc-demo'], status: 'active',
+    });
+    getBillingProviderAdapter.mockReturnValue(
+      adapterMock({
+        validate: vi.fn(async () => ({
+          valid: true,
+          capabilities: ['text-to-image:sdxl', 'tool:byoc-demo'],
+          quota: null,
+        })),
+      }),
+    );
+    const res = await POST(req(rawKey, { 'x-app-id': 'app2' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // sdxl filtered out (not granted to app2); byoc-demo kept.
+    expect(json.data.capabilities).toEqual(['tool:byoc-demo']);
+    expect(json.data.app).toEqual({ id: 'app2', scopes: ['gateway'] });
+  });
+
+  it('app_registry OFF → attribution only, no registry check (zero regression)', async () => {
+    isFeatureEnabled.mockImplementation(async (flag: string) => flag !== 'app_registry');
+    prisma.application.findFirst.mockResolvedValue(null);
+    const res = await POST(req(rawKey, { 'x-app-id': 'unregistered-but-ok' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.app).toEqual({ id: 'unregistered-but-ok' });
+    expect(prisma.application.findFirst).not.toHaveBeenCalled();
   });
 
   it('resolves the SAME key against the C0 stub provider', async () => {

--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -1,0 +1,169 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { POST } from './route';
+import { AdapterNotImplementedError } from '@/lib/billing/adapter';
+import { generateNativeApiKey } from '@/lib/dev-api/native-key';
+import { hashApiKey } from '@naap/database';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({ isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a) }));
+
+vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
+
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+const prisma = vi.hoisted(() => ({
+  devApiKey: { findUnique: vi.fn(), update: vi.fn() },
+  team: { findUnique: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+// A real native key + its stored hash so verifyNativeKeyHash passes.
+const { rawKey } = generateNativeApiKey();
+const keyHash = hashApiKey(rawKey);
+
+function adapterMock(overrides: Record<string, unknown> = {}) {
+  return {
+    slug: 'pymthouse',
+    isConfigured: vi.fn(() => true),
+    mintSignerSession: vi.fn(async () => ({ accessToken: 'signer-tok', tokenType: 'Bearer', expiresIn: 3600 })),
+    validate: vi.fn(async () => ({ valid: true, capabilities: ['text-to-image:sdxl'], quota: { remaining: 9 } })),
+    ...overrides,
+  };
+}
+
+function req(token: string | null, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/v1/keys/validate', {
+    method: 'POST',
+    headers: {
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...headers,
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  prisma.devApiKey.findUnique.mockResolvedValue({
+    id: 'key-1',
+    userId: 'user-1',
+    keyHash,
+    status: 'ACTIVE',
+    seatId: 'seat-1',
+    teamId: 'team-1',
+  });
+  prisma.team.findUnique.mockResolvedValue({
+    id: 'team-1',
+    billingAccountProviderSlug: 'pymthouse',
+    billingAccountId: 'acct_om_1',
+  });
+  prisma.devApiKey.update.mockResolvedValue({});
+  getBillingProviderAdapter.mockReturnValue(adapterMock());
+});
+
+describe('flag OFF (zero regression / fallback)', () => {
+  it('404 no-op when OFF; never touches DB', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('auth + D1 enforcement', () => {
+  it('401 when no bearer', async () => {
+    expect((await POST(req(null))).status).toBe(401);
+  });
+  it('401 for a provider token (passthrough disabled, D1)', async () => {
+    const res = await POST(req('pmth_sometoken'));
+    expect(res.status).toBe(401);
+    expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+  });
+  it('401 for a malformed naap_ key', async () => {
+    const res = await POST(req('naap_short'));
+    expect(res.status).toBe(401);
+  });
+  it('401 for an unknown key (no enumeration)', async () => {
+    prisma.devApiKey.findUnique.mockResolvedValue(null);
+    expect((await POST(req(rawKey))).status).toBe(401);
+  });
+  it('401 on hash mismatch', async () => {
+    prisma.devApiKey.findUnique.mockResolvedValue({
+      id: 'key-1', userId: 'user-1', keyHash: 'deadbeef', status: 'ACTIVE', seatId: 'seat-1', teamId: 'team-1',
+    });
+    expect((await POST(req(rawKey))).status).toBe(401);
+  });
+  it('401 for a revoked key', async () => {
+    prisma.devApiKey.findUnique.mockResolvedValue({
+      id: 'key-1', userId: 'user-1', keyHash, status: 'REVOKED', seatId: 'seat-1', teamId: 'team-1',
+    });
+    expect((await POST(req(rawKey))).status).toBe(401);
+  });
+});
+
+describe('resolution (provider-agnostic, BPP ③)', () => {
+  it('200 with the full contract shape (pymthouse)', async () => {
+    const res = await POST(req(rawKey, { 'x-app-id': 'storyboard' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const d = json.data;
+    expect(d.valid).toBe(true);
+    expect(d.user).toEqual({ sub: 'user-1' });
+    expect(d.app).toEqual({ id: 'storyboard' });
+    expect(d.billingAccount).toEqual({ id: 'acct_om_1', providerSlug: 'pymthouse' });
+    expect(d.capabilities).toEqual(['text-to-image:sdxl']);
+    expect(d.quota).toEqual({ remaining: 9 });
+    expect(d.signerSession.accessToken).toBe('signer-tok');
+  });
+
+  it('resolves the SAME key against the C0 stub provider', async () => {
+    prisma.team.findUnique.mockResolvedValue({
+      id: 'team-1', billingAccountProviderSlug: 'stub', billingAccountId: 'acct_stub_1',
+    });
+    getBillingProviderAdapter.mockReturnValue(adapterMock({ slug: 'stub' }));
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.billingAccount.providerSlug).toBe('stub');
+  });
+
+  it('capabilities fail CLOSED ([]) when the provider has not wired validate', async () => {
+    getBillingProviderAdapter.mockReturnValue(
+      adapterMock({
+        validate: vi.fn(async () => {
+          throw new AdapterNotImplementedError('pymthouse', 'validate');
+        }),
+      }),
+    );
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.capabilities).toEqual([]);
+    // still returns a usable signer session
+    expect(json.data.signerSession.accessToken).toBe('signer-tok');
+  });
+
+  it('403 when the key/team is not bound to a billing account', async () => {
+    prisma.team.findUnique.mockResolvedValue({
+      id: 'team-1', billingAccountProviderSlug: null, billingAccountId: null,
+    });
+    expect((await POST(req(rawKey))).status).toBe(403);
+  });
+
+  it('503 when the bound provider is unavailable', async () => {
+    getBillingProviderAdapter.mockReturnValue(adapterMock({ isConfigured: vi.fn(() => false) }));
+    expect((await POST(req(rawKey))).status).toBe(503);
+  });
+
+  it('400 for a malformed X-App-Id', async () => {
+    const res = await POST(req(rawKey, { 'x-app-id': 'bad id!' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -1,0 +1,196 @@
+/**
+ * Key validation front door (NAAP-C) — BPP ③.
+ *
+ *   POST /api/v1/keys/validate
+ *   auth:   Authorization: Bearer naap_…   (native key ONLY — D1, no passthrough)
+ *   header: X-App-Id: <appId>              (optional; usage attribution)
+ *   → { valid, user, app?, billingAccount, capabilities, quota, signerSession }
+ *
+ * The SINGLE entry point apps/services (the SDK service) call instead of talking
+ * to a provider directly. Resolves naap_ → seat → team → billingAccountRef →
+ * provider adapter (NAAP-A). Provider-agnostic: the same request resolves
+ * whether the backing provider is pymthouse or the C0 stub.
+ *
+ * SECURITY: this endpoint performs NO app-controlled outbound fetch. The only
+ * provider I/O is through the adapter to the provider's ENV-configured base URL
+ * (never a request-derived URL) — so there is no SSRF vector here. X-App-Id is
+ * format-validated and used only for attribution (never to build a URL/query).
+ *
+ * Gated behind the `key_validation_front_door` flag (default OFF): 404 when OFF,
+ * so callers fall back to their existing direct path (lag tolerance).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { error, errors, success } from '@/lib/api/response';
+import { enforceRateLimit } from '@/lib/api/rate-limit';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { parseApiKey } from '@naap/database';
+import { AdapterNotImplementedError } from '@/lib/billing/adapter';
+import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import {
+  resolveNativeKeyToProviderSession,
+  verifyNativeKeyHash,
+} from '@/lib/dev-api/native-key';
+import {
+  FRONT_DOOR_FLAG,
+  INVALID_APP_ID,
+  buildFrontDoorResponse,
+  extractAppId,
+  isNativeKeyToken,
+  parseBearer,
+} from '@/lib/dev-api/validate-key';
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 120;
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+/** Uniform invalid-key response (no enumeration / no reason leak). */
+function invalid(correlationId: string, reason: string): NextResponse {
+  log('warn', 'keys.validate.invalid', { correlationId, reason });
+  return noStore(error('INVALID_KEY', 'Invalid or unauthorized key', 401));
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    // Flag OFF → 404; callers fall back to their existing direct path.
+    if (!(await isFeatureEnabled(FRONT_DOOR_FLAG))) {
+      return noStore(errors.notFound('Resource'));
+    }
+
+    const rateLimited = enforceRateLimit(request, {
+      keyPrefix: 'keys-validate',
+      windowMs: RATE_LIMIT_WINDOW_MS,
+      maxRequests: RATE_LIMIT_MAX,
+    });
+    if (rateLimited) return rateLimited;
+
+    const token = parseBearer(request.headers.get('authorization'));
+    if (!token) return invalid(correlationId, 'no_bearer');
+
+    // D1: native naap_ keys ONLY — provider-token passthrough is disabled.
+    if (!isNativeKeyToken(token)) {
+      return invalid(correlationId, 'provider_token_passthrough_disabled');
+    }
+
+    const appId = extractAppId(request.headers.get('x-app-id'));
+    if (appId === INVALID_APP_ID) {
+      return noStore(errors.badRequest('Invalid X-App-Id'));
+    }
+
+    const parsed = parseApiKey(token);
+    if (!parsed) return invalid(correlationId, 'malformed');
+
+    const key = await prisma.devApiKey.findUnique({
+      where: { keyLookupId: parsed.lookupId },
+      select: {
+        id: true,
+        userId: true,
+        keyHash: true,
+        status: true,
+        seatId: true,
+        teamId: true,
+      },
+    });
+    // Constant-time hash check; uniform failure whether the row is missing or
+    // the secret mismatches (no key enumeration).
+    if (!key || !verifyNativeKeyHash(token, key.keyHash)) {
+      return invalid(correlationId, 'not_found_or_mismatch');
+    }
+    if (key.status !== 'ACTIVE') {
+      return invalid(correlationId, 'revoked');
+    }
+
+    // Resolve the seat's team binding.
+    const team = key.teamId
+      ? await prisma.team.findUnique({
+          where: { id: key.teamId },
+          select: { id: true, billingAccountProviderSlug: true, billingAccountId: true },
+        })
+      : null;
+
+    const resolved = await resolveNativeKeyToProviderSession(
+      { status: key.status, seatId: key.seatId, teamId: key.teamId },
+      team,
+    );
+    if (!resolved.valid || !resolved.signerSession || !resolved.billingAccountRef) {
+      // Map fail-safe reasons: provider lag → 503; binding issues → 403.
+      if (resolved.reason === 'provider_unavailable' || resolved.reason === 'mint_failed') {
+        log('warn', 'keys.validate.provider_unavailable', { correlationId, reason: resolved.reason });
+        return noStore(errors.serviceUnavailable('Billing provider unavailable'));
+      }
+      if (resolved.reason === 'team_unbound' || resolved.reason === 'unbound_seat') {
+        return noStore(errors.forbidden('Key is not bound to a billing account'));
+      }
+      return invalid(correlationId, resolved.reason ?? 'unresolved');
+    }
+
+    const ref = resolved.billingAccountRef;
+
+    // Best-effort capabilities/quota from the provider (BPP ②). When the
+    // provider hasn't wired validate yet (AdapterNotImplementedError), fail
+    // CLOSED to an empty capability set — the key is still valid; NAAP-E gates.
+    let capabilities: string[] = [];
+    let quota: { remaining: number; resetAt?: string } | null = null;
+    const adapter = getBillingProviderAdapter(ref.providerSlug);
+    if (adapter) {
+      try {
+        const v = await adapter.validate(ref.accountId);
+        if (Array.isArray(v.capabilities)) capabilities = v.capabilities;
+        quota = v.quota ?? null;
+      } catch (e) {
+        if (!(e instanceof AdapterNotImplementedError)) {
+          log('warn', 'keys.validate.capabilities_unavailable', {
+            correlationId,
+            providerSlug: ref.providerSlug,
+          });
+        }
+      }
+    }
+
+    // Fire-and-forget last-used update; never block validation on it.
+    prisma.devApiKey.update({ where: { id: key.id }, data: { lastUsedAt: new Date() } }).catch(() => {});
+
+    const body = buildFrontDoorResponse({
+      userSub: key.userId,
+      appId: appId ?? undefined,
+      billingAccountRef: ref,
+      capabilities,
+      quota,
+      signerSession: resolved.signerSession,
+    });
+
+    log('info', 'keys.validate.ok', {
+      correlationId,
+      keyId: key.id,
+      providerSlug: ref.providerSlug,
+      hasApp: Boolean(appId),
+      capabilityCount: capabilities.length,
+    });
+    return noStore(success(body));
+  } catch (err) {
+    log('error', 'keys.validate.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Validation failed'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -30,6 +30,8 @@ import { isFeatureEnabled } from '@/lib/feature-flags';
 import { parseApiKey } from '@naap/database';
 import { AdapterNotImplementedError } from '@/lib/billing/adapter';
 import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import { APP_REGISTRY_FLAG, gateCapabilitiesForApp } from '@/lib/apps/registry';
+import { appBelongsToKeyScope, resolveRegisteredApp } from '@/lib/apps/resolve';
 import {
   resolveNativeKeyToProviderSession,
   verifyNativeKeyHash,
@@ -166,12 +168,33 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
     }
 
+    // App-registry gating (NAAP-D, integration wiring). When the app_registry
+    // flag is ON and an X-App-Id was presented, registry-check the app: it must
+    // be registered, active, and owned by the key's scope. The effective
+    // capabilities are then gated to the app's grant (NAAP-E). Flag OFF keeps
+    // the prior attribution-only behavior (lag tolerance / zero regression).
+    let appScopes: string[] | undefined;
+    if (appId && (await isFeatureEnabled(APP_REGISTRY_FLAG))) {
+      const app = await resolveRegisteredApp(appId);
+      if (!app || app.status !== 'active') {
+        log('warn', 'keys.validate.app_unregistered', { correlationId, appId });
+        return noStore(errors.forbidden('App is not registered or is disabled'));
+      }
+      if (!appBelongsToKeyScope(app, { teamId: key.teamId, userId: key.userId })) {
+        log('warn', 'keys.validate.app_scope_mismatch', { correlationId, appId: app.id });
+        return noStore(errors.forbidden('App is not owned by this key'));
+      }
+      appScopes = app.allowedScopes;
+      capabilities = gateCapabilitiesForApp(app, capabilities);
+    }
+
     // Fire-and-forget last-used update; never block validation on it.
     prisma.devApiKey.update({ where: { id: key.id }, data: { lastUsedAt: new Date() } }).catch(() => {});
 
     const body = buildFrontDoorResponse({
       userSub: key.userId,
       appId: appId ?? undefined,
+      appScopes,
       billingAccountRef: ref,
       capabilities,
       quota,

--- a/apps/web-next/src/app/api/v1/metrics/ingest/route.test.ts
+++ b/apps/web-next/src/app/api/v1/metrics/ingest/route.test.ts
@@ -1,0 +1,100 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { POST } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+}));
+
+const create = vi.fn();
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    providerUsageRecord: { create: (...a: unknown[]) => create(...a) },
+  },
+}));
+
+const TOKEN = 'test-ingest-token';
+
+function req(body: unknown, init?: { auth?: string }): NextRequest {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (init?.auth !== undefined) headers.authorization = init.auth;
+  return new NextRequest('https://naap.test/api/v1/metrics/ingest', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+const validPayload = {
+  providerSlug: 'pymthouse',
+  accountId: 'acct_1',
+  appId: 'app_sb',
+  window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T00:00:00.000Z' },
+  sessions: 1,
+  tickets: 10,
+  feeWei: '1000',
+  networkFeeUsdMicros: '5000',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NAAP_METRICS_INGEST_TOKEN = TOKEN;
+});
+afterEach(() => {
+  delete process.env.NAAP_METRICS_INGEST_TOKEN;
+});
+
+describe('usage_ingest flag OFF → no-op', () => {
+  it('returns 404 and never authenticates or writes', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(req(validPayload, { auth: `Bearer ${TOKEN}` }));
+    expect(res.status).toBe(404);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('usage_ingest flag ON', () => {
+  beforeEach(() => isFeatureEnabled.mockResolvedValue(true));
+
+  it('rejects a missing/invalid token with 401', async () => {
+    const res = await POST(req(validPayload, { auth: 'Bearer wrong' }));
+    expect(res.status).toBe(401);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when no ingest token is configured', async () => {
+    delete process.env.NAAP_METRICS_INGEST_TOKEN;
+    const res = await POST(req(validPayload, { auth: 'Bearer anything' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts a valid neutral payload and stores it', async () => {
+    create.mockResolvedValue({ id: 'rec-1' });
+    const res = await POST(req(validPayload, { auth: `Bearer ${TOKEN}` }));
+    expect(res.status).toBe(200);
+    const arg = create.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(arg.data.providerSlug).toBe('pymthouse');
+    expect(arg.data.appId).toBe('app_sb');
+    expect(arg.data.windowFrom).toBeInstanceOf(Date);
+  });
+
+  it('rejects a payload leaking provider-internal fields with 400', async () => {
+    const leaky = { ...validPayload, openmeter_subscription_id: '01J...' };
+    const res = await POST(req(leaky, { auth: `Bearer ${TOKEN}` }));
+    expect(res.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+    const json = await res.json();
+    expect(json.error.details.leaked).toContain('openmeter_subscription_id');
+  });
+
+  it('rejects an invalid shape with a validation error', async () => {
+    const bad = { providerSlug: 'pymthouse' }; // missing accountId + window
+    const res = await POST(req(bad, { auth: `Bearer ${TOKEN}` }));
+    expect(res.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-next/src/app/api/v1/metrics/ingest/route.ts
+++ b/apps/web-next/src/app/api/v1/metrics/ingest/route.ts
@@ -1,0 +1,102 @@
+/**
+ * BPP ⑥ usage ingest endpoint (NAAP-2).
+ *
+ *   POST /api/v1/metrics/ingest
+ *
+ * Any billing provider pushes a NEUTRAL usage payload here (sessions/tickets/
+ * fees by account+app). This is the authoritative cross-provider usage path.
+ *
+ * Auth: a shared service token in the `Authorization: Bearer …` header, compared
+ * against `NAAP_METRICS_INGEST_TOKEN` (timing-safe). Gated behind the
+ * `usage_ingest` flag (default OFF) → 404 when OFF (no-op, zero regression).
+ *
+ * Seam isolation: provider-internal field names (BPP ⑨) are rejected — NaaP must
+ * never learn a provider's internal metering shape. Never logs secrets/PII.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors } from '@/lib/api/response';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { USAGE_INGEST_FLAG } from '@/lib/metrics/flags';
+import { parseUsageIngest } from '@/lib/metrics/usage-ingest';
+
+function correlationId(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+/** Timing-safe bearer-token check against NAAP_METRICS_INGEST_TOKEN. */
+function isAuthorized(request: NextRequest): boolean {
+  const expected = process.env.NAAP_METRICS_INGEST_TOKEN;
+  if (!expected) return false; // not configured → ingest stays closed
+  const header = request.headers.get('authorization') || '';
+  if (!header.startsWith('Bearer ')) return false;
+  const provided = header.slice(7).trim();
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await isFeatureEnabled(USAGE_INGEST_FLAG))) return errors.notFound('Resource');
+
+  const cid = correlationId(request);
+
+  if (!isAuthorized(request)) {
+    log('warn', 'metrics.ingest.unauthorized', { correlationId: cid });
+    return errors.unauthorized('Invalid ingest token');
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errors.badRequest('Invalid JSON body');
+  }
+
+  const parsed = parseUsageIngest(body);
+  if (!parsed.ok) {
+    if (parsed.reason === 'leaked_internal_fields') {
+      log('warn', 'metrics.ingest.seam_violation', { correlationId: cid, leaked: parsed.leaked });
+      return errors.badRequest('Payload contains provider-internal fields', {
+        leaked: parsed.leaked,
+      });
+    }
+    return errors.validationError(parsed.errors);
+  }
+
+  const data = parsed.data;
+  await prisma.providerUsageRecord.create({
+    data: {
+      providerSlug: data.providerSlug,
+      accountId: data.accountId,
+      appId: data.appId ?? null,
+      windowFrom: new Date(data.window.from),
+      windowTo: new Date(data.window.to),
+      sessions: data.sessions ?? 0,
+      tickets: data.tickets ?? 0,
+      feeWei: data.feeWei ?? null,
+      networkFeeUsdMicros: data.networkFeeUsdMicros ?? null,
+      byCapability: data.byCapability ?? undefined,
+    },
+  });
+
+  log('info', 'metrics.ingest.accepted', {
+    correlationId: cid,
+    providerSlug: data.providerSlug,
+    hasApp: Boolean(data.appId),
+  });
+
+  return success({ accepted: true });
+}

--- a/apps/web-next/src/app/api/v1/metrics/usage/route.ts
+++ b/apps/web-next/src/app/api/v1/metrics/usage/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Cross-provider usage dashboard BFF (NAAP-2).
+ *
+ *   GET /api/v1/metrics/usage?from=ISO&to=ISO[&accountId=…]
+ *
+ * Aggregates ingested BPP ⑥ usage into a spend view keyed by provider (the
+ * "provider column"), so the dashboard can compare spend across ANY number of
+ * billing providers. Read-only.
+ *
+ * Auth: a signed-in user (session). Gated behind the `usage_ingest` flag
+ * (default OFF) → 404 when OFF.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { USAGE_INGEST_FLAG } from '@/lib/metrics/flags';
+import { aggregateSpendByProvider } from '@/lib/metrics/aggregate';
+
+const MAX_RECORDS = 50_000;
+
+function parseDate(raw: string | null): Date | null {
+  if (!raw) return null;
+  const ts = Date.parse(raw);
+  return Number.isNaN(ts) ? null : new Date(ts);
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await isFeatureEnabled(USAGE_INGEST_FLAG))) return errors.notFound('Resource');
+
+  const token = getAuthToken(request);
+  if (!token) return errors.unauthorized('Authentication required');
+  const user = await validateSession(token);
+  if (!user) return errors.unauthorized('Invalid or expired token');
+
+  const sp = request.nextUrl.searchParams;
+  const from = parseDate(sp.get('from'));
+  const to = parseDate(sp.get('to'));
+  if ((sp.get('from') && !from) || (sp.get('to') && !to)) {
+    return errors.badRequest('from/to must be valid ISO timestamps');
+  }
+  if (from && to && from > to) {
+    return errors.badRequest('from must be on or before to');
+  }
+  const accountId = sp.get('accountId')?.trim() || undefined;
+
+  const where = {
+    ...(accountId ? { accountId } : {}),
+    ...(from || to
+      ? { windowTo: { ...(from ? { gte: from } : {}), ...(to ? { lte: to } : {}) } }
+      : {}),
+  };
+
+  const records = await prisma.providerUsageRecord.findMany({
+    where,
+    select: {
+      providerSlug: true,
+      accountId: true,
+      appId: true,
+      sessions: true,
+      tickets: true,
+      feeWei: true,
+      networkFeeUsdMicros: true,
+    },
+    take: MAX_RECORDS,
+  });
+
+  const providers = aggregateSpendByProvider(records);
+  return success({ providers });
+}

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.ts
@@ -22,6 +22,14 @@ import {
   DISCOVERY_RESPONSE_CACHE_CONTROL,
   ensurePymthouseManifestFresh,
 } from '@/lib/pymthouse-manifest';
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
+import {
+  isStoryboardDefaultDiscoveryEnabled,
+  STORYBOARD_DEFAULT_PLAN_ID,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
 
 const DEFAULT_CAPABILITY = 'noop';
 const DEFAULT_TOP_N = 100;
@@ -66,6 +74,70 @@ function resolveTopN(url: URL): number {
   return parsed;
 }
 
+async function handleStoryboardDefaultPlan(
+  request: NextRequest,
+  billingProviderSlug: ReturnType<typeof normalizeBillingProviderSlug>,
+  authToken: string,
+): Promise<Response> {
+  const cookieHeader = request.headers.get('cookie');
+
+  const fetchCapabilityAddresses = async (
+    leaderboardCap: string,
+  ): Promise<CapabilityFetchResult> => {
+    const result = await fetchLeaderboard(leaderboardCap, authToken, request.url, cookieHeader);
+    const addresses: string[] = [];
+    for (const row of result.rows) {
+      const address = row.orch_uri?.trim();
+      if (address) {
+        addresses.push(address);
+      }
+    }
+    return { addresses, fromCache: result.fromCache, cachedAt: result.cachedAt };
+  };
+
+  try {
+    if (billingProviderSlug === 'pymthouse') {
+      await ensurePymthouseManifestFresh();
+    }
+
+    const { addresses, byKind, meta } = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses,
+      billingProviderSlug,
+    });
+
+    console.info(
+      '[python-gateway] storyboard-default plan served',
+      JSON.stringify({
+        billingProviderSlug: billingProviderSlug ?? 'default',
+        total: addresses.length,
+        scope: byKind.scope.length,
+        byocCaps: byKind.byoc.length,
+        toolCaps: byKind.tool.length,
+        staticFleetInjected: meta.staticFleetInjected,
+        fromCache: meta.fromCache,
+      }),
+    );
+
+    return NextResponse.json(
+      addresses.map((address) => ({ address })),
+      {
+        headers: {
+          'Cache-Control': DISCOVERY_RESPONSE_CACHE_CONTROL,
+          'X-Cache': meta.fromCache ? 'HIT' : 'MISS',
+          'X-Cache-Age': String(meta.cacheAgeMs),
+          'X-Discovery-Mode': 'storyboard-default',
+        },
+      },
+    );
+  } catch (err) {
+    console.error('[python-gateway] storyboard-default plan failed', err);
+    return new NextResponse('Internal server error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}
+
 export async function GET(request: NextRequest): Promise<Response> {
   const auth = await authorize(request);
   if (!auth) {
@@ -83,6 +155,17 @@ export async function GET(request: NextRequest): Promise<Response> {
   const capabilityPairs = resolveCapabilityPairs(url);
   const topN = resolveTopN(url);
   const authToken = getAuthToken(request) || '';
+
+  // NAAP-9: `?plan=storyboard-default` selects the fixed default-plan bundle
+  // (static-fleet merge for scope). Gated OFF by default → falls through to the
+  // existing per-cap behavior so the Daydream path stays authoritative.
+  const planParam = url.searchParams.get('plan')?.trim();
+  if (
+    planParam === STORYBOARD_DEFAULT_PLAN_ID &&
+    isStoryboardDefaultDiscoveryEnabled()
+  ) {
+    return handleStoryboardDefaultPlan(request, billingProvider, authToken);
+  }
 
   try {
     if (billingProvider === 'pymthouse') {

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__snapshots__/golden-set.json
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__snapshots__/golden-set.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "NAAP-9 golden set (Daydream parity). Per Decision D7 this is snapshotted empirically from the live Daydream path: scope addresses from signer.daydream.live/discovery/staging.json + orch-staging-3 from simple-infra fleet.yaml; byoc/tool caps from sdk.daydream.monster/capabilities. The committed values below are the staging baseline to reconcile against. The parity test asserts the storyboard-default bundle returns EXACTLY this set (bidirectional: no missing, no extra).",
+  "scope": [
+    "https://orch-staging-1.daydream.monster:8935",
+    "https://orch-staging-2.daydream.monster:8935",
+    "https://orch-staging-3.daydream.monster:8935"
+  ],
+  "byoc": [
+    "nano-banana",
+    "recraft-v4",
+    "flux-schnell",
+    "flux-dev",
+    "ltx-t2v",
+    "ltx-i2v",
+    "kontext-edit",
+    "bg-remove",
+    "topaz-upscale",
+    "chatterbox-tts",
+    "gemini-image",
+    "gemini-text"
+  ],
+  "tool": [
+    "ffmpeg-concat",
+    "ffmpeg-trim",
+    "ffmpeg-overlay",
+    "ffmpeg-export",
+    "ffmpeg-audio-mix",
+    "ffmpeg-loop",
+    "ffmpeg-burn-subtitles",
+    "ffmpeg-grid",
+    "ffmpeg-mux",
+    "pillow-resize",
+    "pillow-watermark",
+    "pillow-format",
+    "pillow-palette",
+    "pillow-grid",
+    "obscura-extract-text",
+    "obscura-extract-markdown",
+    "obscura-extract-links",
+    "hyperframes-caption",
+    "hyperframes-lower-third",
+    "hyperframes-render",
+    "yolo-detect",
+    "yolo-segment",
+    "cad-render",
+    "cad-validate"
+  ]
+}

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__tests__/golden-set.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__tests__/golden-set.test.ts
@@ -1,0 +1,154 @@
+/**
+ * NAAP-9 — Golden-set parity test.
+ *
+ * "Storyboard default discovery returns the golden BYOC + tool + scope
+ * orchestrator set." Guards a non-disruptive Daydream→NaaP discovery switch:
+ * the bundle must return ⊇ AND ⊆ the live Daydream set (no orchestrator/cap
+ * silently dropped, none silently added). The negative tests prove the assert
+ * is bidirectional (catches both missing and extra).
+ *
+ * Per Decision D7 the golden fixture is snapshotted from the live Daydream path
+ * (committed baseline here). fetchLeaderboard is mocked per capability; the
+ * scope mock intentionally omits orch-staging-3 to prove the static-fleet
+ * fallback re-injects it (catching the staging.json drift).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
+import {
+  STORYBOARD_DEFAULT_PLAN,
+  type StoryboardDefaultPlan,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+import goldenJson from '../__snapshots__/golden-set.json';
+
+interface GoldenSet {
+  scope: string[];
+  byoc: string[];
+  tool: string[];
+}
+
+const golden: GoldenSet = {
+  scope: goldenJson.scope,
+  byoc: goldenJson.byoc,
+  tool: goldenJson.tool,
+};
+
+const BYOC_TOOL_STATIC_HOST = 'https://byoc-staging-1.daydream.monster:8935';
+
+/**
+ * Mock leaderboard fetch. Scope caps deliberately return only staging-1/2 (the
+ * staging.json drift) so the static fleet must re-add staging-3. byoc/tool caps
+ * return the BYOC tool host.
+ */
+function goldenFetch(scopeAddresses: string[]): (cap: string) => Promise<CapabilityFetchResult> {
+  return async (_cap: string): Promise<CapabilityFetchResult> => {
+    // We can't tell category from the short cap here, so return a benign host
+    // for non-scope caps and the (drifted) scope set for the scope cap.
+    void _cap;
+    const isScope = _cap === 'scope';
+    return {
+      addresses: isScope ? scopeAddresses : [BYOC_TOOL_STATIC_HOST],
+      fromCache: true,
+      cachedAt: Date.now(),
+    };
+  };
+}
+
+const SORT = (xs: string[]) => [...xs].sort((a, b) => a.localeCompare(b));
+
+describe('NAAP-9 storyboard-default golden-set parity', () => {
+  it('returns the golden scope addresses, byoc caps, and tool caps (bidirectional)', async () => {
+    const result = await buildStoryboardDefaultDiscovery({
+      // scope mock omits orch-staging-3 → static fleet must re-inject it
+      fetchCapabilityAddresses: goldenFetch([
+        'https://orch-staging-1.daydream.monster:8935',
+        'https://orch-staging-2.daydream.monster:8935',
+      ]),
+      billingProviderSlug: 'daydream',
+    });
+
+    expect(SORT(result.byKind.scope)).toEqual(SORT(golden.scope));
+    expect(SORT(result.byKind.byoc)).toEqual(SORT(golden.byoc));
+    expect(SORT(result.byKind.tool)).toEqual(SORT(golden.tool));
+
+    // Static-fleet fallback re-injected orch-staging-3 (the drift).
+    expect(result.meta.staticFleetInjected).toBeGreaterThanOrEqual(1);
+
+    // The flattened payload contains the golden scope orchestrators.
+    for (const addr of golden.scope) {
+      expect(result.addresses).toContain(addr);
+    }
+  });
+
+  it('keeps parity even when ClickHouse returns the full scope set (no drift)', async () => {
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([...golden.scope]),
+      billingProviderSlug: 'daydream',
+    });
+    expect(SORT(result.byKind.scope)).toEqual(SORT(golden.scope));
+    expect(result.meta.staticFleetInjected).toBe(0);
+  });
+
+  it('fails parity if a golden scope address is removed from both live and static fleet (catches missing)', async () => {
+    const planMissingScope: StoryboardDefaultPlan = {
+      ...STORYBOARD_DEFAULT_PLAN,
+      scope: {
+        capabilities: STORYBOARD_DEFAULT_PLAN.scope.capabilities,
+        staticOrchestrators: STORYBOARD_DEFAULT_PLAN.scope.staticOrchestrators.filter(
+          (a) => !a.includes('orch-staging-3'),
+        ),
+      },
+    };
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([
+        'https://orch-staging-1.daydream.monster:8935',
+        'https://orch-staging-2.daydream.monster:8935',
+      ]),
+      billingProviderSlug: 'daydream',
+      plan: planMissingScope,
+    });
+    expect(SORT(result.byKind.scope)).not.toEqual(SORT(golden.scope));
+  });
+
+  it('fails parity if a golden byoc cap is removed (catches missing)', async () => {
+    const planMissingCap: StoryboardDefaultPlan = {
+      ...STORYBOARD_DEFAULT_PLAN,
+      byoc: {
+        capabilities: STORYBOARD_DEFAULT_PLAN.byoc.capabilities.filter((c) => c !== 'nano-banana'),
+        staticOrchestrators: STORYBOARD_DEFAULT_PLAN.byoc.staticOrchestrators,
+      },
+    };
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([...golden.scope]),
+      billingProviderSlug: 'daydream',
+      plan: planMissingCap,
+    });
+    expect(SORT(result.byKind.byoc)).not.toEqual(SORT(golden.byoc));
+  });
+
+  it('fails parity if an extra byoc cap is added (catches extra)', async () => {
+    const planExtraCap: StoryboardDefaultPlan = {
+      ...STORYBOARD_DEFAULT_PLAN,
+      byoc: {
+        capabilities: [...STORYBOARD_DEFAULT_PLAN.byoc.capabilities, 'rogue-model'],
+        staticOrchestrators: STORYBOARD_DEFAULT_PLAN.byoc.staticOrchestrators,
+      },
+    };
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: goldenFetch([...golden.scope]),
+      billingProviderSlug: 'daydream',
+      plan: planExtraCap,
+    });
+    expect(SORT(result.byKind.byoc)).not.toEqual(SORT(golden.byoc));
+  });
+
+  it('the committed plan baseline matches the golden fixture', () => {
+    expect(SORT([...STORYBOARD_DEFAULT_PLAN.byoc.capabilities])).toEqual(SORT(golden.byoc));
+    expect(SORT([...STORYBOARD_DEFAULT_PLAN.tool.capabilities])).toEqual(SORT(golden.tool));
+    expect(SORT([...STORYBOARD_DEFAULT_PLAN.scope.staticOrchestrators])).toEqual(SORT(golden.scope));
+  });
+});

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from 'next/server';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/gateway/authorize', () => ({
+  authorize: vi.fn(),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/query', () => ({
+  fetchLeaderboard: vi.fn(),
+}));
+
+import { authorize } from '@/lib/gateway/authorize';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { STORYBOARD_DEFAULT_DISCOVERY_FLAG } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+
+const FLAG = STORYBOARD_DEFAULT_DISCOVERY_FLAG;
+
+function makeRequest(qs = '') {
+  return new NextRequest(
+    `http://localhost/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway${qs}`,
+    { headers: { Authorization: 'Bearer gw_test' } },
+  );
+}
+
+describe('GET storyboard-default/python-gateway', () => {
+  const prev = process.env[FLAG];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (authorize as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: true,
+      teamId: 'personal:user-1',
+      callerType: 'apiKey',
+      callerId: 'user-1',
+    });
+    (fetchLeaderboard as ReturnType<typeof vi.fn>).mockImplementation(async (cap: string) => ({
+      rows:
+        cap === 'scope'
+          ? [
+              { orch_uri: 'https://orch-staging-1.daydream.monster:8935' },
+              { orch_uri: 'https://orch-staging-2.daydream.monster:8935' },
+            ]
+          : [{ orch_uri: 'https://byoc-staging-1.daydream.monster:8935' }],
+      fromCache: true,
+      cachedAt: Date.now(),
+    }));
+  });
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env[FLAG];
+    } else {
+      process.env[FLAG] = prev;
+    }
+  });
+
+  it('returns 404 when the flag is OFF (default) — Daydream path stays authoritative', async () => {
+    delete process.env[FLAG];
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+    expect(fetchLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated even with the flag ON', async () => {
+    process.env[FLAG] = 'true';
+    (authorize as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the bundle with static-fleet scope orchestrators when the flag is ON', async () => {
+    process.env[FLAG] = 'true';
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Discovery-Mode')).toBe('storyboard-default');
+
+    const body = (await res.json()) as { address: string }[];
+    const addresses = body.map((o) => o.address);
+    // orch-staging-3 was NOT returned by ClickHouse but the static fleet adds it.
+    expect(addresses).toContain('https://orch-staging-3.daydream.monster:8935');
+    expect(addresses).toContain('https://orch-staging-1.daydream.monster:8935');
+    expect(addresses).toContain('https://byoc-staging-1.daydream.monster:8935');
+  });
+});

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.ts
@@ -1,0 +1,102 @@
+/**
+ * GET /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway
+ *
+ * NAAP-9 — the Storyboard Default discovery bundle (Daydream parity). Returns
+ * the fixed default-plan orchestrator/capability set (scope staging + BYOC +
+ * tool) with a static-fleet fallback merged into the tier shuffle, so the
+ * Daydream→NaaP discovery switch is non-disruptive.
+ *
+ * Gated by `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default OFF): when OFF the
+ * endpoint is disabled (404) and the Daydream path stays authoritative.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authorize } from '@/lib/gateway/authorize';
+import { getAuthToken } from '@/lib/api/response';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { normalizeBillingProviderSlug } from '@/lib/orchestrator-leaderboard/provider-restrictions';
+import { DISCOVERY_RESPONSE_CACHE_CONTROL } from '@/lib/orchestrator-leaderboard/discovery-constants';
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
+import { isStoryboardDefaultDiscoveryEnabled } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+
+export async function GET(request: NextRequest): Promise<Response> {
+  if (!isStoryboardDefaultDiscoveryEnabled()) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const auth = await authorize(request);
+  if (!auth) {
+    return new NextResponse('Unauthorized', {
+      status: 401,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const url = new URL(request.url);
+  const billingProviderSlug = normalizeBillingProviderSlug(
+    url.searchParams.get('billingProviderSlug') ?? url.searchParams.get('billingProvider'),
+  );
+  const authToken = getAuthToken(request) || '';
+  const cookieHeader = request.headers.get('cookie');
+
+  const fetchCapabilityAddresses = async (
+    leaderboardCap: string,
+  ): Promise<CapabilityFetchResult> => {
+    const result = await fetchLeaderboard(leaderboardCap, authToken, request.url, cookieHeader);
+    const addresses: string[] = [];
+    for (const row of result.rows) {
+      const address = row.orch_uri?.trim();
+      if (address) {
+        addresses.push(address);
+      }
+    }
+    return { addresses, fromCache: result.fromCache, cachedAt: result.cachedAt };
+  };
+
+  try {
+    const { addresses, byKind, meta } = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses,
+      billingProviderSlug,
+    });
+
+    const out = addresses.map((address) => ({ address }));
+
+    // Structured logging — counts only, no addresses/keys/PII.
+    console.info(
+      '[storyboard-default-discovery] served',
+      JSON.stringify({
+        billingProviderSlug: billingProviderSlug ?? 'default',
+        total: out.length,
+        scope: byKind.scope.length,
+        byocCaps: byKind.byoc.length,
+        toolCaps: byKind.tool.length,
+        staticFleetInjected: meta.staticFleetInjected,
+        fromCache: meta.fromCache,
+      }),
+    );
+
+    return NextResponse.json(out, {
+      headers: {
+        'Cache-Control': DISCOVERY_RESPONSE_CACHE_CONTROL,
+        'X-Cache': meta.fromCache ? 'HIT' : 'MISS',
+        'X-Cache-Age': String(meta.cacheAgeMs),
+        'X-Discovery-Mode': 'storyboard-default',
+      },
+    });
+  } catch (err) {
+    console.error('[storyboard-default-discovery] failed to build bundle', err);
+    return new NextResponse('Internal server error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/billing-account/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/billing-account/route.test.ts
@@ -1,0 +1,158 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, PUT } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({
+  validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a),
+}));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+
+const hasBillingProviderAdapter = vi.fn();
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  hasBillingProviderAdapter: (...a: unknown[]) => hasBillingProviderAdapter(...a),
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+const prisma = vi.hoisted(() => ({
+  team: { findUnique: vi.fn(), update: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }): NextRequest {
+  return new NextRequest(url, {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', 'content-type': 'application/json', ...(init?.headers ?? {}) },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+const params = (teamId: string) => ({ params: Promise.resolve({ teamId }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1', roles: [] });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'admin' } });
+  hasBillingProviderAdapter.mockReturnValue(true);
+  prisma.team.findUnique.mockResolvedValue({
+    id: 'team-1',
+    billingAccountProviderSlug: null,
+    billingAccountId: null,
+  });
+  prisma.team.update.mockResolvedValue({ id: 'team-1' });
+});
+
+describe('flag OFF (zero regression)', () => {
+  it('GET 404 no-op', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req('http://localhost/api/v1/teams/team-1/billing-account'), params('team-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.team.findUnique).not.toHaveBeenCalled();
+  });
+  it('PUT 404 no-op (never writes)', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await PUT(
+      req('http://localhost/api/v1/teams/team-1/billing-account', {
+        method: 'PUT',
+        body: { providerSlug: 'pymthouse', accountId: 'acct_1' },
+      }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(404);
+    expect(prisma.team.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET billing-account (flag ON)', () => {
+  it('returns null for an unbound team', async () => {
+    const res = await GET(req('http://localhost/api/v1/teams/team-1/billing-account'), params('team-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.billingAccountRef).toBeNull();
+  });
+  it('returns the ref for a bound team', async () => {
+    prisma.team.findUnique.mockResolvedValue({
+      id: 'team-1',
+      billingAccountProviderSlug: 'pymthouse',
+      billingAccountId: 'acct_om_1',
+    });
+    const res = await GET(req('http://localhost/api/v1/teams/team-1/billing-account'), params('team-1'));
+    const json = await res.json();
+    expect(json.data.billingAccountRef).toEqual({ providerSlug: 'pymthouse', accountId: 'acct_om_1' });
+  });
+});
+
+describe('PUT billing-account (flag ON)', () => {
+  it('requires admin', async () => {
+    validateTeamAccess.mockRejectedValue(new Error('Requires admin role or higher'));
+    const res = await PUT(
+      req('http://localhost/api/v1/teams/team-1/billing-account', {
+        method: 'PUT',
+        body: { providerSlug: 'pymthouse', accountId: 'acct_1' },
+      }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(403);
+  });
+  it('400 for a malformed ref', async () => {
+    const res = await PUT(
+      req('http://localhost/api/v1/teams/team-1/billing-account', { method: 'PUT', body: { providerSlug: 'x' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(400);
+    expect(prisma.team.update).not.toHaveBeenCalled();
+  });
+  it('400 when provider has no registered adapter (stays generic)', async () => {
+    hasBillingProviderAdapter.mockReturnValue(false);
+    const res = await PUT(
+      req('http://localhost/api/v1/teams/team-1/billing-account', {
+        method: 'PUT',
+        body: { providerSlug: 'nope', accountId: 'acct_1' },
+      }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(400);
+    expect(prisma.team.update).not.toHaveBeenCalled();
+  });
+  it('binds a valid ref via the adapter registry (pymthouse)', async () => {
+    const res = await PUT(
+      req('http://localhost/api/v1/teams/team-1/billing-account', {
+        method: 'PUT',
+        body: { providerSlug: 'Pymthouse', accountId: ' acct_om_1 ' },
+      }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.billingAccountRef).toEqual({ providerSlug: 'pymthouse', accountId: 'acct_om_1' });
+    expect(prisma.team.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { billingAccountProviderSlug: 'pymthouse', billingAccountId: 'acct_om_1' },
+      }),
+    );
+  });
+  it('binds against the C0 stub provider too (provider-agnostic)', async () => {
+    const res = await PUT(
+      req('http://localhost/api/v1/teams/team-1/billing-account', {
+        method: 'PUT',
+        body: { providerSlug: 'stub', accountId: 'acct_stub_1' },
+      }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/billing-account/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/billing-account/route.ts
@@ -1,0 +1,157 @@
+/**
+ * Team billing-account binding (NAAP-1).
+ *
+ *   GET /api/v1/teams/{teamId}/billing-account   — read the team's billingAccountRef (viewer+)
+ *   PUT /api/v1/teams/{teamId}/billing-account    — bind { providerSlug, accountId } (admin+)
+ *
+ * Binds a team to ONE provider-agnostic `billingAccountRef` resolved through the
+ * BillingProviderAdapter registry (NAAP-A) — never a provider-specific FK
+ * (Decision D2: no separate NaaP billing-account entity). `accountId` is the
+ * provider's opaque customer/subscription id (e.g. an OpenMeter customer id).
+ *
+ * Gated behind the `team_seats` flag (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import {
+  TEAM_SEATS_FLAG,
+  isProviderResolvable,
+  normalizeBillingAccountRef,
+  teamBillingAccountRef,
+} from '@/lib/teams/billing-account-ref';
+
+interface RouteParams {
+  params: Promise<{ teamId: string }>;
+}
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'viewer');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { id: true, billingAccountProviderSlug: true, billingAccountId: true },
+    });
+    if (!team) return noStore(errors.notFound('Team'));
+
+    return noStore(success({ billingAccountRef: teamBillingAccountRef(team) }));
+  } catch (err) {
+    log('error', 'team.billing_account.get.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to read billing account'));
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'admin');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return noStore(errors.badRequest('Invalid JSON in request body'));
+    }
+
+    const ref = normalizeBillingAccountRef(body);
+    if (!ref) {
+      return noStore(errors.badRequest('billingAccountRef requires { providerSlug, accountId }'));
+    }
+    // Stay generic: only providers with a registered adapter are bindable.
+    if (!isProviderResolvable(ref)) {
+      log('warn', 'team.billing_account.unknown_provider', {
+        teamId,
+        correlationId,
+        providerSlug: ref.providerSlug,
+      });
+      return noStore(errors.badRequest(`Unknown billing provider "${ref.providerSlug}"`));
+    }
+
+    const team = await prisma.team.findUnique({ where: { id: teamId }, select: { id: true } });
+    if (!team) return noStore(errors.notFound('Team'));
+
+    await prisma.team.update({
+      where: { id: teamId },
+      data: { billingAccountProviderSlug: ref.providerSlug, billingAccountId: ref.accountId },
+    });
+
+    // Never log accountId (provider-opaque, may be sensitive) — slug only.
+    log('info', 'team.billing_account.bind', {
+      teamId,
+      correlationId,
+      providerSlug: ref.providerSlug,
+    });
+    return noStore(success({ billingAccountRef: ref }));
+  } catch (err) {
+    log('error', 'team.billing_account.bind.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to bind billing account'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/[keyId]/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/[keyId]/route.test.ts
@@ -1,0 +1,80 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { DELETE } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({ isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a) }));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({ validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a) }));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+
+const prisma = vi.hoisted(() => ({
+  seat: { findFirst: vi.fn() },
+  devApiKey: { findFirst: vi.fn(), update: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(): NextRequest {
+  return new NextRequest('http://localhost/x', {
+    method: 'DELETE',
+    headers: { cookie: 'naap_auth_token=tok' },
+  });
+}
+
+const params = (teamId: string, seatId: string, keyId: string) => ({
+  params: Promise.resolve({ teamId, seatId, keyId }),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1', roles: [] });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'admin' } });
+  prisma.seat.findFirst.mockResolvedValue({ id: 'seat-1', userId: 'user-1' });
+  prisma.devApiKey.findFirst.mockResolvedValue({ id: 'key-1', status: 'ACTIVE' });
+  prisma.devApiKey.update.mockResolvedValue({ id: 'key-1', status: 'REVOKED' });
+});
+
+describe('DELETE revoke native key', () => {
+  it('404 no-op when flag OFF', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await DELETE(req(), params('team-1', 'seat-1', 'key-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.update).not.toHaveBeenCalled();
+  });
+
+  it('revokes an active key (status → REVOKED)', async () => {
+    const res = await DELETE(req(), params('team-1', 'seat-1', 'key-1'));
+    expect(res.status).toBe(200);
+    expect(prisma.devApiKey.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'REVOKED' }) }),
+    );
+  });
+
+  it('is idempotent for an already-revoked key', async () => {
+    prisma.devApiKey.findFirst.mockResolvedValue({ id: 'key-1', status: 'REVOKED' });
+    const res = await DELETE(req(), params('team-1', 'seat-1', 'key-1'));
+    expect(res.status).toBe(200);
+    expect(prisma.devApiKey.update).not.toHaveBeenCalled();
+  });
+
+  it('404 for an unknown key', async () => {
+    prisma.devApiKey.findFirst.mockResolvedValue(null);
+    const res = await DELETE(req(), params('team-1', 'seat-1', 'nope'));
+    expect(res.status).toBe(404);
+  });
+
+  it('404 for an unknown seat', async () => {
+    prisma.seat.findFirst.mockResolvedValue(null);
+    const res = await DELETE(req(), params('team-1', 'nope', 'key-1'));
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/[keyId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/[keyId]/route.ts
@@ -1,0 +1,109 @@
+/**
+ * Revoke a native `naap_` key (NAAP-B).
+ *
+ *   DELETE /api/v1/teams/{teamId}/seats/{seatId}/keys/{keyId}
+ *
+ * Revocation flips status → REVOKED, which invalidates the key INSTANTLY:
+ * `resolveNativeKeyToProviderSession` rejects any non-ACTIVE key before making a
+ * provider call. (Key rotation = revoke here + POST a new key.)
+ *
+ * Gated behind the `native_keys` flag (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { NATIVE_KEYS_FLAG } from '@/lib/dev-api/native-key';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; seatId: string; keyId: string }>;
+}
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, seatId, keyId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    // Authorize: member acting on their own seat, or a team admin.
+    try {
+      await validateTeamAccess(user.id, teamId, 'member');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+    const seat = await prisma.seat.findFirst({
+      where: { id: seatId, teamId },
+      select: { id: true, userId: true },
+    });
+    if (!seat) return noStore(errors.notFound('Seat'));
+    if (seat.userId !== user.id) {
+      try {
+        await validateTeamAccess(user.id, teamId, 'admin');
+      } catch (err) {
+        return mapAccessError(err);
+      }
+    }
+
+    const key = await prisma.devApiKey.findFirst({
+      where: { id: keyId, seatId, teamId },
+      select: { id: true, status: true },
+    });
+    if (!key) return noStore(errors.notFound('Key'));
+
+    if (key.status !== 'REVOKED') {
+      await prisma.devApiKey.update({
+        where: { id: keyId },
+        data: { status: 'REVOKED', revokedAt: new Date() },
+      });
+    }
+
+    log('info', 'native_key.revoke', { teamId, seatId, correlationId, keyId });
+    return noStore(success({ revoked: true, keyId }));
+  } catch (err) {
+    log('error', 'native_key.revoke.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to revoke key'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/route.test.ts
@@ -1,0 +1,149 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, POST } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({ isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a) }));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({ validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a) }));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+const prisma = vi.hoisted(() => ({
+  seat: { findFirst: vi.fn() },
+  devApiKey: { findMany: vi.fn(), count: vi.fn(), create: vi.fn() },
+  team: { findUnique: vi.fn() },
+  billingProvider: { findUnique: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }): NextRequest {
+  return new NextRequest(url, {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', 'content-type': 'application/json', ...(init?.headers ?? {}) },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+const params = (teamId: string, seatId: string) => ({ params: Promise.resolve({ teamId, seatId }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1', email: 'u@e.co', roles: [] });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'admin' } });
+  prisma.seat.findFirst.mockResolvedValue({ id: 'seat-1', userId: 'user-1', status: 'active', keyLimit: 5 });
+  prisma.devApiKey.findMany.mockResolvedValue([]);
+  prisma.devApiKey.count.mockResolvedValue(0);
+  prisma.devApiKey.create.mockImplementation(async ({ select: _s, data }: { select: unknown; data: Record<string, unknown> }) => ({
+    id: 'key-1',
+    keyPrefix: data.keyPrefix,
+    label: data.label ?? null,
+    status: data.status,
+    seatId: data.seatId,
+    teamId: data.teamId,
+    createdAt: new Date(),
+    lastUsedAt: null,
+    revokedAt: null,
+  }));
+  prisma.team.findUnique.mockResolvedValue({
+    id: 'team-1',
+    billingAccountProviderSlug: 'pymthouse',
+    billingAccountId: 'acct_om_1',
+  });
+  prisma.billingProvider.findUnique.mockResolvedValue({ id: 'bp-1', enabled: true });
+  getBillingProviderAdapter.mockReturnValue({ slug: 'pymthouse', isConfigured: () => true });
+});
+
+describe('flag OFF (zero regression)', () => {
+  it('GET 404 no-op', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req('http://localhost/x'), params('team-1', 'seat-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.findMany).not.toHaveBeenCalled();
+  });
+  it('POST 404 no-op (never mints)', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(req('http://localhost/x', { method: 'POST', body: {} }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST mint (flag ON)', () => {
+  it('401 without token', async () => {
+    const res = await POST(new NextRequest('http://localhost/x', { method: 'POST' }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(401);
+  });
+
+  it('mints a provider-opaque naap_ key and returns it once', async () => {
+    const res = await POST(req('http://localhost/x', { method: 'POST', body: { label: 'ci' } }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.rawKey).toMatch(/^naap_[0-9a-f]{16}_[0-9a-f]{48}$/);
+    // The created row never exposes the hash; an encrypted session ref is stored.
+    const createArg = prisma.devApiKey.create.mock.calls[0][0].data;
+    expect(createArg.providerSessionRefEnc).toBeTruthy();
+    expect(createArg.providerSessionRefIv).toBeTruthy();
+    expect(createArg.seatId).toBe('seat-1');
+    expect(createArg.billingProviderId).toBe('bp-1');
+    // The response must NOT leak provider tokens/URLs or the account id.
+    expect(JSON.stringify(json.data)).not.toContain('acct_om_1');
+    expect(JSON.stringify(json.data)).not.toContain('pmth_');
+  });
+
+  it('rejects minting when the seat is over its key limit', async () => {
+    prisma.devApiKey.count.mockResolvedValue(5);
+    const res = await POST(req('http://localhost/x', { method: 'POST', body: {} }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(403);
+    expect(prisma.devApiKey.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects minting when the team is not bound to a billing account', async () => {
+    prisma.team.findUnique.mockResolvedValue({
+      id: 'team-1',
+      billingAccountProviderSlug: null,
+      billingAccountId: null,
+    });
+    const res = await POST(req('http://localhost/x', { method: 'POST', body: {} }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects minting when the bound provider lacks a BillingProvider row', async () => {
+    prisma.billingProvider.findUnique.mockResolvedValue(null);
+    const res = await POST(req('http://localhost/x', { method: 'POST', body: {} }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('forbids acting on another user\u2019s seat without admin', async () => {
+    prisma.seat.findFirst.mockResolvedValue({ id: 'seat-1', userId: 'other', status: 'active', keyLimit: 5 });
+    validateTeamAccess.mockImplementation(async (_u: string, _t: string, role: string) => {
+      if (role === 'admin') throw new Error('Requires admin role or higher');
+      return { team: { id: 'team-1' }, member: { role: 'member' } };
+    });
+    const res = await POST(req('http://localhost/x', { method: 'POST', body: {} }), params('team-1', 'seat-1'));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET list (flag ON)', () => {
+  it('lists safe key rows for the seat', async () => {
+    prisma.devApiKey.findMany.mockResolvedValue([{ id: 'key-1', keyPrefix: 'naap_abc...', status: 'ACTIVE' }]);
+    const res = await GET(req('http://localhost/x'), params('team-1', 'seat-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.keys).toHaveLength(1);
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/route.ts
@@ -1,0 +1,240 @@
+/**
+ * Native `naap_` keys for a seat (NAAP-B).
+ *
+ *   GET  /api/v1/teams/{teamId}/seats/{seatId}/keys   — list a seat's native keys (member/owner+admin)
+ *   POST /api/v1/teams/{teamId}/seats/{seatId}/keys    — mint a native key for the seat
+ *
+ * The minted key is provider-OPAQUE (`naap_…`); it maps server-side to the
+ * provider that backs the team's billing account (NAAP-1 billingAccountRef →
+ * adapter, NAAP-A). Apps never receive provider tokens/URLs. The raw key is
+ * returned exactly once at creation.
+ *
+ * Gated behind the `native_keys` flag (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { encrypt } from '@/lib/gateway/encryption';
+import { deriveKeyLookupId, formatBillingKeyPublicPrefix, hashApiKey } from '@naap/database';
+import { teamBillingAccountRef } from '@/lib/teams/billing-account-ref';
+import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import { seatCanMintKey } from '@/lib/teams/seats';
+import { NATIVE_KEYS_FLAG, generateNativeApiKey } from '@/lib/dev-api/native-key';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; seatId: string }>;
+}
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+const SAFE_KEY_SELECT = {
+  id: true,
+  keyPrefix: true,
+  label: true,
+  status: true,
+  seatId: true,
+  teamId: true,
+  createdAt: true,
+  lastUsedAt: true,
+  revokedAt: true,
+} as const;
+
+/**
+ * Authorize the caller for this seat: a team member acting on THEIR OWN seat,
+ * or a team admin acting on any seat. Returns null on success or an error
+ * response. Loads the seat (scoped to the team) as a side benefit.
+ */
+async function authorizeSeatAction(
+  userId: string,
+  teamId: string,
+  seatId: string,
+): Promise<{ error: NextResponse } | { seat: { id: string; userId: string | null; status: string; keyLimit: number } }> {
+  try {
+    await validateTeamAccess(userId, teamId, 'member');
+  } catch (err) {
+    return { error: mapAccessError(err) };
+  }
+  const seat = await prisma.seat.findFirst({
+    where: { id: seatId, teamId },
+    select: { id: true, userId: true, status: true, keyLimit: true },
+  });
+  if (!seat) return { error: noStore(errors.notFound('Seat')) };
+
+  if (seat.userId !== userId) {
+    // Acting on someone else's seat requires admin.
+    try {
+      await validateTeamAccess(userId, teamId, 'admin');
+    } catch (err) {
+      return { error: mapAccessError(err) };
+    }
+  }
+  return { seat };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, seatId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    const authz = await authorizeSeatAction(user.id, teamId, seatId);
+    if ('error' in authz) return authz.error;
+
+    const keys = await prisma.devApiKey.findMany({
+      where: { seatId, teamId },
+      orderBy: { createdAt: 'desc' },
+      select: SAFE_KEY_SELECT,
+    });
+    return noStore(success({ keys }));
+  } catch (err) {
+    log('error', 'native_key.list.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to list keys'));
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, seatId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    const authz = await authorizeSeatAction(user.id, teamId, seatId);
+    if ('error' in authz) return authz.error;
+    const { seat } = authz;
+
+    // Seat must be active and within its per-seat key limit (NAAP-1).
+    const activeKeyCount = await prisma.devApiKey.count({
+      where: { seatId, status: 'ACTIVE' },
+    });
+    if (!seatCanMintKey(seat, activeKeyCount)) {
+      return noStore(errors.forbidden('Seat is not active or has reached its key limit'));
+    }
+
+    // Resolve the team's billing binding → provider (stays generic).
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { id: true, billingAccountProviderSlug: true, billingAccountId: true },
+    });
+    const ref = team ? teamBillingAccountRef(team) : null;
+    if (!ref) {
+      return noStore(errors.badRequest('Team is not bound to a billing account (set billingAccountRef first)'));
+    }
+    const adapter = getBillingProviderAdapter(ref.providerSlug);
+    if (!adapter) {
+      return noStore(errors.badRequest(`Unknown billing provider "${ref.providerSlug}"`));
+    }
+    // DevApiKey requires a BillingProvider row (FK). Native keys mint only for
+    // providers present in the registry AND seeded as a BillingProvider.
+    const provider = await prisma.billingProvider.findUnique({
+      where: { slug: ref.providerSlug },
+      select: { id: true, enabled: true },
+    });
+    if (!provider || !provider.enabled) {
+      return noStore(errors.badRequest(`Billing provider "${ref.providerSlug}" is not enabled for key minting`));
+    }
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      // Body is optional (label only); ignore parse errors → no label.
+    }
+    const label =
+      typeof body.label === 'string' && body.label.trim() ? body.label.trim().slice(0, 120) : null;
+
+    const { rawKey } = generateNativeApiKey();
+    const keyLookupId = deriveKeyLookupId(rawKey);
+    const keyPrefix = formatBillingKeyPublicPrefix(rawKey);
+    const keyHash = hashApiKey(rawKey);
+    // Store an encrypted, provider-opaque session ref (the account pointer this
+    // key maps to). Never store/return the provider token itself.
+    const sessionRef = encrypt(ref.accountId);
+
+    const created = await prisma.devApiKey.create({
+      data: {
+        userId: user.id,
+        billingProviderId: provider.id,
+        seatId,
+        teamId,
+        keyLookupId,
+        keyPrefix,
+        keyHash,
+        label,
+        status: 'ACTIVE',
+        providerSessionRefEnc: sessionRef.encryptedValue,
+        providerSessionRefIv: sessionRef.iv,
+      },
+      select: SAFE_KEY_SELECT,
+    });
+
+    // Never log the raw key, hash, accountId, or session ref — slug + ids only.
+    log('info', 'native_key.mint', {
+      teamId,
+      seatId,
+      correlationId,
+      keyId: created.id,
+      providerSlug: ref.providerSlug,
+    });
+
+    return noStore(
+      success({
+        key: created,
+        rawKey,
+        warning: 'Store this key securely. It is provider-opaque and will not be shown again.',
+      }),
+    );
+  } catch (err) {
+    log('error', 'native_key.mint.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to mint key'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/route.ts
@@ -1,0 +1,195 @@
+/**
+ * Single Team Seat API (NAAP-1).
+ *
+ *   GET    /api/v1/teams/{teamId}/seats/{seatId}   — read a seat (viewer+)
+ *   PATCH  /api/v1/teams/{teamId}/seats/{seatId}   — update role/keyLimit/status (admin+)
+ *   DELETE /api/v1/teams/{teamId}/seats/{seatId}   — revoke/remove a seat (admin+)
+ *
+ * Gated behind the `team_seats` flag (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { TEAM_SEATS_FLAG } from '@/lib/teams/billing-account-ref';
+import { isSeatRole, isSeatStatus, normalizeKeyLimit } from '@/lib/teams/seats';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; seatId: string }>;
+}
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+const SEAT_SELECT = {
+  id: true,
+  teamId: true,
+  userId: true,
+  email: true,
+  role: true,
+  status: true,
+  keyLimit: true,
+  invitedBy: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, seatId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'viewer');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const seat = await prisma.seat.findFirst({ where: { id: seatId, teamId }, select: SEAT_SELECT });
+    if (!seat) return noStore(errors.notFound('Seat'));
+
+    return noStore(success({ seat }));
+  } catch (err) {
+    log('error', 'team.seat.get.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to read seat'));
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, seatId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'admin');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const existing = await prisma.seat.findFirst({ where: { id: seatId, teamId }, select: { id: true } });
+    if (!existing) return noStore(errors.notFound('Seat'));
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return noStore(errors.badRequest('Invalid JSON in request body'));
+    }
+
+    const data: { role?: string; status?: string; keyLimit?: number } = {};
+    if (body.role !== undefined) {
+      if (!isSeatRole(body.role)) return noStore(errors.badRequest('Invalid role'));
+      data.role = body.role;
+    }
+    if (body.status !== undefined) {
+      if (!isSeatStatus(body.status)) return noStore(errors.badRequest('Invalid status'));
+      data.status = body.status;
+    }
+    if (body.keyLimit !== undefined) {
+      const normalized = normalizeKeyLimit(body.keyLimit);
+      if (normalized === null) return noStore(errors.badRequest('Invalid keyLimit'));
+      data.keyLimit = normalized;
+    }
+    if (Object.keys(data).length === 0) {
+      return noStore(errors.badRequest('No updatable fields provided'));
+    }
+
+    const seat = await prisma.seat.update({ where: { id: seatId }, data, select: SEAT_SELECT });
+    log('info', 'team.seat.update', { teamId, correlationId, seatId, fields: Object.keys(data) });
+    return noStore(success({ seat }));
+  } catch (err) {
+    log('error', 'team.seat.update.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to update seat'));
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, seatId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'admin');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const existing = await prisma.seat.findFirst({ where: { id: seatId, teamId }, select: { id: true } });
+    if (!existing) return noStore(errors.notFound('Seat'));
+
+    // Revoke (soft) so any keys remain auditable; status flips to revoked.
+    const seat = await prisma.seat.update({
+      where: { id: seatId },
+      data: { status: 'revoked' },
+      select: SEAT_SELECT,
+    });
+    log('info', 'team.seat.revoke', { teamId, correlationId, seatId });
+    return noStore(success({ seat }));
+  } catch (err) {
+    log('error', 'team.seat.revoke.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to revoke seat'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/route.test.ts
@@ -1,0 +1,147 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, POST } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({
+  validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a),
+}));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+
+const prisma = vi.hoisted(() => ({
+  seat: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn() },
+  user: { findUnique: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }): NextRequest {
+  return new NextRequest(url, {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', 'content-type': 'application/json', ...(init?.headers ?? {}) },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+const params = (teamId: string) => ({ params: Promise.resolve({ teamId }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1', email: 'u@example.com', roles: [] });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'admin' } });
+  prisma.seat.findMany.mockResolvedValue([]);
+  prisma.seat.findUnique.mockResolvedValue(null);
+  prisma.user.findUnique.mockResolvedValue(null);
+  prisma.seat.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+    id: 'seat-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...data,
+  }));
+});
+
+describe('flag OFF (zero regression)', () => {
+  it('GET is a no-op 404 and never touches DB/auth', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req('http://localhost/api/v1/teams/team-1/seats'), params('team-1'));
+    expect(res.status).toBe(404);
+    expect(validateSession).not.toHaveBeenCalled();
+    expect(prisma.seat.findMany).not.toHaveBeenCalled();
+  });
+  it('POST is a no-op 404 when OFF', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { email: 'a@b.co' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(404);
+    expect(prisma.seat.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET seats (flag ON)', () => {
+  it('401 without a token', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/v1/teams/team-1/seats'), params('team-1'));
+    expect(res.status).toBe(401);
+  });
+  it('403 when not a team member', async () => {
+    validateTeamAccess.mockRejectedValue(new Error('Not a member of this team'));
+    const res = await GET(req('http://localhost/api/v1/teams/team-1/seats'), params('team-1'));
+    expect(res.status).toBe(403);
+  });
+  it('lists seats for a member', async () => {
+    prisma.seat.findMany.mockResolvedValue([{ id: 'seat-1', teamId: 'team-1', role: 'member' }]);
+    const res = await GET(req('http://localhost/api/v1/teams/team-1/seats'), params('team-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.seats).toHaveLength(1);
+    expect(validateTeamAccess).toHaveBeenCalledWith('user-1', 'team-1', 'viewer');
+  });
+});
+
+describe('POST seats (flag ON)', () => {
+  it('requires admin role', async () => {
+    validateTeamAccess.mockRejectedValue(new Error('Requires admin role or higher'));
+    const res = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { email: 'a@b.co' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(403);
+  });
+  it('400 when neither email nor userId provided', async () => {
+    const res = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { role: 'member' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(400);
+  });
+  it('400 for an invalid role', async () => {
+    const res = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { email: 'a@b.co', role: 'owner' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(400);
+  });
+  it('creates a PENDING invite seat when the email is unknown', async () => {
+    const res = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { email: 'new@b.co', role: 'member' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.seat.status).toBe('pending');
+    const createArg = prisma.seat.create.mock.calls[0][0].data;
+    expect(createArg.userId).toBeNull();
+    expect(createArg.inviteToken).toBeTruthy();
+  });
+  it('creates an ACTIVE seat for an existing user and rejects duplicates', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2' });
+    const res = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { email: 'known@b.co' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.seat.status).toBe('active');
+
+    // duplicate
+    prisma.seat.findUnique.mockResolvedValue({ id: 'seat-existing' });
+    const dup = await POST(
+      req('http://localhost/api/v1/teams/team-1/seats', { method: 'POST', body: { email: 'known@b.co' } }),
+      params('team-1'),
+    );
+    expect(dup.status).toBe(409);
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/route.ts
@@ -1,0 +1,233 @@
+/**
+ * Team Seats API (NAAP-1).
+ *
+ *   GET  /api/v1/teams/{teamId}/seats   — list seats (viewer+)
+ *   POST /api/v1/teams/{teamId}/seats   — invite / create a seat (admin+)
+ *
+ * Gated behind the `team_seats` flag (default OFF): when OFF this route is a
+ * no-op (404), so no existing team behavior changes. Zero regression.
+ *
+ * Never logs secrets/PII — only ids + correlation id.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { TEAM_SEATS_FLAG } from '@/lib/teams/billing-account-ref';
+import {
+  DEFAULT_SEAT_KEY_LIMIT,
+  isSeatRole,
+  normalizeKeyLimit,
+  type SeatRole,
+} from '@/lib/teams/seats';
+
+interface RouteParams {
+  params: Promise<{ teamId: string }>;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+/** Map a thrown access error from validateTeamAccess to an HTTP response. */
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (
+    message.includes('Not a member') ||
+    message.includes('Requires') ||
+    message.includes('role')
+  ) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) {
+      return noStore(errors.notFound('Resource'));
+    }
+
+    const { teamId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'viewer');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const seats = await prisma.seat.findMany({
+      where: { teamId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        teamId: true,
+        userId: true,
+        email: true,
+        role: true,
+        status: true,
+        keyLimit: true,
+        invitedBy: true,
+        createdAt: true,
+        updatedAt: true,
+        user: { select: { id: true, email: true, displayName: true, avatarUrl: true } },
+      },
+    });
+
+    log('info', 'team.seats.list', { teamId, correlationId, count: seats.length });
+    return noStore(success({ seats }));
+  } catch (err) {
+    log('error', 'team.seats.list.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to list seats'));
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) {
+      return noStore(errors.notFound('Resource'));
+    }
+
+    const { teamId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'admin');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return noStore(errors.badRequest('Invalid JSON in request body'));
+    }
+
+    const emailRaw = typeof body.email === 'string' ? body.email.trim().toLowerCase() : undefined;
+    const userIdRaw = typeof body.userId === 'string' ? body.userId.trim() : undefined;
+    const roleRaw = typeof body.role === 'string' ? body.role : 'member';
+
+    if (!emailRaw && !userIdRaw) {
+      return noStore(errors.badRequest('Either email or userId is required'));
+    }
+    if (emailRaw && !EMAIL_RE.test(emailRaw)) {
+      return noStore(errors.badRequest('Invalid email'));
+    }
+    if (!isSeatRole(roleRaw)) {
+      return noStore(errors.badRequest('Invalid role. Must be admin, member, or viewer.'));
+    }
+    const role: SeatRole = roleRaw;
+
+    let keyLimit = DEFAULT_SEAT_KEY_LIMIT;
+    if (body.keyLimit !== undefined) {
+      const normalized = normalizeKeyLimit(body.keyLimit);
+      if (normalized === null) {
+        return noStore(errors.badRequest('Invalid keyLimit'));
+      }
+      keyLimit = normalized;
+    }
+
+    // Resolve the target NaaP user (by id or email). When unknown, create a
+    // PENDING invite seat with an opaque single-use token.
+    let targetUserId: string | null = null;
+    let targetEmail: string | null = emailRaw ?? null;
+    if (userIdRaw) {
+      const found = await prisma.user.findUnique({ where: { id: userIdRaw }, select: { id: true, email: true } });
+      if (!found) return noStore(errors.badRequest('User not found'));
+      targetUserId = found.id;
+      targetEmail = found.email ?? targetEmail;
+    } else if (emailRaw) {
+      const found = await prisma.user.findUnique({ where: { email: emailRaw }, select: { id: true } });
+      targetUserId = found?.id ?? null;
+    }
+
+    if (targetUserId) {
+      const existing = await prisma.seat.findUnique({
+        where: { teamId_userId: { teamId, userId: targetUserId } },
+        select: { id: true },
+      });
+      if (existing) {
+        return noStore(errors.conflict('User already has a seat in this team'));
+      }
+    }
+
+    const isPending = targetUserId === null;
+    const seat = await prisma.seat.create({
+      data: {
+        teamId,
+        userId: targetUserId,
+        email: targetEmail,
+        role,
+        status: isPending ? 'pending' : 'active',
+        keyLimit,
+        invitedBy: user.id,
+        inviteToken: isPending ? randomUUID() : null,
+      },
+      select: {
+        id: true,
+        teamId: true,
+        userId: true,
+        email: true,
+        role: true,
+        status: true,
+        keyLimit: true,
+        invitedBy: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    log('info', 'team.seats.create', {
+      teamId,
+      correlationId,
+      seatId: seat.id,
+      role,
+      status: seat.status,
+    });
+    return noStore(success({ seat }));
+  } catch (err) {
+    log('error', 'team.seats.create.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to create seat'));
+  }
+}

--- a/apps/web-next/src/integration/_mocks/pymthouse-mock.ts
+++ b/apps/web-next/src/integration/_mocks/pymthouse-mock.ts
@@ -1,0 +1,148 @@
+/**
+ * Pymthouse MOCK — used by INT-0 / INT-G (no live staging secrets).
+ *
+ * Models the reference provider's BPP surface using the **C0 contract shapes**
+ * only. Crucially it returns a NEUTRAL opaque `subscriptionRef` (the shape
+ * pymthouse PR #149 standardized on) and NEVER leaks provider-internal
+ * OpenMeter fields (`openmeter_subscription_id`, `source:"openmeter"`, …) across
+ * the seam — exactly what the BPP requires of the real provider.
+ *
+ * Two faces:
+ *   - `createPymthouseMockProvider()` → a `BppConformanceProvider` for INT-0.
+ *   - `PymthouseMockAdapter` → a `BillingProviderAdapter` for INT-G front-door
+ *     resolution.
+ */
+
+import type { BppConformanceProvider } from '@/lib/billing/bpp/stub-provider';
+import {
+  type AppUsageInput,
+  type BillingProviderAdapter,
+  type Capability,
+  type CuratedOrchestrator,
+  type MintSignerSessionInput,
+  type Plan,
+  type SignerSession,
+  type UsageForExternalUserInput,
+  type ValidateResult,
+} from '@/lib/billing/adapter';
+
+export const PYMTHOUSE_MOCK_SLUG = 'pymthouse';
+
+/** Neutral opaque subscription pointer (pymthouse PR #149 `subscriptionRef`). */
+export const PYMTHOUSE_MOCK_SUBSCRIPTION_REF = 'pmthsub_2x9neutralopaque';
+
+const MOCK_CAPABILITIES = ['text-to-image:sdxl', 'text-to-video:ltx', 'tool:byoc-demo'];
+
+/** C0-shaped ② validate payload — neutral, no OpenMeter field names. */
+function validatePayload(valid: boolean): Record<string, unknown> {
+  if (!valid) return { valid: false };
+  return {
+    valid: true,
+    user: { sub: 'pmth-user-42' },
+    billing_account: {
+      id: 'acct_pmth_1',
+      providerSlug: PYMTHOUSE_MOCK_SLUG,
+      billingMode: 'delegated',
+    },
+    capabilities: MOCK_CAPABILITIES,
+    quota: { remaining: 5000, resetAt: '2026-12-31T23:59:59.999Z' },
+    // PR #149: neutral opaque pointer — NOT openmeter_subscription_id.
+    subscriptionRef: PYMTHOUSE_MOCK_SUBSCRIPTION_REF,
+    signerSession: {
+      url: 'https://signer.staging.pymthouse.com/session',
+      headers: { Authorization: 'Bearer pmth-mock-signer-token' },
+    },
+  };
+}
+
+/** A BppConformanceProvider (INT-0) backed by C0 shapes. */
+export function createPymthouseMockProvider(): BppConformanceProvider {
+  return {
+    slug: PYMTHOUSE_MOCK_SLUG,
+    async validate(key: string) {
+      return validatePayload(Boolean(key));
+    },
+    async getPlans() {
+      return [
+        {
+          id: 'pro',
+          name: 'Pro',
+          price: { amount: 4900, interval: 'month', currency: 'USD' },
+          bundles: [
+            { capability: 'text-to-image:sdxl', sla: { uptime: 0.995, p95Ms: 2500 }, maxPriceWeiPerUnit: '1000' },
+            { capability: 'text-to-video:ltx', sla: { uptime: 0.99, p95Ms: 8000 }, maxPriceWeiPerUnit: '5000' },
+          ],
+        },
+      ];
+    },
+    async getAccount() {
+      return {
+        account: {
+          id: 'acct_pmth_1',
+          ownerSub: 'pmth-user-42',
+          providerSlug: PYMTHOUSE_MOCK_SLUG,
+          planId: 'pro',
+          creditBalanceWei: '0',
+          billingMode: 'delegated',
+        },
+        members: [{ accountId: 'acct_pmth_1', sub: 'pmth-user-42', role: 'admin' }],
+        billingAccountRef: { providerSlug: PYMTHOUSE_MOCK_SLUG, accountId: 'acct_pmth_1' },
+      };
+    },
+    async getUsageIngest() {
+      // C0 ⑥ neutral usage — raw OpenMeter field names must NOT appear.
+      return {
+        providerSlug: PYMTHOUSE_MOCK_SLUG,
+        accountId: 'acct_pmth_1',
+        appId: 'app-storyboard',
+        window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+        sessions: 21,
+        tickets: 480,
+        feeWei: '123456789',
+        networkFeeUsdMicros: '210000',
+        byCapability: {
+          'text-to-image:sdxl': { tickets: 400, networkFeeUsdMicros: '180000' },
+          'text-to-video:ltx': { tickets: 80, networkFeeUsdMicros: '30000' },
+        },
+      };
+    },
+    async getCuratedList() {
+      return {
+        plan: 'pro',
+        version: '2026-06-17T00:00:00.000Z',
+        orchestrators: [
+          { address: 'https://orch.staging.pymthouse.com:8935', capabilities: MOCK_CAPABILITIES, score: 0.95 },
+        ],
+      };
+    },
+  };
+}
+
+/** A BillingProviderAdapter (INT-G) backed by the same C0 shapes. */
+export class PymthouseMockAdapter implements BillingProviderAdapter {
+  readonly slug = PYMTHOUSE_MOCK_SLUG;
+  isConfigured(): boolean {
+    return true;
+  }
+  async validate(key: string): Promise<ValidateResult> {
+    return validatePayload(Boolean(key)) as unknown as ValidateResult;
+  }
+  async getPlans(): Promise<Plan[]> {
+    return (await createPymthouseMockProvider().getPlans()) as Plan[];
+  }
+  async getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown> {
+    return { externalUserId: input.externalUserId, period: { start: input.startDate, end: input.endDate }, requestCount: 120 };
+  }
+  async getAppUsage(input: AppUsageInput): Promise<unknown> {
+    return { period: { start: input.startDate, end: input.endDate }, totals: { requestCount: 480 } };
+  }
+  async mintSignerSession(_input: MintSignerSessionInput): Promise<SignerSession> {
+    return { url: 'https://signer.staging.pymthouse.com/session', headers: { Authorization: 'Bearer pmth-mock-signer-token' } };
+  }
+  async receiveCuratedOrchestrators(_plan: string, _list: CuratedOrchestrator[]): Promise<void> {
+    /* no-op mock */
+  }
+  async getCapabilityManifest(): Promise<Capability[]> {
+    return MOCK_CAPABILITIES.map((id) => ({ id }));
+  }
+}

--- a/apps/web-next/src/integration/int-0.test.ts
+++ b/apps/web-next/src/integration/int-0.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment node */
+
+/**
+ * INT-0 — BPP contract conformance (consolidated branch).
+ *
+ * Proves both providers' payloads validate against the C0 JSON Schemas and that
+ * the provider-agnostic seam holds: no provider-internal (OpenMeter ⑨) field
+ * names leak through ② validate / ⑥ usage. Runs against:
+ *   - the C0 in-memory stub provider, and
+ *   - a pymthouse MOCK (C0 shapes; neutral subscriptionRef per PR #149).
+ *
+ * No live secrets — stub + mock only.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { createStubBillingProvider } from '@/lib/billing/bpp/stub-provider';
+import {
+  compileAllSchemas,
+  findLeakedInternalFields,
+  getForbiddenInternalFieldNames,
+  runConformance,
+  validateAgainstBppSchema,
+} from '@/lib/billing/bpp/conformance';
+import { StubAdapter } from '@/lib/billing/stub-adapter';
+import {
+  PYMTHOUSE_MOCK_SUBSCRIPTION_REF,
+  PymthouseMockAdapter,
+  createPymthouseMockProvider,
+} from './_mocks/pymthouse-mock';
+
+describe('INT-0 — schema lint', () => {
+  it('every BPP schema compiles (2020-12)', () => {
+    expect(() => compileAllSchemas()).not.toThrow();
+  });
+});
+
+describe('INT-0 — conformance: stub provider', () => {
+  it('passes all BPP seams with no leaks and a consistent account ref', async () => {
+    const report = await runConformance(createStubBillingProvider());
+    expect(report.seams.every((s) => s.valid)).toBe(true);
+    expect(report.leakedFields).toEqual([]);
+    expect(report.accountRefMismatches).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+});
+
+describe('INT-0 — conformance: pymthouse mock', () => {
+  it('passes all BPP seams with no OpenMeter leakage', async () => {
+    const report = await runConformance(createPymthouseMockProvider());
+    expect(report.passed).toBe(true);
+    expect(report.leakedFields).toEqual([]);
+    expect(report.accountRefMismatches).toEqual([]);
+  });
+
+  it('surfaces a NEUTRAL opaque subscriptionRef (PR #149), not an internal id', async () => {
+    const v = (await createPymthouseMockProvider().validate('k')) as Record<string, unknown>;
+    expect(v.subscriptionRef).toBe(PYMTHOUSE_MOCK_SUBSCRIPTION_REF);
+    expect(JSON.stringify(v)).not.toMatch(/openmeter|konnect|source"\s*:\s*"openmeter/i);
+  });
+});
+
+describe('INT-0 — seam isolation guard works', () => {
+  it('catches a planted provider-internal field name', () => {
+    const forbidden = getForbiddenInternalFieldNames();
+    const leak = findLeakedInternalFields(
+      { valid: true, openmeter_subscription_id: 'sub_123' },
+      forbidden,
+    );
+    expect(leak).toContain('openmeter_subscription_id');
+  });
+});
+
+describe('INT-0 — adapter validate() outputs conform to validate.schema.json', () => {
+  it('stub adapter', async () => {
+    const out = await new StubAdapter().validate('k');
+    expect(validateAgainstBppSchema('validate', out).valid).toBe(true);
+  });
+  it('pymthouse mock adapter', async () => {
+    const out = await new PymthouseMockAdapter().validate('k');
+    const check = validateAgainstBppSchema('validate', out);
+    expect(check.valid, JSON.stringify(check.errors)).toBe(true);
+  });
+});

--- a/apps/web-next/src/integration/int-1.test.ts
+++ b/apps/web-next/src/integration/int-1.test.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment node */
+
+/**
+ * INT-1 / INV-1 — no-regression with ALL new flags OFF (consolidated branch).
+ *
+ * The whole point of the integration branch is that merging 11 feature branches
+ * changes NOTHING until a flag is flipped. This proves it two ways:
+ *   1. Every NEW cross-system flag defaults OFF in KNOWN_FLAGS.
+ *   2. The front door (the new cross-system entry point) is a 404 no-op when its
+ *      flag is OFF and never touches the database — so existing callers fall back
+ *      to their current path unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { KNOWN_FLAGS } from '@/lib/feature-flags';
+
+/** The flags introduced by the Phase-0/2 branches — all must default OFF. */
+const NEW_CROSS_SYSTEM_FLAGS = [
+  'provider_adapters',
+  'team_seats',
+  'native_keys',
+  'key_validation_front_door',
+  'app_registry',
+  'usage_ingest',
+  'db_adapter_registry',
+] as const;
+
+describe('INV-1 — every new cross-system flag defaults OFF', () => {
+  it.each(NEW_CROSS_SYSTEM_FLAGS)('flag %s is present and OFF by default', (key) => {
+    const flag = KNOWN_FLAGS.find((f) => f.key === key);
+    expect(flag, `flag ${key} should be registered`).toBeDefined();
+    expect(flag?.enabled, `flag ${key} must default OFF`).toBe(false);
+  });
+
+  it('the merge introduced no flag that defaults ON (except pre-existing enableTeams)', () => {
+    const onByDefault = KNOWN_FLAGS.filter((f) => f.enabled).map((f) => f.key);
+    expect(onByDefault).toEqual(['enableTeams']);
+  });
+});
+
+// Front-door no-op proof (flag OFF) — isolated module mocks.
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/feature-flags')>();
+  return { ...actual, isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a) };
+});
+vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
+const prisma = vi.hoisted(() => ({
+  devApiKey: { findUnique: vi.fn(), update: vi.fn() },
+  team: { findUnique: vi.fn() },
+  application: { findFirst: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+describe('INT-1 — front door is a 404 no-op when its flag is OFF', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isFeatureEnabled.mockResolvedValue(false); // ALL flags OFF
+  });
+
+  it('404s and never touches the DB (callers keep their existing path)', async () => {
+    const { POST } = await import('@/app/api/v1/keys/validate/route');
+    const res = await POST(
+      new NextRequest('http://localhost/api/v1/keys/validate', {
+        method: 'POST',
+        headers: { authorization: 'Bearer naap_anything', 'x-app-id': 'storyboard' },
+      }),
+    );
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+    expect(prisma.application.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-next/src/integration/int-g.test.ts
+++ b/apps/web-next/src/integration/int-g.test.ts
@@ -1,0 +1,151 @@
+/** @vitest-environment node */
+
+/**
+ * INT-G — the generalization proof (consolidated branch).
+ *
+ * A native naap_ key resolves END-TO-END through the front door → seat → team →
+ * billingAccountRef → adapter for the full 2×2 matrix:
+ *   providers: { stub, pymthouse-mock }   ×   apps: { Storyboard, APP-2 }
+ *
+ * For every cell it asserts: correct provider resolution (E8), correct per-app
+ * attribution + capability gating (E9), the adapter's validate() payload
+ * conforms to the C0 validate.schema.json, and NO provider-internal field leaks
+ * through the seam. Flags are ON only in this test context. No live secrets —
+ * stub + pymthouse mock (C0 shapes, PR #149 subscriptionRef) only.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { generateNativeApiKey } from '@/lib/dev-api/native-key';
+import { hashApiKey } from '@naap/database';
+import { StubAdapter } from '@/lib/billing/stub-adapter';
+import {
+  findLeakedInternalFields,
+  getForbiddenInternalFieldNames,
+  validateAgainstBppSchema,
+} from '@/lib/billing/bpp/conformance';
+import { PymthouseMockAdapter } from './_mocks/pymthouse-mock';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({ isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a) }));
+vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
+
+// Registry dispatch by slug — used by BOTH the native-key resolver
+// (mintSignerSession) and the front door (capabilities).
+const adapters: Record<string, StubAdapter | PymthouseMockAdapter> = {
+  stub: new StubAdapter(),
+  pymthouse: new PymthouseMockAdapter(),
+};
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (slug: string) => adapters[slug],
+}));
+
+const prisma = vi.hoisted(() => ({
+  devApiKey: { findUnique: vi.fn(), update: vi.fn() },
+  team: { findUnique: vi.fn() },
+  application: { findFirst: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+const { rawKey } = generateNativeApiKey();
+const keyHash = hashApiKey(rawKey);
+
+const APPS = {
+  storyboard: {
+    id: 'app-storyboard', slug: 'storyboard', type: 'app', teamId: 'team-1', ownerUserId: null,
+    allowedScopes: ['gateway', 'llm'], allowedCapabilities: ['*'], status: 'active',
+  },
+  'naap-sample-cli': {
+    id: 'app-naap-cli', slug: 'naap-sample-cli', type: 'cli', teamId: 'team-1', ownerUserId: null,
+    allowedScopes: ['gateway'], allowedCapabilities: ['text-to-image:sdxl'], status: 'active',
+  },
+} as const;
+
+// Expected gated capability set per (provider × app).
+const EXPECTED: Record<string, Record<string, string[]>> = {
+  stub: {
+    storyboard: ['text-to-image:sdxl'],
+    'naap-sample-cli': ['text-to-image:sdxl'],
+  },
+  pymthouse: {
+    storyboard: ['text-to-image:sdxl', 'text-to-video:ltx', 'tool:byoc-demo'],
+    'naap-sample-cli': ['text-to-image:sdxl'],
+  },
+};
+
+const ACCOUNT_ID: Record<string, string> = { stub: 'acct_stub_1', pymthouse: 'acct_pmth_1' };
+
+function frontDoorReq(appId: string): NextRequest {
+  return new NextRequest('http://localhost/api/v1/keys/validate', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${rawKey}`, 'x-app-id': appId },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true); // flags ON only in this test context
+  prisma.devApiKey.findUnique.mockResolvedValue({
+    id: 'key-1', userId: 'user-1', keyHash, status: 'ACTIVE', seatId: 'seat-1', teamId: 'team-1',
+  });
+  prisma.devApiKey.update.mockResolvedValue({});
+});
+
+describe('INT-G — naap_ key resolves across 2 providers × 2 apps', () => {
+  const providers = ['stub', 'pymthouse'] as const;
+  const appIds = ['storyboard', 'naap-sample-cli'] as const;
+  const matrix: Array<{ provider: string; app: string; pass: boolean; detail: string }> = [];
+
+  for (const provider of providers) {
+    for (const appId of appIds) {
+      it(`resolves provider=${provider} app=${appId} with correct caps + attribution + schema`, async () => {
+        prisma.team.findUnique.mockResolvedValue({
+          id: 'team-1', billingAccountProviderSlug: provider, billingAccountId: ACCOUNT_ID[provider],
+        });
+        prisma.application.findFirst.mockResolvedValue(APPS[appId]);
+
+        const { POST } = await import('@/app/api/v1/keys/validate/route');
+        const res = await POST(frontDoorReq(appId));
+
+        let pass = false;
+        let detail = '';
+        try {
+          expect(res.status).toBe(200);
+          const body = await res.json();
+          const d = body.data;
+
+          // E8 — provider-agnostic resolution.
+          expect(d.billingAccount.providerSlug).toBe(provider);
+          expect(d.billingAccount.id).toBe(ACCOUNT_ID[provider]);
+          // E9 — per-app attribution + capability gating.
+          expect(d.app.id).toBe(appId);
+          expect([...d.capabilities].sort()).toEqual([...EXPECTED[provider][appId]].sort());
+          // signer session present + opaque.
+          expect(d.signerSession).toBeTruthy();
+          // Seam isolation end-to-end: no provider-internal field leaks.
+          expect(findLeakedInternalFields(d, getForbiddenInternalFieldNames())).toEqual([]);
+          // Adapter validate() payload conforms to C0 validate.schema.json.
+          const v = await adapters[provider].validate(ACCOUNT_ID[provider]);
+          expect(validateAgainstBppSchema('validate', v).valid).toBe(true);
+
+          pass = true;
+          detail = `caps=[${d.capabilities.join(',')}]`;
+        } catch (e) {
+          detail = e instanceof Error ? e.message.split('\n')[0] : String(e);
+          throw e;
+        } finally {
+          matrix.push({ provider, app: appId, pass, detail });
+        }
+      });
+    }
+  }
+
+  it('captures the full pass/fail matrix (all 4 cells pass)', () => {
+    // Printed for the INT-G report.
+    // eslint-disable-next-line no-console
+    console.log('INT-G matrix:\n' + matrix.map((m) => `  ${m.provider} × ${m.app}: ${m.pass ? 'PASS' : 'FAIL'} ${m.detail}`).join('\n'));
+    expect(matrix).toHaveLength(4);
+    expect(matrix.every((m) => m.pass)).toBe(true);
+  });
+});

--- a/apps/web-next/src/lib/apps/registry.test.ts
+++ b/apps/web-next/src/lib/apps/registry.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Guardrail tests for the application registry logic (NAAP-D).
+ *
+ * Proves the catalog DoD: "two registered apps get distinct attribution + scope
+ * enforcement" — provider/app-agnostic, no app hardcoded.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  appAllowsCapability,
+  appAllowsScope,
+  invalidScopes,
+  resolveAppAttribution,
+  type RegisteredApp,
+} from './registry';
+
+function app(overrides: Partial<RegisteredApp> = {}): RegisteredApp {
+  return {
+    id: 'app-1',
+    slug: 'app-one',
+    type: 'app',
+    teamId: 'team-1',
+    ownerUserId: null,
+    allowedScopes: [],
+    allowedCapabilities: [],
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('resolveAppAttribution', () => {
+  it('attributes two apps distinctly even within the same team', () => {
+    const storyboard = app({ id: 'app-sb', slug: 'storyboard', teamId: 'team-1' });
+    const cli = app({ id: 'app-cli', slug: 'naap-cli', teamId: 'team-1' });
+
+    const a = resolveAppAttribution(storyboard);
+    const b = resolveAppAttribution(cli);
+
+    expect(a).toEqual({ appId: 'app-sb', slug: 'storyboard', ownerScope: 'team-1' });
+    expect(b).toEqual({ appId: 'app-cli', slug: 'naap-cli', ownerScope: 'team-1' });
+    expect(a.appId).not.toBe(b.appId);
+  });
+
+  it('uses personal:{userId} as the owner scope for personal apps', () => {
+    const personal = app({ teamId: null, ownerUserId: 'user-9' });
+    expect(resolveAppAttribution(personal).ownerScope).toBe('personal:user-9');
+  });
+});
+
+describe('appAllowsScope', () => {
+  it('enforces distinct coarse scopes per app', () => {
+    const discoveryApp = app({ id: 'a', allowedScopes: ['discovery'] });
+    const gatewayApp = app({ id: 'b', allowedScopes: ['gateway'] });
+
+    expect(appAllowsScope(discoveryApp, 'discovery')).toBe(true);
+    expect(appAllowsScope(discoveryApp, 'gateway')).toBe(false);
+
+    expect(appAllowsScope(gatewayApp, 'gateway')).toBe(true);
+    expect(appAllowsScope(gatewayApp, 'discovery')).toBe(false);
+  });
+
+  it('denies all scopes for a disabled app', () => {
+    const disabled = app({ allowedScopes: ['discovery'], status: 'disabled' });
+    expect(appAllowsScope(disabled, 'discovery')).toBe(false);
+  });
+});
+
+describe('appAllowsCapability', () => {
+  it('enforces capability grants and supports the wildcard', () => {
+    const limited = app({ allowedCapabilities: ['text-to-image:sdxl'] });
+    expect(appAllowsCapability(limited, 'text-to-image:sdxl')).toBe(true);
+    expect(appAllowsCapability(limited, 'text-to-video:ltx')).toBe(false);
+
+    const wildcard = app({ allowedCapabilities: ['*'] });
+    expect(appAllowsCapability(wildcard, 'anything:goes')).toBe(true);
+  });
+
+  it('denies capabilities for a disabled app even with wildcard', () => {
+    const disabled = app({ allowedCapabilities: ['*'], status: 'disabled' });
+    expect(appAllowsCapability(disabled, 'x:y')).toBe(false);
+  });
+});
+
+describe('invalidScopes', () => {
+  it('flags unknown scopes and accepts known ones', () => {
+    expect(invalidScopes(['discovery', 'gateway'])).toEqual([]);
+    expect(invalidScopes(['discovery', 'bogus'])).toEqual(['bogus']);
+  });
+});

--- a/apps/web-next/src/lib/apps/registry.test.ts
+++ b/apps/web-next/src/lib/apps/registry.test.ts
@@ -9,10 +9,12 @@ import { describe, it, expect } from 'vitest';
 import {
   appAllowsCapability,
   appAllowsScope,
+  gateCapabilitiesForApp,
   invalidScopes,
   resolveAppAttribution,
   type RegisteredApp,
 } from './registry';
+import { appBelongsToKeyScope } from './resolve';
 
 function app(overrides: Partial<RegisteredApp> = {}): RegisteredApp {
   return {
@@ -85,5 +87,41 @@ describe('invalidScopes', () => {
   it('flags unknown scopes and accepts known ones', () => {
     expect(invalidScopes(['discovery', 'gateway'])).toEqual([]);
     expect(invalidScopes(['discovery', 'bogus'])).toEqual(['bogus']);
+  });
+});
+
+describe('gateCapabilitiesForApp (NAAP-C↔NAAP-D↔NAAP-E integration)', () => {
+  const providerCaps = ['text-to-image:sdxl', 'tool:byoc-demo', 'text-to-video:ltx'];
+
+  it('intersects provider caps with the app grant', () => {
+    const limited = app({ allowedCapabilities: ['tool:byoc-demo', 'text-to-image:sdxl'] });
+    expect(gateCapabilitiesForApp(limited, providerCaps)).toEqual([
+      'text-to-image:sdxl',
+      'tool:byoc-demo',
+    ]);
+  });
+
+  it('passes provider caps through unchanged for a wildcard grant', () => {
+    const wildcard = app({ allowedCapabilities: ['*'] });
+    expect(gateCapabilitiesForApp(wildcard, providerCaps)).toEqual(providerCaps);
+  });
+
+  it('fails CLOSED ([]) for a disabled app', () => {
+    const disabled = app({ allowedCapabilities: ['*'], status: 'disabled' });
+    expect(gateCapabilitiesForApp(disabled, providerCaps)).toEqual([]);
+  });
+});
+
+describe('appBelongsToKeyScope (NAAP-D ownership check)', () => {
+  it('matches a team-scoped app to the key team', () => {
+    const teamApp = app({ teamId: 'team-1', ownerUserId: null });
+    expect(appBelongsToKeyScope(teamApp, { teamId: 'team-1', userId: 'u1' })).toBe(true);
+    expect(appBelongsToKeyScope(teamApp, { teamId: 'team-2', userId: 'u1' })).toBe(false);
+  });
+
+  it('matches a personal app to the key user', () => {
+    const personal = app({ teamId: null, ownerUserId: 'u9' });
+    expect(appBelongsToKeyScope(personal, { teamId: null, userId: 'u9' })).toBe(true);
+    expect(appBelongsToKeyScope(personal, { teamId: null, userId: 'u8' })).toBe(false);
   });
 });

--- a/apps/web-next/src/lib/apps/registry.ts
+++ b/apps/web-next/src/lib/apps/registry.ts
@@ -1,0 +1,90 @@
+/**
+ * Application / service registry (NAAP-D).
+ *
+ * NaaP registers any application or service (the Storyboard app, the SDK
+ * service, a CLI, a 3rd-party integration) as a provider-agnostic `Application`.
+ * Each app presents its `appId` (via the `X-App-Id` header on the validation
+ * front door, BPP ③) so usage and rate limits attribute *per app*. No app is
+ * hardcoded — Storyboard is just one registered app among equals.
+ *
+ * This module holds the provider-neutral, DB-free logic (scope/capability
+ * enforcement + attribution) so it can be unit-tested in isolation; the HTTP
+ * routes under `src/app/api/v1/apps/*` persist `Application` rows.
+ */
+
+/** Feature flag gating the application registry surface (default OFF). */
+export const APP_REGISTRY_FLAG = 'app_registry';
+
+/** App kinds. Generic — not tied to any specific app. */
+export const APP_TYPES = ['app', 'service', 'cli'] as const;
+export type AppType = (typeof APP_TYPES)[number];
+
+/**
+ * Coarse scopes an app may be granted. These gate *which NaaP surfaces* an app
+ * may use; fine-grained capability gating (pipeline × model × tool) is separate
+ * (`allowedCapabilities`, enforced by NAAP-E).
+ */
+export const APP_SCOPES = ['discovery', 'gateway', 'llm', 'billing', 'usage'] as const;
+export type AppScope = (typeof APP_SCOPES)[number];
+
+/** Wildcard capability grant. */
+export const CAPABILITY_WILDCARD = '*';
+
+/** The minimal shape the registry logic needs (subset of the Prisma row). */
+export interface RegisteredApp {
+  id: string;
+  slug: string;
+  type: AppType;
+  /** Exactly one of teamId / ownerUserId identifies the owning scope. */
+  teamId: string | null;
+  ownerUserId: string | null;
+  allowedScopes: string[];
+  allowedCapabilities: string[];
+  status: string;
+}
+
+/** Stable per-app attribution key for usage/rate-limit accounting. */
+export interface AppAttribution {
+  appId: string;
+  slug: string;
+  /** Owning scope: a real `teamId` or `personal:{userId}`. */
+  ownerScope: string;
+}
+
+export function isAppType(value: unknown): value is AppType {
+  return typeof value === 'string' && (APP_TYPES as readonly string[]).includes(value);
+}
+
+export function isAppScope(value: unknown): value is AppScope {
+  return typeof value === 'string' && (APP_SCOPES as readonly string[]).includes(value);
+}
+
+/** Validate a list of requested scopes; returns the unknown ones (empty = all valid). */
+export function invalidScopes(scopes: string[]): string[] {
+  return scopes.filter((s) => !isAppScope(s));
+}
+
+/**
+ * Resolve an app's attribution key. Distinct apps always produce distinct
+ * `appId`s, so usage attributes separately even within one owning team.
+ */
+export function resolveAppAttribution(app: RegisteredApp): AppAttribution {
+  const ownerScope = app.teamId ?? (app.ownerUserId ? `personal:${app.ownerUserId}` : 'unknown');
+  return { appId: app.id, slug: app.slug, ownerScope };
+}
+
+/** True when the app is active and has been granted the given coarse scope. */
+export function appAllowsScope(app: RegisteredApp, scope: AppScope): boolean {
+  if (app.status !== 'active') return false;
+  return app.allowedScopes.includes(scope);
+}
+
+/**
+ * True when the app may use a generic capability id (`<pipeline>:<model>` or
+ * `tool:<name>`). A `*` grant allows any capability.
+ */
+export function appAllowsCapability(app: RegisteredApp, capability: string): boolean {
+  if (app.status !== 'active') return false;
+  if (app.allowedCapabilities.includes(CAPABILITY_WILDCARD)) return true;
+  return app.allowedCapabilities.includes(capability);
+}

--- a/apps/web-next/src/lib/apps/registry.ts
+++ b/apps/web-next/src/lib/apps/registry.ts
@@ -88,3 +88,25 @@ export function appAllowsCapability(app: RegisteredApp, capability: string): boo
   if (app.allowedCapabilities.includes(CAPABILITY_WILDCARD)) return true;
   return app.allowedCapabilities.includes(capability);
 }
+
+/**
+ * Gate a provider's capability set down to what the registered app is allowed to
+ * use (NAAP-C ↔ NAAP-D ↔ NAAP-E). The effective capabilities a key exposes
+ * through an app are the intersection of:
+ *   - what the billing provider's plan enables (`providerCapabilities`), and
+ *   - what the app is granted (`app.allowedCapabilities`).
+ *
+ * A `*` app grant passes the provider set through unchanged. A non-active app
+ * yields `[]` (fail CLOSED). This is provider- and app-agnostic: it works
+ * identically whether the provider is pymthouse or the stub, and whether the app
+ * is Storyboard or APP-2.
+ */
+export function gateCapabilitiesForApp(
+  app: RegisteredApp,
+  providerCapabilities: string[],
+): string[] {
+  if (app.status !== 'active') return [];
+  if (app.allowedCapabilities.includes(CAPABILITY_WILDCARD)) return [...providerCapabilities];
+  const allowed = new Set(app.allowedCapabilities);
+  return providerCapabilities.filter((cap) => allowed.has(cap));
+}

--- a/apps/web-next/src/lib/apps/resolve.ts
+++ b/apps/web-next/src/lib/apps/resolve.ts
@@ -1,0 +1,56 @@
+/**
+ * DB-backed Application resolution (NAAP-D) for the validation front door.
+ *
+ * Kept separate from `registry.ts` (which is intentionally DB-free) so the
+ * scope/capability logic stays unit-testable in isolation. The front door
+ * (NAAP-C) calls this to registry-check the `X-App-Id` it was presented.
+ */
+
+import { prisma } from '@/lib/db';
+import type { RegisteredApp } from './registry';
+
+/**
+ * Resolve a presented `X-App-Id` to a registered `Application`. The header may
+ * carry either the app's `id` (uuid) or its `slug`; both are accepted so apps
+ * can present a human-friendly slug. Returns `null` when nothing matches.
+ */
+export async function resolveRegisteredApp(appId: string): Promise<RegisteredApp | null> {
+  const row = await prisma.application.findFirst({
+    where: { OR: [{ id: appId }, { slug: appId }] },
+    select: {
+      id: true,
+      slug: true,
+      type: true,
+      teamId: true,
+      ownerUserId: true,
+      allowedScopes: true,
+      allowedCapabilities: true,
+      status: true,
+    },
+  });
+  if (!row) return null;
+  return {
+    id: row.id,
+    slug: row.slug,
+    type: row.type as RegisteredApp['type'],
+    teamId: row.teamId,
+    ownerUserId: row.ownerUserId,
+    allowedScopes: row.allowedScopes,
+    allowedCapabilities: row.allowedCapabilities,
+    status: row.status,
+  };
+}
+
+/**
+ * Decide whether a resolved key (its team + user) is permitted to act as the
+ * given registered app. Team-scoped apps must match the key's team; personal
+ * apps must be owned by the key's user. Provider-agnostic.
+ */
+export function appBelongsToKeyScope(
+  app: Pick<RegisteredApp, 'teamId' | 'ownerUserId'>,
+  keyScope: { teamId: string | null; userId: string },
+): boolean {
+  if (app.teamId) return app.teamId === keyScope.teamId;
+  if (app.ownerUserId) return app.ownerUserId === keyScope.userId;
+  return false;
+}

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -1,0 +1,125 @@
+/**
+ * Billing Provider Adapter SPI (NAAP-A).
+ *
+ * NaaP reaches every billing provider ONLY through this interface + the registry
+ * (`registry.ts`). NaaP code must never import a provider client directly — the
+ * reference provider (pymthouse) is wrapped by `PymthouseAdapter` behind this
+ * SPI. This is the NaaP-side surface of the Billing Provider Protocol (BPP, C0).
+ *
+ * Methods that a given provider has not implemented yet throw
+ * `AdapterNotImplementedError` (HTTP 501-equivalent) rather than guessing.
+ */
+
+/** BPP ② validate result (provider-neutral; mirrors validate.schema.json). */
+export interface ValidateResult {
+  valid: boolean;
+  user?: { sub: string };
+  billing_account?: {
+    id: string;
+    providerSlug: string;
+    billingMode: 'delegated' | 'prepay';
+  };
+  capabilities?: string[];
+  quota?: { remaining: number; resetAt?: string } | null;
+  /** Neutral opaque subscription pointer — never a provider-internal id name. */
+  subscriptionRef?: string;
+  signerSession?: SignerSession;
+}
+
+/** Provider-issued signer session, opaque to applications. */
+export interface SignerSession {
+  url?: string;
+  headers?: Record<string, string>;
+  accessToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  scope?: string;
+}
+
+/** BPP ④ plan. */
+export interface Plan {
+  id: string;
+  name?: string;
+  price?: { amount: number; interval: string; currency?: string };
+  bundles: Array<{
+    capability: string;
+    sla?: { uptime?: number; p95Ms?: number };
+    maxPriceWeiPerUnit?: string;
+  }>;
+}
+
+/** BPP capability manifest entry. */
+export interface Capability {
+  id: string;
+  description?: string;
+}
+
+/** Curated orchestrator (BPP ⑧). */
+export interface CuratedOrchestrator {
+  address: string;
+  capabilities: string[];
+  score?: number;
+}
+
+export interface UsageForExternalUserInput {
+  externalUserId: string;
+  startDate: string;
+  endDate: string;
+  maxEndUserIds?: number;
+}
+
+export interface AppUsageInput {
+  startDate: string;
+  endDate: string;
+  groupBy?: 'none' | 'user';
+  userId?: string;
+}
+
+export interface MintSignerSessionInput {
+  externalUserId: string;
+  email?: string;
+}
+
+/**
+ * The provider-neutral adapter SPI. Every method maps to a BPP seam.
+ */
+export interface BillingProviderAdapter {
+  /** Provider slug, e.g. "pymthouse" | "stub". */
+  readonly slug: string;
+
+  /** Whether this provider has the configuration it needs to serve requests. */
+  isConfigured(): boolean;
+
+  /** BPP ② — resolve an opaque key into identity + capabilities + signer session. */
+  validate(key: string): Promise<ValidateResult>;
+
+  /** BPP ④ — plan catalogue. */
+  getPlans(): Promise<Plan[]>;
+
+  /** BPP usage/telemetry — per-user usage rollup for one external user. */
+  getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown>;
+
+  /** BPP usage/telemetry — app-wide usage (admin scope). */
+  getAppUsage(input: AppUsageInput): Promise<unknown>;
+
+  /** BPP mintSignerSession — provider-issued, opaque to apps. */
+  mintSignerSession(input: MintSignerSessionInput): Promise<SignerSession>;
+
+  /** BPP ⑧ — receive a curated orchestrator list for a plan. */
+  receiveCuratedOrchestrators(plan: string, list: CuratedOrchestrator[]): Promise<void>;
+
+  /** BPP capability manifest — what this provider can enable. */
+  getCapabilityManifest(): Promise<Capability[]>;
+}
+
+/** Thrown when a provider has not implemented a BPP method yet. */
+export class AdapterNotImplementedError extends Error {
+  readonly providerSlug: string;
+  readonly method: string;
+  constructor(providerSlug: string, method: string) {
+    super(`Adapter "${providerSlug}" does not implement "${method}"`);
+    this.name = 'AdapterNotImplementedError';
+    this.providerSlug = providerSlug;
+    this.method = method;
+  }
+}

--- a/apps/web-next/src/lib/billing/bpp/conformance.test.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.test.ts
@@ -33,6 +33,7 @@ describe('BPP conformance — stub provider', () => {
     const failing = report.seams.filter((s) => !s.valid);
     expect(failing, JSON.stringify(failing, null, 2)).toHaveLength(0);
     expect(report.leakedFields).toEqual([]);
+    expect(report.accountRefMismatches).toEqual([]);
     expect(report.passed).toBe(true);
   });
 });
@@ -61,6 +62,38 @@ describe('BPP conformance — negative cases (the suite catches drift)', () => {
     };
     const report = await runConformance(leaky);
     expect(report.leakedFields).toContain('openmeter_subscription_id');
+    expect(report.passed).toBe(false);
+  });
+
+  it('fails seam isolation when a provider-internal id leaks through usage ingest (⑥)', async () => {
+    const leaky: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async getUsageIngest() {
+        const base = (await createStubBillingProvider().getUsageIngest()) as Record<
+          string,
+          unknown
+        >;
+        return { ...base, openmeter_subscription_id: '01J-usage-leak' };
+      },
+    };
+    const report = await runConformance(leaky);
+    expect(report.leakedFields).toContain('openmeter_subscription_id');
+    expect(report.passed).toBe(false);
+  });
+
+  it('fails when account.id diverges from billingAccountRef.accountId (⑤ identity)', async () => {
+    const mismatched: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async getAccount() {
+        const base = (await createStubBillingProvider().getAccount()) as Record<string, unknown>;
+        return {
+          ...base,
+          billingAccountRef: { providerSlug: 'stub', accountId: 'acct_DIFFERENT' },
+        };
+      },
+    };
+    const report = await runConformance(mismatched);
+    expect(report.accountRefMismatches.length).toBeGreaterThan(0);
     expect(report.passed).toBe(false);
   });
 

--- a/apps/web-next/src/lib/billing/bpp/conformance.test.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.test.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+
+import { createStubBillingProvider, type BppConformanceProvider } from './stub-provider';
+import {
+  ALL_SCHEMA_FILES,
+  compileAllSchemas,
+  getForbiddenInternalFieldNames,
+  findLeakedInternalFields,
+  runConformance,
+} from './conformance';
+
+describe('BPP contracts', () => {
+  it('every schema file compiles (schema lint)', () => {
+    const compiled = compileAllSchemas();
+    expect(Object.keys(compiled)).toEqual([...ALL_SCHEMA_FILES]);
+    for (const file of ALL_SCHEMA_FILES) {
+      expect(typeof compiled[file]).toBe('function');
+    }
+  });
+
+  it('declares forbidden provider-internal field names (⑨ seam isolation)', () => {
+    const forbidden = getForbiddenInternalFieldNames();
+    expect(forbidden).toContain('openmeter_subscription_id');
+    expect(forbidden).toContain('network_fee_usd_micros');
+  });
+});
+
+describe('BPP conformance — stub provider', () => {
+  it('passes every BPP seam and the seam-isolation assertion', async () => {
+    const report = await runConformance(createStubBillingProvider());
+    const failing = report.seams.filter((s) => !s.valid);
+    expect(failing, JSON.stringify(failing, null, 2)).toHaveLength(0);
+    expect(report.leakedFields).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+});
+
+describe('BPP conformance — negative cases (the suite catches drift)', () => {
+  it('fails schema validation when validate returns the wrong shape', async () => {
+    const broken: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      // `valid` must be a boolean; a string violates the schema.
+      async validate() {
+        return { valid: 'yes' };
+      },
+    };
+    const report = await runConformance(broken);
+    expect(report.passed).toBe(false);
+    expect(report.seams.find((s) => s.seam === 'validate')?.valid).toBe(false);
+  });
+
+  it('fails seam isolation when a provider-internal id leaks through validate', async () => {
+    const leaky: BppConformanceProvider = {
+      ...createStubBillingProvider(),
+      async validate(key: string) {
+        const base = (await createStubBillingProvider().validate(key)) as Record<string, unknown>;
+        return { ...base, openmeter_subscription_id: '01J-leaky' };
+      },
+    };
+    const report = await runConformance(leaky);
+    expect(report.leakedFields).toContain('openmeter_subscription_id');
+    expect(report.passed).toBe(false);
+  });
+
+  it('findLeakedInternalFields detects nested leaks', () => {
+    const forbidden = getForbiddenInternalFieldNames();
+    const leaked = findLeakedInternalFields(
+      { window: { from: 'x' }, meta: { source: 'openmeter', model_id: 'm' } },
+      forbidden,
+    );
+    expect(leaked).toContain('model_id');
+  });
+});

--- a/apps/web-next/src/lib/billing/bpp/conformance.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.ts
@@ -64,7 +64,16 @@ export function getForbiddenInternalFieldNames(): string[] {
   if (!Array.isArray(names)) {
     throw new Error('provider-internal-openmeter.schema.json missing x-bpp-forbidden-field-names');
   }
-  return names.map((n) => String(n));
+  // Fail fast on malformed schema values rather than silently coercing with
+  // String(): a non-string entry means the contract itself is wrong.
+  return names.map((n) => {
+    if (typeof n !== 'string') {
+      throw new Error(
+        'provider-internal-openmeter.schema.json x-bpp-forbidden-field-names entries must be strings',
+      );
+    }
+    return n;
+  });
 }
 
 /** Recursively collect every object key present in a payload. */
@@ -88,6 +97,35 @@ export function findLeakedInternalFields(payload: unknown, forbidden: string[]):
   return forbidden.filter((name) => keys.has(name));
 }
 
+/**
+ * Enforce the ⑤ account identity invariant that plain JSON Schema (2020-12)
+ * cannot express: `account.id` / `account.providerSlug` MUST equal the neutral
+ * `billingAccountRef.accountId` / `billingAccountRef.providerSlug` pointer. NaaP
+ * only ever persists `billingAccountRef`, so a divergence would leave the stored
+ * pointer aimed at a different account than the one the provider described.
+ * Returns a list of human-readable mismatches (empty when consistent).
+ */
+export function checkAccountRefIdentity(accountPayload: unknown): string[] {
+  if (!accountPayload || typeof accountPayload !== 'object') return [];
+  const root = accountPayload as Record<string, unknown>;
+  const account = root.account as Record<string, unknown> | undefined;
+  const ref = root.billingAccountRef as Record<string, unknown> | undefined;
+  if (!account || !ref) return [];
+
+  const mismatches: string[] = [];
+  if (account.id !== ref.accountId) {
+    mismatches.push(
+      `account.id (${String(account.id)}) !== billingAccountRef.accountId (${String(ref.accountId)})`,
+    );
+  }
+  if (account.providerSlug !== ref.providerSlug) {
+    mismatches.push(
+      `account.providerSlug (${String(account.providerSlug)}) !== billingAccountRef.providerSlug (${String(ref.providerSlug)})`,
+    );
+  }
+  return mismatches;
+}
+
 export interface SeamResult {
   seam: BppSeam;
   valid: boolean;
@@ -99,6 +137,8 @@ export interface ConformanceReport {
   seams: SeamResult[];
   /** Seam-isolation: provider-internal (⑨) names found in ② and ⑥ payloads. */
   leakedFields: string[];
+  /** ⑤ account ↔ billingAccountRef identity-invariant violations. */
+  accountRefMismatches: string[];
   passed: boolean;
 }
 
@@ -126,31 +166,39 @@ async function payloadForSeam(
 
 /**
  * Run the BPP conformance suite (② ④ ⑤ ⑥ ⑧) against a provider plus the
- * seam-isolation assertion on the ② validate and ⑥ usage payloads.
+ * seam-isolation assertion on the ② validate and ⑥ usage payloads and the ⑤
+ * account-ref identity invariant. Each seam is fetched from the provider exactly
+ * once and the captured payloads are reused for the cross-cutting checks, so a
+ * provider with time-varying/stateful responses cannot make the suite flaky.
  */
 export async function runConformance(
   provider: BppConformanceProvider,
 ): Promise<ConformanceReport> {
   const ajv = newAjv();
   const seams: SeamResult[] = [];
+  const payloads = new Map<BppSeam, unknown>();
 
   for (const seam of BPP_SEAMS) {
     const validate = ajv.compile(readSchema(schemaFileForSeam(seam)));
     const payload = await payloadForSeam(provider, seam);
+    payloads.set(seam, payload);
     const valid = validate(payload) as boolean;
     seams.push({ seam, valid, errors: valid ? [] : (validate.errors ?? []) });
   }
 
   const forbidden = getForbiddenInternalFieldNames();
-  const validatePayload = await provider.validate('opaque-test-key');
-  const usagePayload = await provider.getUsageIngest();
   const leakedFields = Array.from(
     new Set([
-      ...findLeakedInternalFields(validatePayload, forbidden),
-      ...findLeakedInternalFields(usagePayload, forbidden),
+      ...findLeakedInternalFields(payloads.get('validate'), forbidden),
+      ...findLeakedInternalFields(payloads.get('usage-ingest'), forbidden),
     ]),
   );
 
-  const passed = seams.every((s) => s.valid) && leakedFields.length === 0;
-  return { provider: provider.slug, seams, leakedFields, passed };
+  const accountRefMismatches = checkAccountRefIdentity(payloads.get('account'));
+
+  const passed =
+    seams.every((s) => s.valid) &&
+    leakedFields.length === 0 &&
+    accountRefMismatches.length === 0;
+  return { provider: provider.slug, seams, leakedFields, accountRefMismatches, passed };
 }

--- a/apps/web-next/src/lib/billing/bpp/conformance.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.ts
@@ -47,6 +47,24 @@ function newAjv(): Ajv2020 {
   return ajv;
 }
 
+export interface SchemaCheck {
+  valid: boolean;
+  errors: ErrorObject[];
+}
+
+/**
+ * Validate an arbitrary payload against one of the BPP schema files (by base
+ * name, e.g. `validate`, `usage-ingest`). Reusable across INT-0 / INT-G so a
+ * producer (a real adapter, the stub, or a pymthouse mock) is checked against
+ * the SAME canonical C0 schema the conformance suite uses — no drift.
+ */
+export function validateAgainstBppSchema(seam: string, payload: unknown): SchemaCheck {
+  const ajv = newAjv();
+  const validate = ajv.compile(readSchema(`${seam}.schema.json`));
+  const valid = validate(payload) as boolean;
+  return { valid, errors: valid ? [] : (validate.errors ?? []) };
+}
+
 /** Compile every schema file (schema-lint guardrail). Throws on an invalid schema. */
 export function compileAllSchemas(): Record<string, ValidateFunction> {
   const ajv = newAjv();

--- a/apps/web-next/src/lib/billing/bpp/conformance.ts
+++ b/apps/web-next/src/lib/billing/bpp/conformance.ts
@@ -1,0 +1,156 @@
+/**
+ * BPP conformance suite (C0).
+ *
+ * Validates a provider's payloads against the JSON Schemas in
+ * `contracts/billing-provider-protocol/`. Any provider (pymthouse, the stub, or
+ * a third party) must pass this. CI runs it so a producer that drifts from the
+ * protocol fails before integration.
+ *
+ * This is test-support code: it reads schema files from disk with ajv and is
+ * imported only by `conformance.test.ts` (never by the app runtime).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020, { type ValidateFunction, type ErrorObject } from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+
+import type { BppConformanceProvider } from './stub-provider';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+/** Repo root is six levels up from src/lib/billing/bpp/. */
+export const CONTRACTS_DIR = path.resolve(
+  HERE,
+  '../../../../../../contracts/billing-provider-protocol',
+);
+
+/** BPP seams the conformance suite exercises against a provider. */
+export const BPP_SEAMS = ['validate', 'plans', 'account', 'usage-ingest', 'curated-list'] as const;
+export type BppSeam = (typeof BPP_SEAMS)[number];
+
+/** All schema files in the contracts dir (includes the non-BPP ⑨ doc). */
+export const ALL_SCHEMA_FILES = [
+  ...BPP_SEAMS.map((s) => `${s}.schema.json`),
+  'discovery.schema.json',
+  'provider-internal-openmeter.schema.json',
+] as const;
+
+function readSchema(fileName: string): Record<string, unknown> {
+  const full = path.join(CONTRACTS_DIR, fileName);
+  return JSON.parse(fs.readFileSync(full, 'utf8')) as Record<string, unknown>;
+}
+
+function newAjv(): Ajv2020 {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+/** Compile every schema file (schema-lint guardrail). Throws on an invalid schema. */
+export function compileAllSchemas(): Record<string, ValidateFunction> {
+  const ajv = newAjv();
+  const out: Record<string, ValidateFunction> = {};
+  for (const file of ALL_SCHEMA_FILES) {
+    out[file] = ajv.compile(readSchema(file));
+  }
+  return out;
+}
+
+/** Provider-internal field names that MUST NOT leak through the BPP seams (⑨). */
+export function getForbiddenInternalFieldNames(): string[] {
+  const schema = readSchema('provider-internal-openmeter.schema.json');
+  const names = schema['x-bpp-forbidden-field-names'];
+  if (!Array.isArray(names)) {
+    throw new Error('provider-internal-openmeter.schema.json missing x-bpp-forbidden-field-names');
+  }
+  return names.map((n) => String(n));
+}
+
+/** Recursively collect every object key present in a payload. */
+function collectKeys(value: unknown, acc: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, acc);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      acc.add(key);
+      collectKeys(child, acc);
+    }
+  }
+}
+
+/** Find any forbidden provider-internal field names present in a payload. */
+export function findLeakedInternalFields(payload: unknown, forbidden: string[]): string[] {
+  const keys = new Set<string>();
+  collectKeys(payload, keys);
+  return forbidden.filter((name) => keys.has(name));
+}
+
+export interface SeamResult {
+  seam: BppSeam;
+  valid: boolean;
+  errors: ErrorObject[];
+}
+
+export interface ConformanceReport {
+  provider: string;
+  seams: SeamResult[];
+  /** Seam-isolation: provider-internal (⑨) names found in ② and ⑥ payloads. */
+  leakedFields: string[];
+  passed: boolean;
+}
+
+function schemaFileForSeam(seam: BppSeam): string {
+  return `${seam}.schema.json`;
+}
+
+async function payloadForSeam(
+  provider: BppConformanceProvider,
+  seam: BppSeam,
+): Promise<unknown> {
+  switch (seam) {
+    case 'validate':
+      return provider.validate('opaque-test-key');
+    case 'plans':
+      return provider.getPlans();
+    case 'account':
+      return provider.getAccount();
+    case 'usage-ingest':
+      return provider.getUsageIngest();
+    case 'curated-list':
+      return provider.getCuratedList();
+  }
+}
+
+/**
+ * Run the BPP conformance suite (② ④ ⑤ ⑥ ⑧) against a provider plus the
+ * seam-isolation assertion on the ② validate and ⑥ usage payloads.
+ */
+export async function runConformance(
+  provider: BppConformanceProvider,
+): Promise<ConformanceReport> {
+  const ajv = newAjv();
+  const seams: SeamResult[] = [];
+
+  for (const seam of BPP_SEAMS) {
+    const validate = ajv.compile(readSchema(schemaFileForSeam(seam)));
+    const payload = await payloadForSeam(provider, seam);
+    const valid = validate(payload) as boolean;
+    seams.push({ seam, valid, errors: valid ? [] : (validate.errors ?? []) });
+  }
+
+  const forbidden = getForbiddenInternalFieldNames();
+  const validatePayload = await provider.validate('opaque-test-key');
+  const usagePayload = await provider.getUsageIngest();
+  const leakedFields = Array.from(
+    new Set([
+      ...findLeakedInternalFields(validatePayload, forbidden),
+      ...findLeakedInternalFields(usagePayload, forbidden),
+    ]),
+  );
+
+  const passed = seams.every((s) => s.valid) && leakedFields.length === 0;
+  return { provider: provider.slug, seams, leakedFields, passed };
+}

--- a/apps/web-next/src/lib/billing/bpp/stub-provider.ts
+++ b/apps/web-next/src/lib/billing/bpp/stub-provider.ts
@@ -1,0 +1,118 @@
+/**
+ * Tiny in-memory **stub billing provider** (C0).
+ *
+ * It is the *second* implementation of the Billing Provider Protocol (after the
+ * reference provider, pymthouse). It exists only to prove the seam is
+ * provider-neutral — it is NOT a real provider. Keep it minimal.
+ *
+ * Every method returns a payload that conforms to the matching BPP schema in
+ * `contracts/billing-provider-protocol/`. The conformance suite validates it.
+ */
+
+export const STUB_PROVIDER_SLUG = 'stub';
+
+/** The provider surface the BPP conformance suite exercises (② ④ ⑤ ⑥ ⑧). */
+export interface BppConformanceProvider {
+  readonly slug: string;
+  /** ② validate */
+  validate(key: string): Promise<unknown>;
+  /** ④ plans */
+  getPlans(): Promise<unknown>;
+  /** ⑤ account + member + billingAccountRef */
+  getAccount(): Promise<unknown>;
+  /** ⑥ usage ingest payload */
+  getUsageIngest(): Promise<unknown>;
+  /** ⑧ curated list (+ optional token bundle) */
+  getCuratedList(): Promise<unknown>;
+}
+
+export function createStubBillingProvider(): BppConformanceProvider {
+  return {
+    slug: STUB_PROVIDER_SLUG,
+
+    async validate(key: string): Promise<unknown> {
+      if (!key || key.length < 1) {
+        return { valid: false };
+      }
+      return {
+        valid: true,
+        user: { sub: 'stub-user-1' },
+        billing_account: {
+          id: 'acct_stub_1',
+          providerSlug: STUB_PROVIDER_SLUG,
+          billingMode: 'delegated',
+        },
+        capabilities: ['text-to-image:sdxl', 'tool:byoc-demo'],
+        quota: { remaining: 1000, resetAt: '2026-12-31T23:59:59.999Z' },
+        // Neutral opaque pointer — never a provider-internal id name.
+        subscriptionRef: 'sub_stub_opaque_1',
+        signerSession: {
+          url: 'https://signer.stub.example/session',
+          headers: { Authorization: 'Bearer stub-signer-token' },
+        },
+      };
+    },
+
+    async getPlans(): Promise<unknown> {
+      return [
+        {
+          id: 'free',
+          name: 'Free',
+          price: { amount: 0, interval: 'month', currency: 'USD' },
+          bundles: [
+            {
+              capability: 'text-to-image:sdxl',
+              sla: { uptime: 0.99, p95Ms: 3000 },
+              maxPriceWeiPerUnit: '500',
+            },
+          ],
+        },
+      ];
+    },
+
+    async getAccount(): Promise<unknown> {
+      return {
+        account: {
+          id: 'acct_stub_1',
+          ownerSub: 'stub-user-1',
+          providerSlug: STUB_PROVIDER_SLUG,
+          planId: 'free',
+          creditBalanceWei: '0',
+          billingMode: 'delegated',
+        },
+        members: [{ accountId: 'acct_stub_1', sub: 'stub-user-1', role: 'admin' }],
+        billingAccountRef: { providerSlug: STUB_PROVIDER_SLUG, accountId: 'acct_stub_1' },
+      };
+    },
+
+    async getUsageIngest(): Promise<unknown> {
+      return {
+        providerSlug: STUB_PROVIDER_SLUG,
+        accountId: 'acct_stub_1',
+        appId: 'app_demo',
+        window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+        sessions: 3,
+        tickets: 12,
+        feeWei: '1000',
+        networkFeeUsdMicros: '5000',
+        byCapability: {
+          'text-to-image:sdxl': { tickets: 12, networkFeeUsdMicros: '5000' },
+        },
+      };
+    },
+
+    async getCuratedList(): Promise<unknown> {
+      return {
+        plan: 'free',
+        version: '2026-06-17T00:00:00.000Z',
+        orchestrators: [
+          {
+            address: 'https://orch.stub.example:8935',
+            capabilities: ['text-to-image:sdxl'],
+            score: 0.9,
+          },
+        ],
+      };
+    },
+  };
+}

--- a/apps/web-next/src/lib/billing/provider-config.test.ts
+++ b/apps/web-next/src/lib/billing/provider-config.test.ts
@@ -1,0 +1,92 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { BILLING_PROVIDERS } from '../../../../../packages/database/src/billing-providers';
+import {
+  PYMTHOUSE_PROVIDER_SLUG,
+  PYMTHOUSE_STAGING_ISSUER_ORIGIN,
+  PYMTHOUSE_STAGING_CLIENT_ID,
+  PYMTHOUSE_ENV_VARS,
+  verifyPymthouseEnv,
+  logPymthouseEnvStatus,
+  findPymthouseSeed,
+  isPymthouseSeedEnabled,
+} from './provider-config';
+
+describe('NAAP-0 — BillingProvider seed verify', () => {
+  it('seeds BillingProvider{slug:pymthouse, enabled:true}', () => {
+    const seed = findPymthouseSeed(BILLING_PROVIDERS);
+    expect(seed).toBeDefined();
+    expect(seed?.slug).toBe(PYMTHOUSE_PROVIDER_SLUG);
+    expect(seed?.enabled).toBe(true);
+    expect(isPymthouseSeedEnabled(BILLING_PROVIDERS)).toBe(true);
+  });
+});
+
+describe('NAAP-0 — PYMTHOUSE_* env wiring', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const name of PYMTHOUSE_ENV_VARS) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of PYMTHOUSE_ENV_VARS) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  });
+
+  it('reports all vars missing and not configured when env is empty', () => {
+    const status = verifyPymthouseEnv();
+    expect(status.configured).toBe(false);
+    expect(status.missing).toEqual([...PYMTHOUSE_ENV_VARS]);
+    expect(Object.values(status.present).every((v) => v === false)).toBe(true);
+  });
+
+  it('reports configured + staging match for valid staging wiring', () => {
+    process.env.PYMTHOUSE_ISSUER_URL = `${PYMTHOUSE_STAGING_ISSUER_ORIGIN}/api/v1/oidc`;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_SECRET = 'test-only-secret-not-real';
+
+    const status = verifyPymthouseEnv();
+    expect(status.configured).toBe(true);
+    expect(status.missing).toEqual([]);
+    expect(status.issuerMatchesStaging).toBe(true);
+    expect(status.clientIdMatchesStaging).toBe(true);
+  });
+
+  it('flags only the missing secret when the rest is present', () => {
+    process.env.PYMTHOUSE_ISSUER_URL = `${PYMTHOUSE_STAGING_ISSUER_ORIGIN}/api/v1/oidc`;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+
+    const status = verifyPymthouseEnv();
+    expect(status.configured).toBe(false);
+    expect(status.missing).toEqual(['PYMTHOUSE_M2M_CLIENT_SECRET']);
+    expect(status.present.PYMTHOUSE_M2M_CLIENT_SECRET).toBe(false);
+  });
+
+  it('NEVER leaks the secret value via the structured log line', () => {
+    const secret = 'super-secret-value-should-never-appear';
+    process.env.PYMTHOUSE_ISSUER_URL = `${PYMTHOUSE_STAGING_ISSUER_ORIGIN}/api/v1/oidc`;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_ID = PYMTHOUSE_STAGING_CLIENT_ID;
+    process.env.PYMTHOUSE_M2M_CLIENT_SECRET = secret;
+
+    const lines: string[] = [];
+    const status = logPymthouseEnvStatus({ info: (m) => lines.push(m) }, 'test-correlation-id');
+
+    expect(status.configured).toBe(true);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('test-correlation-id');
+    expect(lines[0]).toContain('"present"');
+    // The secret value must NOT appear anywhere in the emitted log line.
+    expect(lines[0]).not.toContain(secret);
+  });
+});

--- a/apps/web-next/src/lib/billing/provider-config.ts
+++ b/apps/web-next/src/lib/billing/provider-config.ts
@@ -1,0 +1,141 @@
+/**
+ * NAAP-0 — pymthouse BillingProvider env wiring + seed verification.
+ *
+ * Server-only. Reports the *presence* of the `PYMTHOUSE_*` env vars and whether
+ * the configured issuer/client match the staging reference values. It NEVER
+ * reads, returns, or logs the M2M client secret value — only a boolean
+ * indicating whether it is set.
+ */
+
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import {
+  isPymthouseConfigured,
+  getPymthouseIssuerUrlFromEnv,
+  getPymthousePublicClientIdFromEnv,
+} from '@pymthouse/builder-sdk/config';
+
+export const PYMTHOUSE_PROVIDER_SLUG = 'pymthouse';
+
+/**
+ * Public (non-secret) staging reference values from the execution handover.
+ * The OIDC issuer origin and the public/M2M client id are NOT secrets. The M2M
+ * client *secret* is provided ONLY via `PYMTHOUSE_M2M_CLIENT_SECRET` and is never
+ * stored here.
+ */
+export const PYMTHOUSE_STAGING_ISSUER_ORIGIN = 'https://staging.pymthouse.com';
+export const PYMTHOUSE_STAGING_CLIENT_ID = 'app_2d89999406f9be57dd0233de';
+
+/** Env vars the pymthouse adapter requires (secret listed last, never logged). */
+export const PYMTHOUSE_ENV_VARS = [
+  'PYMTHOUSE_ISSUER_URL',
+  'PYMTHOUSE_PUBLIC_CLIENT_ID',
+  'PYMTHOUSE_M2M_CLIENT_ID',
+  'PYMTHOUSE_M2M_CLIENT_SECRET',
+] as const;
+export type PymthouseEnvVar = (typeof PYMTHOUSE_ENV_VARS)[number];
+
+export interface PymthouseEnvStatus {
+  /** True when all required vars are present (delegates to the SDK). */
+  configured: boolean;
+  /** Presence booleans only — values (especially the secret) are never exposed. */
+  present: Record<PymthouseEnvVar, boolean>;
+  /** Names of the missing required vars. */
+  missing: PymthouseEnvVar[];
+  /** Configured issuer origin matches the staging reference. */
+  issuerMatchesStaging: boolean;
+  /** Configured public client id matches the staging reference. */
+  clientIdMatchesStaging: boolean;
+}
+
+function isPresent(name: PymthouseEnvVar): boolean {
+  const value = process.env[name];
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** Inspect `PYMTHOUSE_*` env wiring without ever touching the secret value. */
+export function verifyPymthouseEnv(): PymthouseEnvStatus {
+  const present = PYMTHOUSE_ENV_VARS.reduce(
+    (acc, name) => {
+      acc[name] = isPresent(name);
+      return acc;
+    },
+    {} as Record<PymthouseEnvVar, boolean>,
+  );
+
+  const missing = PYMTHOUSE_ENV_VARS.filter((name) => !present[name]);
+
+  let issuerMatchesStaging = false;
+  const issuer = getPymthouseIssuerUrlFromEnv();
+  if (issuer) {
+    try {
+      issuerMatchesStaging = new URL(issuer).origin === PYMTHOUSE_STAGING_ISSUER_ORIGIN;
+    } catch {
+      issuerMatchesStaging = false;
+    }
+  }
+
+  const clientIdMatchesStaging =
+    getPymthousePublicClientIdFromEnv() === PYMTHOUSE_STAGING_CLIENT_ID;
+
+  return {
+    configured: isPymthouseConfigured(),
+    present,
+    missing,
+    issuerMatchesStaging,
+    clientIdMatchesStaging,
+  };
+}
+
+/** Minimal structured logger surface (console satisfies it). */
+export interface StructuredLogger {
+  info?: (message: string) => void;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Emit a single structured log line describing the pymthouse env wiring.
+ * Logs presence booleans only — never the secret value. Returns the status so
+ * callers (e.g. a CI presence check) can assert on it.
+ */
+export function logPymthouseEnvStatus(
+  logger: StructuredLogger = console,
+  correlationId: string = randomUUID(),
+): PymthouseEnvStatus {
+  const status = verifyPymthouseEnv();
+  const line = JSON.stringify({
+    level: status.configured ? 'info' : 'warn',
+    event: 'billing.provider.pymthouse.env_verify',
+    correlationId,
+    configured: status.configured,
+    present: status.present,
+    missing: status.missing,
+    issuerMatchesStaging: status.issuerMatchesStaging,
+    clientIdMatchesStaging: status.clientIdMatchesStaging,
+  });
+  const emit = status.configured
+    ? (logger.info ?? logger.log)
+    : (logger.warn ?? logger.log);
+  emit?.call(logger, line);
+  return status;
+}
+
+/** Minimal shape of a seeded `BillingProvider` row (from `@naap/database`). */
+export interface SeedProviderLike {
+  readonly slug: string;
+  readonly enabled: boolean;
+}
+
+/** Find the pymthouse entry in a seed/catalog list. */
+export function findPymthouseSeed(
+  providers: readonly SeedProviderLike[],
+): SeedProviderLike | undefined {
+  return providers.find((p) => p.slug === PYMTHOUSE_PROVIDER_SLUG);
+}
+
+/** True when the seed declares `BillingProvider{slug:pymthouse, enabled:true}`. */
+export function isPymthouseSeedEnabled(providers: readonly SeedProviderLike[]): boolean {
+  return findPymthouseSeed(providers)?.enabled === true;
+}

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Reference billing provider adapter: pymthouse (NAAP-A).
+ *
+ * Wraps the existing `getPmtHouseServerClient()` BEHIND the BillingProviderAdapter
+ * SPI. This is the ONLY place that may import the pymthouse client; all other NaaP
+ * code goes through the adapter + registry. Methods the NaaP side does not yet
+ * support (BPP validate/plans/curation/manifest — PYMT-3/5/7 pending) throw
+ * AdapterNotImplementedError rather than fabricating a response.
+ */
+
+import 'server-only';
+
+import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
+
+import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import {
+  AdapterNotImplementedError,
+  type AppUsageInput,
+  type BillingProviderAdapter,
+  type Capability,
+  type CuratedOrchestrator,
+  type MintSignerSessionInput,
+  type Plan,
+  type SignerSession,
+  type UsageForExternalUserInput,
+  type ValidateResult,
+} from './adapter';
+
+export const PYMTHOUSE_ADAPTER_SLUG = 'pymthouse';
+
+export class PymthouseAdapter implements BillingProviderAdapter {
+  readonly slug = PYMTHOUSE_ADAPTER_SLUG;
+
+  isConfigured(): boolean {
+    return isPymthouseConfigured();
+  }
+
+  async validate(_key: string): Promise<ValidateResult> {
+    // BPP ② validate is provider-side (PYMT-3) and not yet C0-shaped on the NaaP
+    // side; do not fabricate identity/capabilities here.
+    throw new AdapterNotImplementedError(this.slug, 'validate');
+  }
+
+  async getPlans(): Promise<Plan[]> {
+    throw new AdapterNotImplementedError(this.slug, 'getPlans');
+  }
+
+  async getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown> {
+    return getPmtHouseServerClient().fetchUsageForExternalUser({
+      externalUserId: input.externalUserId,
+      startDate: input.startDate,
+      endDate: input.endDate,
+      ...(input.maxEndUserIds != null ? { maxEndUserIds: input.maxEndUserIds } : {}),
+    });
+  }
+
+  async getAppUsage(input: AppUsageInput): Promise<unknown> {
+    return getPmtHouseServerClient().getUsage({
+      startDate: input.startDate,
+      endDate: input.endDate,
+      ...(input.groupBy ? { groupBy: input.groupBy } : {}),
+      ...(input.userId ? { userId: input.userId } : {}),
+    });
+  }
+
+  async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSession> {
+    const session = await getPmtHouseServerClient().mintSignerSessionForExternalUser({
+      externalUserId: input.externalUserId,
+      email: input.email,
+    });
+    return {
+      accessToken: session.accessToken,
+      tokenType: session.tokenType,
+      expiresIn: session.expiresIn,
+      scope: session.scope,
+    };
+  }
+
+  async receiveCuratedOrchestrators(
+    _plan: string,
+    _list: CuratedOrchestrator[],
+  ): Promise<void> {
+    throw new AdapterNotImplementedError(this.slug, 'receiveCuratedOrchestrators');
+  }
+
+  async getCapabilityManifest(): Promise<Capability[]> {
+    throw new AdapterNotImplementedError(this.slug, 'getCapabilityManifest');
+  }
+}

--- a/apps/web-next/src/lib/billing/registry-db.test.ts
+++ b/apps/web-next/src/lib/billing/registry-db.test.ts
@@ -1,0 +1,127 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    billingProvider: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: vi.fn(),
+}));
+
+import { prisma } from '@/lib/db';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import {
+  DB_ADAPTER_REGISTRY_FLAG,
+  resolveBillingProviderAdapter,
+  resolveBillingProviderAdapterDetailed,
+  registerAdapterFactoryForTests,
+  resetAdapterFactoriesForTests,
+} from './registry-db';
+
+const findUnique = prisma.billingProvider.findUnique as ReturnType<typeof vi.fn>;
+const flag = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  resetAdapterFactoriesForTests();
+});
+
+describe('NAAP-A-db — DB-driven adapter registry', () => {
+  describe('flag OFF (default) — zero regression', () => {
+    beforeEach(() => flag.mockResolvedValue(false));
+
+    it('resolves from the static registry by slug and never touches the DB', async () => {
+      const res = await resolveBillingProviderAdapterDetailed('pymthouse');
+      expect(res.source).toBe('static');
+      expect(res.adapter?.slug).toBe('pymthouse');
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined for an unknown provider (parity with static map)', async () => {
+      const res = await resolveBillingProviderAdapter('does-not-exist');
+      expect(res).toBeUndefined();
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON — DB-driven', () => {
+    beforeEach(() => flag.mockResolvedValue(true));
+
+    it('resolves the adapter from the row adapterType', async () => {
+      findUnique.mockResolvedValue({ adapterType: 'pymthouse' });
+      const res = await resolveBillingProviderAdapterDetailed('pymthouse');
+      expect(res.source).toBe('db');
+      expect(res.adapterType).toBe('pymthouse');
+      expect(res.adapter?.slug).toBe('pymthouse');
+    });
+
+    it('maps a custom provider slug to a shared adapterType implementation', async () => {
+      findUnique.mockResolvedValue({ adapterType: 'stub' });
+      const res = await resolveBillingProviderAdapterDetailed('acme-billing');
+      expect(res.source).toBe('db');
+      expect(res.adapterType).toBe('stub');
+      expect(res.adapter?.slug).toBe('stub');
+    });
+
+    it('falls back to the slug as adapterType when the column is NULL', async () => {
+      findUnique.mockResolvedValue({ adapterType: null });
+      const res = await resolveBillingProviderAdapterDetailed('stub');
+      expect(res.source).toBe('db');
+      expect(res.adapterType).toBe('stub');
+      expect(res.adapter?.slug).toBe('stub');
+    });
+
+    it('falls back to the static map when no provider row exists', async () => {
+      findUnique.mockResolvedValue(null);
+      const res = await resolveBillingProviderAdapterDetailed('pymthouse');
+      // adapterType defaults to slug, which IS a known factory → still db source.
+      expect(res.adapter?.slug).toBe('pymthouse');
+    });
+
+    it('falls back to the static map for an unknown adapterType', async () => {
+      findUnique.mockResolvedValue({ adapterType: 'mystery-not-built' });
+      const res = await resolveBillingProviderAdapterDetailed('mystery-not-built');
+      expect(res.source).toBe('db-fallback-static');
+      // No static adapter for this slug either → undefined (graceful).
+      expect(res.adapter).toBeUndefined();
+    });
+
+    it('falls back to the static map (never hard-fails) when the DB query throws', async () => {
+      findUnique.mockRejectedValue(new Error('connection refused'));
+      const res = await resolveBillingProviderAdapterDetailed('pymthouse');
+      expect(res.source).toBe('db-fallback-static');
+      expect(res.adapter?.slug).toBe('pymthouse');
+    });
+
+    it('supports registering a new adapterType factory without a code change to the registry', async () => {
+      registerAdapterFactoryForTests('custom', () => ({
+        slug: 'custom',
+        isConfigured: () => true,
+        validate: async () => ({ valid: true }),
+        getPlans: async () => [],
+        getUsageForExternalUser: async () => ({}),
+        getAppUsage: async () => ({}),
+        mintSignerSession: async () => ({ accessToken: 'x' }),
+        receiveCuratedOrchestrators: async () => {},
+        getCapabilityManifest: async () => [],
+      }));
+      findUnique.mockResolvedValue({ adapterType: 'custom' });
+      const res = await resolveBillingProviderAdapterDetailed('any-provider');
+      expect(res.source).toBe('db');
+      expect(res.adapter?.slug).toBe('custom');
+    });
+  });
+
+  it('exposes the flag key', () => {
+    expect(DB_ADAPTER_REGISTRY_FLAG).toBe('db_adapter_registry');
+  });
+});

--- a/apps/web-next/src/lib/billing/registry-db.ts
+++ b/apps/web-next/src/lib/billing/registry-db.ts
@@ -1,0 +1,144 @@
+/**
+ * DB-driven billing-provider adapter registry (NAAP-A-db).
+ *
+ * NAAP-A keyed the registry by a STATIC slug→adapter map (`registry.ts`).
+ * NAAP-A-db makes resolution DB-driven: a `BillingProvider` row's `adapterType`
+ * column selects which `BillingProviderAdapter` implementation backs that
+ * provider (many provider rows may share one adapterType, differentiated by the
+ * `config` column). This lets operators add/retarget a provider without a code
+ * change.
+ *
+ * Flag-gated (`db_adapter_registry`, default OFF). When OFF — or whenever the DB
+ * lookup is unavailable, the row is missing, or the adapterType is unknown — it
+ * FALLS BACK to the static registry keyed by slug. So flag-OFF (and any DB lag)
+ * is a no-op with zero regression versus NAAP-A.
+ *
+ * Never logs secrets/PII — only the slug, resolved adapterType, and resolution
+ * source.
+ */
+
+import 'server-only';
+
+import { prisma } from '@/lib/db';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+
+import type { BillingProviderAdapter } from './adapter';
+import { PymthouseAdapter } from './pymthouse-adapter';
+import { StubAdapter } from './stub-adapter';
+import { getBillingProviderAdapter } from './registry';
+
+export const DB_ADAPTER_REGISTRY_FLAG = 'db_adapter_registry';
+
+/** How a provider's adapter was resolved (for structured logging/telemetry). */
+export type AdapterResolutionSource =
+  | 'static' // flag OFF, or fell back to the static slug→adapter map
+  | 'db' // resolved from BillingProvider.adapterType via a DB factory
+  | 'db-fallback-static'; // flag ON but row/adapterType unusable → static
+
+export interface AdapterResolution {
+  adapter: BillingProviderAdapter | undefined;
+  source: AdapterResolutionSource;
+  adapterType: string | null;
+}
+
+type AdapterFactory = () => BillingProviderAdapter;
+
+/** adapterType → adapter implementation factory. */
+function buildDefaultFactories(): Map<string, AdapterFactory> {
+  return new Map<string, AdapterFactory>([
+    ['pymthouse', () => new PymthouseAdapter()],
+    ['stub', () => new StubAdapter()],
+  ]);
+}
+
+let factories: Map<string, AdapterFactory> = buildDefaultFactories();
+/** Memoized adapter instances per adapterType (adapters are stateless). */
+let instanceCache: Map<string, BillingProviderAdapter> = new Map();
+
+function instantiate(adapterType: string): BillingProviderAdapter | undefined {
+  const cached = instanceCache.get(adapterType);
+  if (cached) {
+    return cached;
+  }
+  const factory = factories.get(adapterType);
+  if (!factory) {
+    return undefined;
+  }
+  const adapter = factory();
+  instanceCache.set(adapterType, adapter);
+  return adapter;
+}
+
+/**
+ * Resolve a provider slug → adapter, DB-driven when the flag is ON. Returns the
+ * resolution source so callers can log/telemeter without a second lookup.
+ *
+ * Resolution order when the flag is ON:
+ *  1. Look up the BillingProvider row by slug; read `adapterType`.
+ *  2. adapterType (or slug when NULL) → adapter factory → instance.
+ *  3. On any miss/error → static registry by slug (zero-regression fallback).
+ */
+export async function resolveBillingProviderAdapterDetailed(
+  slug: string,
+): Promise<AdapterResolution> {
+  let flagOn = false;
+  try {
+    flagOn = await isFeatureEnabled(DB_ADAPTER_REGISTRY_FLAG);
+  } catch {
+    flagOn = false;
+  }
+
+  if (!flagOn) {
+    return { adapter: getBillingProviderAdapter(slug), source: 'static', adapterType: null };
+  }
+
+  try {
+    const row = await prisma.billingProvider.findUnique({
+      where: { slug },
+      select: { adapterType: true },
+    });
+
+    const adapterType = row?.adapterType?.trim() || slug;
+    const adapter = instantiate(adapterType);
+    if (adapter) {
+      return { adapter, source: 'db', adapterType };
+    }
+    // Unknown adapterType → fall back to the static slug map.
+    return {
+      adapter: getBillingProviderAdapter(slug),
+      source: 'db-fallback-static',
+      adapterType,
+    };
+  } catch {
+    // DB unavailable / lagging → never hard-fail; keep the static behavior.
+    return {
+      adapter: getBillingProviderAdapter(slug),
+      source: 'db-fallback-static',
+      adapterType: null,
+    };
+  }
+}
+
+/** Convenience wrapper returning just the adapter. */
+export async function resolveBillingProviderAdapter(
+  slug: string,
+): Promise<BillingProviderAdapter | undefined> {
+  return (await resolveBillingProviderAdapterDetailed(slug)).adapter;
+}
+
+// ── Test seams ──
+
+/** Register/override an adapterType factory (tests / future dynamic config). */
+export function registerAdapterFactoryForTests(
+  adapterType: string,
+  factory: AdapterFactory,
+): void {
+  factories.set(adapterType, factory);
+  instanceCache.delete(adapterType);
+}
+
+/** Reset factories + instance cache to defaults (test isolation). */
+export function resetAdapterFactoriesForTests(): void {
+  factories = buildDefaultFactories();
+  instanceCache = new Map();
+}

--- a/apps/web-next/src/lib/billing/registry.test.ts
+++ b/apps/web-next/src/lib/billing/registry.test.ts
@@ -1,0 +1,63 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import type { BillingProviderAdapter } from './adapter';
+import {
+  getBillingProviderAdapter,
+  hasBillingProviderAdapter,
+  listBillingProviderSlugs,
+  registerBillingProviderAdapter,
+  resetBillingProviderRegistryForTests,
+} from './registry';
+
+afterEach(() => resetBillingProviderRegistryForTests());
+
+describe('NAAP-A — billing provider adapter registry', () => {
+  it('resolves the pymthouse + stub reference adapters (≥2 providers)', () => {
+    expect(hasBillingProviderAdapter('pymthouse')).toBe(true);
+    expect(hasBillingProviderAdapter('stub')).toBe(true);
+    expect(getBillingProviderAdapter('pymthouse')?.slug).toBe('pymthouse');
+    expect(getBillingProviderAdapter('stub')?.slug).toBe('stub');
+    expect(listBillingProviderSlugs().length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns undefined for an unknown provider', () => {
+    expect(getBillingProviderAdapter('does-not-exist')).toBeUndefined();
+    expect(hasBillingProviderAdapter('does-not-exist')).toBe(false);
+  });
+
+  it('accepts any object satisfying the SPI (provider-neutral)', () => {
+    const fake: BillingProviderAdapter = {
+      slug: 'fake',
+      isConfigured: () => true,
+      validate: async () => ({ valid: true }),
+      getPlans: async () => [],
+      getUsageForExternalUser: async () => ({}),
+      getAppUsage: async () => ({}),
+      mintSignerSession: async () => ({ accessToken: 'x' }),
+      receiveCuratedOrchestrators: async () => {},
+      getCapabilityManifest: async () => [],
+    };
+    registerBillingProviderAdapter(fake);
+    expect(getBillingProviderAdapter('fake')).toBe(fake);
+  });
+
+  it('reset restores the default registry', () => {
+    registerBillingProviderAdapter({
+      slug: 'temp',
+      isConfigured: () => true,
+      validate: async () => ({ valid: true }),
+      getPlans: async () => [],
+      getUsageForExternalUser: async () => ({}),
+      getAppUsage: async () => ({}),
+      mintSignerSession: async () => ({}),
+      receiveCuratedOrchestrators: async () => {},
+      getCapabilityManifest: async () => [],
+    });
+    expect(hasBillingProviderAdapter('temp')).toBe(true);
+    resetBillingProviderRegistryForTests();
+    expect(hasBillingProviderAdapter('temp')).toBe(false);
+    expect(hasBillingProviderAdapter('pymthouse')).toBe(true);
+  });
+});

--- a/apps/web-next/src/lib/billing/registry.ts
+++ b/apps/web-next/src/lib/billing/registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Billing provider adapter registry (NAAP-A).
+ *
+ * Resolves a provider slug → its `BillingProviderAdapter`. NaaP code looks up a
+ * provider here instead of importing a provider client directly.
+ *
+ * Keyed by provider slug. (The plan's `BillingProvider.adapterType` column is a
+ * later refinement; until then `adapterType` defaults to the slug, so the
+ * registry is keyed by slug and resolves the same adapter.)
+ */
+
+import type { BillingProviderAdapter } from './adapter';
+import { PymthouseAdapter } from './pymthouse-adapter';
+import { StubAdapter } from './stub-adapter';
+
+function buildDefaultRegistry(): Map<string, BillingProviderAdapter> {
+  const adapters: BillingProviderAdapter[] = [new PymthouseAdapter(), new StubAdapter()];
+  const map = new Map<string, BillingProviderAdapter>();
+  for (const adapter of adapters) {
+    map.set(adapter.slug, adapter);
+  }
+  return map;
+}
+
+let registry: Map<string, BillingProviderAdapter> = buildDefaultRegistry();
+
+/** Resolve an adapter by provider slug, or `undefined` if none is registered. */
+export function getBillingProviderAdapter(slug: string): BillingProviderAdapter | undefined {
+  return registry.get(slug);
+}
+
+/** True when an adapter is registered for the slug. */
+export function hasBillingProviderAdapter(slug: string): boolean {
+  return registry.has(slug);
+}
+
+/** The slugs of all registered adapters. */
+export function listBillingProviderSlugs(): string[] {
+  return Array.from(registry.keys());
+}
+
+/**
+ * Register (or override) an adapter. Primarily for tests / future dynamic
+ * registration; production uses the default registry.
+ */
+export function registerBillingProviderAdapter(adapter: BillingProviderAdapter): void {
+  registry.set(adapter.slug, adapter);
+}
+
+/** Reset the registry to its defaults (test isolation). */
+export function resetBillingProviderRegistryForTests(): void {
+  registry = buildDefaultRegistry();
+}

--- a/apps/web-next/src/lib/billing/stub-adapter.ts
+++ b/apps/web-next/src/lib/billing/stub-adapter.ts
@@ -1,0 +1,91 @@
+/**
+ * In-memory stub billing provider adapter (NAAP-A).
+ *
+ * The second adapter in the registry — it proves the SPI is provider-neutral
+ * (the Phase 0 gate requires the registry to resolve ≥2 providers). Tiny and
+ * canned by design; it is NOT a real provider.
+ */
+
+import {
+  type AppUsageInput,
+  type BillingProviderAdapter,
+  type Capability,
+  type CuratedOrchestrator,
+  type MintSignerSessionInput,
+  type Plan,
+  type SignerSession,
+  type UsageForExternalUserInput,
+  type ValidateResult,
+} from './adapter';
+
+export const STUB_ADAPTER_SLUG = 'stub';
+
+export class StubAdapter implements BillingProviderAdapter {
+  readonly slug = STUB_ADAPTER_SLUG;
+
+  isConfigured(): boolean {
+    return true;
+  }
+
+  async validate(key: string): Promise<ValidateResult> {
+    if (!key) return { valid: false };
+    return {
+      valid: true,
+      user: { sub: 'stub-user-1' },
+      billing_account: {
+        id: 'acct_stub_1',
+        providerSlug: this.slug,
+        billingMode: 'delegated',
+      },
+      capabilities: ['text-to-image:sdxl'],
+      quota: { remaining: 1000, resetAt: '2026-12-31T23:59:59.999Z' },
+      subscriptionRef: 'sub_stub_opaque_1',
+    };
+  }
+
+  async getPlans(): Promise<Plan[]> {
+    return [
+      {
+        id: 'free',
+        name: 'Free',
+        price: { amount: 0, interval: 'month', currency: 'USD' },
+        bundles: [{ capability: 'text-to-image:sdxl' }],
+      },
+    ];
+  }
+
+  async getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown> {
+    return {
+      externalUserId: input.externalUserId,
+      period: { start: input.startDate, end: input.endDate },
+      requestCount: 0,
+    };
+  }
+
+  async getAppUsage(input: AppUsageInput): Promise<unknown> {
+    return {
+      period: { start: input.startDate, end: input.endDate },
+      totals: { requestCount: 0 },
+    };
+  }
+
+  async mintSignerSession(_input: MintSignerSessionInput): Promise<SignerSession> {
+    return {
+      accessToken: 'stub-signer-token',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      scope: 'sign:job',
+    };
+  }
+
+  async receiveCuratedOrchestrators(
+    _plan: string,
+    _list: CuratedOrchestrator[],
+  ): Promise<void> {
+    // no-op for the in-memory stub
+  }
+
+  async getCapabilityManifest(): Promise<Capability[]> {
+    return [{ id: 'text-to-image:sdxl', description: 'Stub capability' }];
+  }
+}

--- a/apps/web-next/src/lib/dev-api/native-key.test.ts
+++ b/apps/web-next/src/lib/dev-api/native-key.test.ts
@@ -1,0 +1,143 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+import {
+  NATIVE_KEY_RE,
+  generateNativeApiKey,
+  isNativeKeyFormat,
+  resolveNativeKeyToProviderSession,
+  verifyNativeKeyHash,
+  type NativeKeyRecord,
+} from './native-key';
+import type { TeamBillingBinding } from '@/lib/teams/billing-account-ref';
+import { hashApiKey } from '@naap/database';
+
+function fakeAdapter(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    slug,
+    isConfigured: vi.fn(() => true),
+    mintSignerSession: vi.fn(async () => ({
+      accessToken: `tok-${slug}`,
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      scope: 'sign:job',
+    })),
+    ...overrides,
+  };
+}
+
+const activeKey: NativeKeyRecord = { status: 'ACTIVE', seatId: 'seat-1', teamId: 'team-1' };
+const pymtTeam: TeamBillingBinding = {
+  id: 'team-1',
+  billingAccountProviderSlug: 'pymthouse',
+  billingAccountId: 'acct_om_1',
+};
+const stubTeam: TeamBillingBinding = {
+  id: 'team-1',
+  billingAccountProviderSlug: 'stub',
+  billingAccountId: 'acct_stub_1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('generateNativeApiKey', () => {
+  it('produces a canonical naap_<16>_<48> key', () => {
+    const { rawKey, lookupId, secret } = generateNativeApiKey();
+    expect(NATIVE_KEY_RE.test(rawKey)).toBe(true);
+    expect(isNativeKeyFormat(rawKey)).toBe(true);
+    expect(lookupId).toHaveLength(16);
+    expect(secret).toHaveLength(48);
+    expect(rawKey).toBe(`naap_${lookupId}_${secret}`);
+  });
+  it('is unique across calls', () => {
+    expect(generateNativeApiKey().rawKey).not.toBe(generateNativeApiKey().rawKey);
+  });
+});
+
+describe('verifyNativeKeyHash (constant-time)', () => {
+  it('accepts the matching hash and rejects others/null', () => {
+    const { rawKey } = generateNativeApiKey();
+    const hash = hashApiKey(rawKey);
+    expect(verifyNativeKeyHash(rawKey, hash)).toBe(true);
+    expect(verifyNativeKeyHash(`${rawKey}x`, hash)).toBe(false);
+    expect(verifyNativeKeyHash(rawKey, null)).toBe(false);
+    expect(verifyNativeKeyHash(rawKey, 'deadbeef')).toBe(false);
+  });
+});
+
+describe('resolveNativeKeyToProviderSession — provider-agnostic mapping', () => {
+  it('resolves a naap_ key to the pymthouse provider session', async () => {
+    const adapter = fakeAdapter('pymthouse');
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await resolveNativeKeyToProviderSession(activeKey, pymtTeam, { email: 'u@e.co' });
+    expect(res.valid).toBe(true);
+    expect(res.billingAccountRef).toEqual({ providerSlug: 'pymthouse', accountId: 'acct_om_1' });
+    expect(res.signerSession?.accessToken).toBe('tok-pymthouse');
+    // externalUserId is the provider account id from the binding.
+    expect(adapter.mintSignerSession).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'acct_om_1', email: 'u@e.co' }),
+    );
+  });
+
+  it('resolves the SAME key shape against the C0 stub provider', async () => {
+    getBillingProviderAdapter.mockReturnValue(fakeAdapter('stub'));
+    const res = await resolveNativeKeyToProviderSession(activeKey, stubTeam);
+    expect(res.valid).toBe(true);
+    expect(res.signerSession?.accessToken).toBe('tok-stub');
+  });
+
+  it('revocation invalidates instantly (no provider call)', async () => {
+    const adapter = fakeAdapter('pymthouse');
+    getBillingProviderAdapter.mockReturnValue(adapter);
+    const res = await resolveNativeKeyToProviderSession({ ...activeKey, status: 'REVOKED' }, pymtTeam);
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('revoked');
+    expect(adapter.mintSignerSession).not.toHaveBeenCalled();
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+  });
+
+  it('rejects a key whose seat has no team binding', async () => {
+    const res = await resolveNativeKeyToProviderSession({ ...activeKey, teamId: null }, null);
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('unbound_seat');
+  });
+
+  it('rejects when the team is unbound to a billing account', async () => {
+    const res = await resolveNativeKeyToProviderSession(activeKey, {
+      id: 'team-1',
+      billingAccountProviderSlug: null,
+      billingAccountId: null,
+    });
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('team_unbound');
+  });
+
+  it('fails safe when the bound provider is unavailable/unconfigured', async () => {
+    getBillingProviderAdapter.mockReturnValue(fakeAdapter('pymthouse', { isConfigured: vi.fn(() => false) }));
+    const res = await resolveNativeKeyToProviderSession(activeKey, pymtTeam);
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('provider_unavailable');
+  });
+
+  it('fails safe (no internals leaked) when mint throws', async () => {
+    getBillingProviderAdapter.mockReturnValue(
+      fakeAdapter('pymthouse', {
+        mintSignerSession: vi.fn(async () => {
+          throw new Error('provider boom: secret-token-xyz');
+        }),
+      }),
+    );
+    const res = await resolveNativeKeyToProviderSession(activeKey, pymtTeam);
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('mint_failed');
+    expect(res.signerSession).toBeUndefined();
+  });
+});

--- a/apps/web-next/src/lib/dev-api/native-key.ts
+++ b/apps/web-next/src/lib/dev-api/native-key.ts
@@ -1,0 +1,126 @@
+/**
+ * Native `naap_` key mint + resolution service (NAAP-B).
+ *
+ * Decision D1: native NaaP keys are the ONLY credential apps/SDK present — they
+ * are provider-OPAQUE. A `naap_` key is issued to a SEAT (NAAP-1); server-side
+ * it maps to whatever provider backs the seat's team account via the
+ * BillingProviderAdapter (NAAP-A). Apps NEVER see `pmth_`, provider tokens, or
+ * provider URLs.
+ *
+ * This module is DB-free so the mapping rules can be unit-tested in isolation;
+ * the HTTP routes persist `DevApiKey` rows and the validation front door
+ * (NAAP-C) calls {@link resolveNativeKeyToProviderSession}.
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { hashApiKey } from '@naap/database';
+import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import type { SignerSession } from '@/lib/billing/adapter';
+import {
+  type BillingAccountRef,
+  type TeamBillingBinding,
+  teamBillingAccountRef,
+} from '@/lib/teams/billing-account-ref';
+
+/** Feature flag gating native-key issuance + resolution (default OFF). */
+export const NATIVE_KEYS_FLAG = 'native_keys';
+
+/** Canonical native key shape: `naap_<16 hex>_<48 hex>` (matches parseApiKey). */
+export const NATIVE_KEY_RE = /^naap_[0-9a-f]{16}_[0-9a-f]{48}$/;
+
+export interface GeneratedNativeKey {
+  /** The full secret to return to the caller ONCE; never stored in clear. */
+  rawKey: string;
+  /** Blind-index lookup id (16 hex) — stored as `keyLookupId`. */
+  lookupId: string;
+  /** Secret portion (48 hex). */
+  secret: string;
+}
+
+/** Mint a fresh native `naap_` key. The raw key is shown to the caller once. */
+export function generateNativeApiKey(): GeneratedNativeKey {
+  const lookupId = randomBytes(8).toString('hex'); // 16 hex chars
+  const secret = randomBytes(24).toString('hex'); // 48 hex chars
+  return { rawKey: `naap_${lookupId}_${secret}`, lookupId, secret };
+}
+
+/** True when a raw key has the canonical native shape. */
+export function isNativeKeyFormat(rawKey: string): boolean {
+  return NATIVE_KEY_RE.test(rawKey.trim());
+}
+
+/**
+ * Constant-time comparison of a presented raw key against a stored scrypt hash.
+ * Returns false on any mismatch (including length) without short-circuiting on
+ * content, to avoid timing oracles.
+ */
+export function verifyNativeKeyHash(rawKey: string, storedHash: string | null | undefined): boolean {
+  if (!storedHash) return false;
+  const actual = Buffer.from(hashApiKey(rawKey), 'utf8');
+  const expected = Buffer.from(storedHash, 'utf8');
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}
+
+/** Minimal native-key record the resolver needs (subset of the DevApiKey row). */
+export interface NativeKeyRecord {
+  status: string; // ACTIVE | REVOKED | EXPIRED
+  seatId: string | null;
+  teamId: string | null;
+}
+
+export type ResolveFailureReason =
+  | 'revoked'
+  | 'unbound_seat'
+  | 'team_unbound'
+  | 'provider_unavailable'
+  | 'mint_failed';
+
+export interface ResolvedProviderSession {
+  valid: boolean;
+  reason?: ResolveFailureReason;
+  /** Provider-agnostic account pointer the session was minted for. */
+  billingAccountRef?: BillingAccountRef;
+  /** Provider-issued session, OPAQUE to applications. */
+  signerSession?: SignerSession;
+}
+
+/**
+ * Resolve a native key (record + its team binding) into a provider signer
+ * session — the core "naap_ → provider session" mapping. Provider-agnostic:
+ * works for pymthouse, the C0 stub, or any registered adapter. Revocation is
+ * instant because a non-ACTIVE key fails before any provider call.
+ *
+ * @param key   the stored key record (status + seat/team attribution)
+ * @param team  the seat's team billing binding, or null if unresolved
+ */
+export async function resolveNativeKeyToProviderSession(
+  key: NativeKeyRecord,
+  team: TeamBillingBinding | null,
+  opts?: { email?: string },
+): Promise<ResolvedProviderSession> {
+  // Revocation/expiry invalidates instantly — before touching any provider.
+  if (key.status !== 'ACTIVE') return { valid: false, reason: 'revoked' };
+  if (!key.teamId) return { valid: false, reason: 'unbound_seat' };
+  if (!team || team.id !== key.teamId) return { valid: false, reason: 'team_unbound' };
+
+  const ref = teamBillingAccountRef(team);
+  if (!ref) return { valid: false, reason: 'team_unbound' };
+
+  const adapter = getBillingProviderAdapter(ref.providerSlug);
+  if (!adapter || !adapter.isConfigured()) {
+    return { valid: false, reason: 'provider_unavailable', billingAccountRef: ref };
+  }
+
+  try {
+    const signerSession = await adapter.mintSignerSession({
+      externalUserId: ref.accountId,
+      email: opts?.email,
+    });
+    return { valid: true, billingAccountRef: ref, signerSession };
+  } catch {
+    // Never surface provider internals; lag-tolerant fail-safe.
+    return { valid: false, reason: 'mint_failed', billingAccountRef: ref };
+  }
+}

--- a/apps/web-next/src/lib/dev-api/validate-key.test.ts
+++ b/apps/web-next/src/lib/dev-api/validate-key.test.ts
@@ -1,0 +1,76 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  INVALID_APP_ID,
+  buildFrontDoorResponse,
+  extractAppId,
+  isNativeKeyToken,
+  parseBearer,
+} from './validate-key';
+
+describe('parseBearer', () => {
+  it('extracts the token', () => {
+    expect(parseBearer('Bearer naap_abc')).toBe('naap_abc');
+    expect(parseBearer('bearer  naap_abc ')).toBe('naap_abc');
+  });
+  it('returns null for missing/non-bearer', () => {
+    expect(parseBearer(null)).toBeNull();
+    expect(parseBearer('Basic xyz')).toBeNull();
+  });
+});
+
+describe('isNativeKeyToken (D1: native only)', () => {
+  it('accepts naap_ and rejects provider tokens', () => {
+    expect(isNativeKeyToken('naap_abc')).toBe(true);
+    expect(isNativeKeyToken('pmth_abc')).toBe(false);
+  });
+});
+
+describe('extractAppId', () => {
+  it('returns null when absent/empty', () => {
+    expect(extractAppId(null)).toBeNull();
+    expect(extractAppId('   ')).toBeNull();
+  });
+  it('accepts a valid slug/uuid', () => {
+    expect(extractAppId('storyboard')).toBe('storyboard');
+    expect(extractAppId('app_123-abc.def')).toBe('app_123-abc.def');
+  });
+  it('flags malformed ids (never used to build a URL/query)', () => {
+    expect(extractAppId('bad id!')).toBe(INVALID_APP_ID);
+    expect(extractAppId('x'.repeat(200))).toBe(INVALID_APP_ID);
+  });
+});
+
+describe('buildFrontDoorResponse (BPP ③ shape)', () => {
+  const base = {
+    userSub: 'user-1',
+    billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_om_1' },
+    signerSession: { accessToken: 'tok', tokenType: 'Bearer', expiresIn: 3600 },
+  };
+
+  it('produces the contract shape with capabilities defaulting to []', () => {
+    const res = buildFrontDoorResponse(base);
+    expect(res).toMatchObject({
+      valid: true,
+      user: { sub: 'user-1' },
+      billingAccount: { id: 'acct_om_1', providerSlug: 'pymthouse' },
+      capabilities: [],
+      quota: null,
+    });
+    expect(res.signerSession.accessToken).toBe('tok');
+    expect(res.app).toBeUndefined();
+  });
+
+  it('includes app attribution only when an appId is given', () => {
+    const res = buildFrontDoorResponse({ ...base, appId: 'storyboard', capabilities: ['text-to-image:sdxl'] });
+    expect(res.app).toEqual({ id: 'storyboard' });
+    expect(res.capabilities).toEqual(['text-to-image:sdxl']);
+  });
+
+  it('passes through quota when provided', () => {
+    const res = buildFrontDoorResponse({ ...base, quota: { remaining: 10, resetAt: '2026-12-31T00:00:00Z' } });
+    expect(res.quota).toEqual({ remaining: 10, resetAt: '2026-12-31T00:00:00Z' });
+  });
+});

--- a/apps/web-next/src/lib/dev-api/validate-key.ts
+++ b/apps/web-next/src/lib/dev-api/validate-key.ts
@@ -1,0 +1,97 @@
+/**
+ * Key-validation front-door helpers (NAAP-C).
+ *
+ * The front door (`POST /api/v1/keys/validate`) is the SINGLE entry point apps
+ * and services call (BPP ③). It resolves a native `naap_` key → seat → team →
+ * `billingAccountRef` → provider adapter → a provider-neutral response:
+ *
+ *     { user, app, billingAccount, capabilities, quota, signerSession }
+ *
+ * Decision D1: native `naap_` keys ONLY — there is NO provider-token
+ * passthrough. A presented provider token is rejected.
+ *
+ * This module holds the DB-free parsing + response-shaping logic so it can be
+ * unit-tested in isolation; the route persists/looks up rows.
+ */
+
+import type { SignerSession } from '@/lib/billing/adapter';
+import type { BillingAccountRef } from '@/lib/teams/billing-account-ref';
+
+/** Feature flag gating the validation front door (default OFF → 404 / fallback). */
+export const FRONT_DOOR_FLAG = 'key_validation_front_door';
+
+/** Native key prefix (D1). */
+export const NATIVE_KEY_PREFIX = 'naap_';
+
+/** App-id (X-App-Id) format: lowercase slug or a uuid; bounded length. */
+const APP_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
+
+/** Extract a Bearer token from an Authorization header, or null. */
+export function parseBearer(authHeader: string | null): string | null {
+  if (!authHeader) return null;
+  const m = authHeader.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+/** True when the token is (claims to be) a native NaaP key. */
+export function isNativeKeyToken(token: string): boolean {
+  return token.startsWith(NATIVE_KEY_PREFIX);
+}
+
+/**
+ * Validate + normalize an optional X-App-Id header. Returns the appId, or null
+ * when absent. Returns the sentinel `INVALID_APP_ID` when present but malformed
+ * so the caller can 400 (never used to build a URL or query — attribution only).
+ */
+export const INVALID_APP_ID = Symbol('invalid_app_id');
+export function extractAppId(header: string | null): string | null | typeof INVALID_APP_ID {
+  if (header == null) return null;
+  const v = header.trim();
+  if (v === '') return null;
+  if (!APP_ID_RE.test(v)) return INVALID_APP_ID;
+  return v;
+}
+
+/** BPP ③ front-door response (provider-neutral). */
+export interface FrontDoorResponse {
+  valid: true;
+  user: { sub: string };
+  app?: { id: string; scopes?: string[] };
+  billingAccount: { id: string; providerSlug: string };
+  capabilities: string[];
+  quota: { remaining: number; resetAt?: string } | null;
+  signerSession: SignerSession;
+}
+
+export interface BuildFrontDoorInput {
+  userSub: string;
+  appId?: string | null;
+  appScopes?: string[];
+  billingAccountRef: BillingAccountRef;
+  capabilities?: string[] | null;
+  quota?: { remaining: number; resetAt?: string } | null;
+  signerSession: SignerSession;
+}
+
+/**
+ * Shape the provider-neutral ③ response. Capabilities default to `[]` (not `*`)
+ * when the provider hasn't wired BPP validate yet — fail CLOSED for capability
+ * surface (NAAP-E enforces), while the key itself is still valid.
+ */
+export function buildFrontDoorResponse(input: BuildFrontDoorInput): FrontDoorResponse {
+  const res: FrontDoorResponse = {
+    valid: true,
+    user: { sub: input.userSub },
+    billingAccount: {
+      id: input.billingAccountRef.accountId,
+      providerSlug: input.billingAccountRef.providerSlug,
+    },
+    capabilities: Array.isArray(input.capabilities) ? input.capabilities : [],
+    quota: input.quota ?? null,
+    signerSession: input.signerSession,
+  };
+  if (input.appId) {
+    res.app = { id: input.appId, ...(input.appScopes ? { scopes: input.appScopes } : {}) };
+  }
+  return res;
+}

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -21,7 +21,27 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: true,
     description: 'Enable teams collaboration feature (team creation, team switching, team pages)',
   },
+  {
+    key: 'app_registry',
+    enabled: false,
+    description:
+      'Enable the application/service registry (/api/v1/apps/*) so usage and rate limits attribute per registered app. OFF = registry endpoints return 404 (no-op).',
+  },
 ];
+
+/**
+ * Read a single feature flag's effective state without writing to the DB.
+ * Falls back to the KNOWN_FLAGS default (or `false`) when the flag row does not
+ * exist yet, so a flag defaulting OFF is a no-op until an admin enables it.
+ */
+export async function isFeatureEnabled(key: string): Promise<boolean> {
+  const flag = await prisma.featureFlag.findUnique({
+    where: { key },
+    select: { enabled: true },
+  });
+  if (flag) return flag.enabled;
+  return KNOWN_FLAGS.find((f) => f.key === key)?.enabled ?? false;
+}
 
 /**
  * Ensure all known flags exist in the database.

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -21,7 +21,27 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: true,
     description: 'Enable teams collaboration feature (team creation, team switching, team pages)',
   },
+  {
+    key: 'usage_ingest',
+    enabled: false,
+    description:
+      'Enable cross-provider usage telemetry: the BPP ⑥ ingest endpoint (/api/v1/metrics/ingest) and the spend dashboard BFF (/api/v1/metrics/usage). OFF = both return 404 (no-op).',
+  },
 ];
+
+/**
+ * Read a single feature flag's effective state without writing to the DB.
+ * Falls back to the KNOWN_FLAGS default (or `false`) when the flag row does not
+ * exist yet, so a flag defaulting OFF is a no-op until an admin enables it.
+ */
+export async function isFeatureEnabled(key: string): Promise<boolean> {
+  const flag = await prisma.featureFlag.findUnique({
+    where: { key },
+    select: { enabled: true },
+  });
+  if (flag) return flag.enabled;
+  return KNOWN_FLAGS.find((f) => f.key === key)?.enabled ?? false;
+}
 
 /**
  * Ensure all known flags exist in the database.

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -27,6 +27,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     description:
       'Route billing requests through the generic BillingProviderAdapter registry (/api/v1/billing/{provider}/*). OFF = legacy /billing/pymthouse/* behavior only.',
   },
+  {
+    key: 'db_adapter_registry',
+    enabled: false,
+    description:
+      'Resolve the BillingProviderAdapter from the BillingProvider.adapterType DB column (NAAP-A-db) instead of the static slug→adapter map. OFF = static registry (zero regression); falls back to static on any DB miss/error.',
+  },
 ];
 
 /**

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -39,6 +39,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     description:
       'Native provider-opaque naap_ keys issued to a seat (/api/v1/teams/{id}/seats/{seatId}/keys). OFF = endpoints 404, no-op (NAAP-B).',
   },
+  {
+    key: 'key_validation_front_door',
+    enabled: false,
+    description:
+      'Key validation front door POST /api/v1/keys/validate (resolves naap_ → provider via adapter, BPP ③). OFF = 404 so callers fall back to their direct path (NAAP-C).',
+  },
 ];
 
 /**

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -33,6 +33,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     description:
       'Team Seats API + provider-agnostic billingAccountRef binding (/api/v1/teams/{id}/seats/*, /billing-account). OFF = endpoints 404, no-op (NAAP-1).',
   },
+  {
+    key: 'native_keys',
+    enabled: false,
+    description:
+      'Native provider-opaque naap_ keys issued to a seat (/api/v1/teams/{id}/seats/{seatId}/keys). OFF = endpoints 404, no-op (NAAP-B).',
+  },
 ];
 
 /**

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -27,6 +27,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     description:
       'Route billing requests through the generic BillingProviderAdapter registry (/api/v1/billing/{provider}/*). OFF = legacy /billing/pymthouse/* behavior only.',
   },
+  {
+    key: 'team_seats',
+    enabled: false,
+    description:
+      'Team Seats API + provider-agnostic billingAccountRef binding (/api/v1/teams/{id}/seats/*, /billing-account). OFF = endpoints 404, no-op (NAAP-1).',
+  },
 ];
 
 /**

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -21,7 +21,27 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: true,
     description: 'Enable teams collaboration feature (team creation, team switching, team pages)',
   },
+  {
+    key: 'provider_adapters',
+    enabled: false,
+    description:
+      'Route billing requests through the generic BillingProviderAdapter registry (/api/v1/billing/{provider}/*). OFF = legacy /billing/pymthouse/* behavior only.',
+  },
 ];
+
+/**
+ * Read a single feature flag's effective state without writing to the DB.
+ * Falls back to the KNOWN_FLAGS default (or `false`) when the flag row does not
+ * exist yet, so a flag defaulting OFF is a no-op until an admin enables it.
+ */
+export async function isFeatureEnabled(key: string): Promise<boolean> {
+  const flag = await prisma.featureFlag.findUnique({
+    where: { key },
+    select: { enabled: true },
+  });
+  if (flag) return flag.enabled;
+  return KNOWN_FLAGS.find((f) => f.key === key)?.enabled ?? false;
+}
 
 /**
  * Ensure all known flags exist in the database.

--- a/apps/web-next/src/lib/gateway/__tests__/service-key.test.ts
+++ b/apps/web-next/src/lib/gateway/__tests__/service-key.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for discovery-scoped service keys (NAAP-4).
+ *
+ * Covers minting a `gw_` service key scoped to discovery, the scope helper, and
+ * that a minted key resolves through `authorize()` (so the discovery endpoint
+ * accepts it) — without changing behavior of existing unscoped keys.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHash } from 'crypto';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    gatewayApiKey: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    gatewayMasterKey: { findUnique: vi.fn() },
+    teamMember: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/api/auth', () => ({ validateSession: vi.fn() }));
+vi.mock('@/lib/api/response', () => ({
+  getAuthToken: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+vi.mock('@naap/cache', () => ({
+  createRateLimiter: () => ({
+    consume: vi.fn().mockResolvedValue({ allowed: true }),
+  }),
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  DISCOVERY_ENDPOINT,
+  keyAllowsDiscovery,
+  mintServiceDiscoveryKey,
+} from '../service-key';
+import { authorize } from '../authorize';
+
+const mockCreate = prisma.gatewayApiKey.create as ReturnType<typeof vi.fn>;
+const mockFindUnique = prisma.gatewayApiKey.findUnique as ReturnType<typeof vi.fn>;
+
+describe('keyAllowsDiscovery', () => {
+  it('allows when allowlist is empty (all endpoints) — existing keys unchanged', () => {
+    expect(keyAllowsDiscovery(undefined)).toBe(true);
+    expect(keyAllowsDiscovery([])).toBe(true);
+  });
+
+  it('allows when discovery endpoint is in the allowlist', () => {
+    expect(keyAllowsDiscovery([DISCOVERY_ENDPOINT])).toBe(true);
+    expect(keyAllowsDiscovery(['/other', DISCOVERY_ENDPOINT])).toBe(true);
+  });
+
+  it('rejects when allowlist is set but excludes discovery', () => {
+    expect(keyAllowsDiscovery(['/api/v1/gw/some-connector'])).toBe(false);
+  });
+});
+
+describe('mintServiceDiscoveryKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: 'key-1',
+      keyPrefix: data.keyPrefix,
+    }));
+  });
+
+  it('mints a gw_ key scoped to discovery for a team', async () => {
+    const result = await mintServiceDiscoveryKey({
+      name: 'sdk-service',
+      createdBy: 'user-1',
+      teamId: 'team-1',
+    });
+
+    expect(result.rawKey.startsWith('gw_')).toBe(true);
+    expect(result.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT]);
+    expect(result.keyPrefix).toBe(result.rawKey.slice(0, 11));
+
+    const createArg = mockCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createArg.data.teamId).toBe('team-1');
+    expect(createArg.data.ownerUserId).toBeUndefined();
+    expect(createArg.data.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT]);
+    // Only the SHA-256 hash is persisted, never the raw key.
+    expect(createArg.data.keyHash).toBe(
+      createHash('sha256').update(result.rawKey).digest('hex'),
+    );
+    expect(Object.values(createArg.data)).not.toContain(result.rawKey);
+  });
+
+  it('merges additional endpoints without duplicating discovery', async () => {
+    const result = await mintServiceDiscoveryKey({
+      name: 'sdk-service',
+      createdBy: 'user-1',
+      ownerUserId: 'user-1',
+      additionalEndpoints: ['/api/v1/gw/catalog', DISCOVERY_ENDPOINT],
+    });
+    expect(result.allowedEndpoints).toEqual([DISCOVERY_ENDPOINT, '/api/v1/gw/catalog']);
+  });
+
+  it('requires exactly one of teamId / ownerUserId', async () => {
+    await expect(
+      mintServiceDiscoveryKey({ name: 'x', createdBy: 'u' }),
+    ).rejects.toThrow(/exactly one/);
+    await expect(
+      mintServiceDiscoveryKey({ name: 'x', createdBy: 'u', teamId: 't', ownerUserId: 'u' }),
+    ).rejects.toThrow(/exactly one/);
+  });
+});
+
+describe('authorize() accepts a minted discovery service key', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('resolves a gw_ service key and surfaces its discovery scope', async () => {
+    const rawKey = 'gw_' + 'a'.repeat(64);
+    const keyHash = createHash('sha256').update(rawKey).digest('hex');
+    mockFindUnique.mockResolvedValue({
+      id: 'key-1',
+      teamId: 'team-1',
+      ownerUserId: null,
+      connectorId: null,
+      status: 'active',
+      expiresAt: null,
+      planId: null,
+      createdBy: 'user-1',
+      allowedEndpoints: [DISCOVERY_ENDPOINT],
+      allowedIPs: [],
+      plan: null,
+    });
+
+    const request = new Request('https://naap.test' + DISCOVERY_ENDPOINT, {
+      headers: { authorization: `Bearer ${rawKey}` },
+    });
+    const auth = await authorize(request);
+
+    expect(auth).not.toBeNull();
+    expect(auth?.callerType).toBe('apiKey');
+    expect(auth?.teamId).toBe('team-1');
+    expect(keyAllowsDiscovery(auth?.allowedEndpoints)).toBe(true);
+    expect(mockFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { keyHash } }),
+    );
+  });
+});

--- a/apps/web-next/src/lib/gateway/service-key.ts
+++ b/apps/web-next/src/lib/gateway/service-key.ts
@@ -1,0 +1,99 @@
+/**
+ * Service Gateway — Discovery-scoped service keys (NAAP-4).
+ *
+ * Mints a service-level `gw_` key that the SDK service (and other infra
+ * consumers) use to reach NaaP discovery
+ * (`GET /api/v1/orchestrator-leaderboard/python-gateway`).
+ *
+ * The key is a normal `gatewayApiKey` row — `authorize()` already accepts
+ * `gw_` keys — but it is scoped to the discovery endpoint via `allowedEndpoints`.
+ * Existing keys carry an empty `allowedEndpoints` ("all endpoints"), so minting a
+ * scoped service key is purely additive and changes no existing key's behavior
+ * (zero regression). The `keyAllowsDiscovery` helper is exported for downstream
+ * scope enforcement (e.g. INFRA-2) without coupling it to the live route here.
+ */
+
+import { randomBytes, createHash } from 'crypto';
+import { prisma } from '@/lib/db';
+
+/** Canonical discovery endpoint a service key is scoped to (BPP ⑦). */
+export const DISCOVERY_ENDPOINT = '/api/v1/orchestrator-leaderboard/python-gateway';
+
+export interface MintServiceDiscoveryKeyInput {
+  /** Human-readable label for the key. */
+  name: string;
+  /** Acting user id (audit: who created the key). */
+  createdBy: string;
+  /** Team-scoped key owner. Provide exactly one of teamId / ownerUserId. */
+  teamId?: string;
+  /** Personal-scoped key owner. Provide exactly one of teamId / ownerUserId. */
+  ownerUserId?: string;
+  /** Optional extra endpoints the service key may reach, in addition to discovery. */
+  additionalEndpoints?: string[];
+  /** Optional expiry. */
+  expiresAt?: Date | null;
+}
+
+export interface MintedServiceDiscoveryKey {
+  id: string;
+  keyPrefix: string;
+  /** Raw key — returned exactly ONCE, never persisted in plaintext. */
+  rawKey: string;
+  allowedEndpoints: string[];
+}
+
+/**
+ * True when a key's `allowedEndpoints` permit the discovery endpoint.
+ *
+ * An empty allowlist means "all endpoints" (current behavior for every existing
+ * key), so it always permits discovery — keeping enforcement a no-op until a key
+ * is explicitly minted with a non-empty scope.
+ */
+export function keyAllowsDiscovery(allowedEndpoints: string[] | undefined): boolean {
+  if (!allowedEndpoints || allowedEndpoints.length === 0) return true;
+  return allowedEndpoints.includes(DISCOVERY_ENDPOINT);
+}
+
+/**
+ * Mint a service-level `gw_` key scoped to discovery for an SDK service.
+ *
+ * The scope is recorded as `allowedEndpoints`; the raw key is returned once and
+ * only its SHA-256 hash is stored.
+ */
+export async function mintServiceDiscoveryKey(
+  input: MintServiceDiscoveryKeyInput,
+): Promise<MintedServiceDiscoveryKey> {
+  const hasTeam = Boolean(input.teamId);
+  const hasOwner = Boolean(input.ownerUserId);
+  if (hasTeam === hasOwner) {
+    throw new Error('mintServiceDiscoveryKey: provide exactly one of teamId or ownerUserId');
+  }
+
+  const allowedEndpoints = Array.from(
+    new Set([DISCOVERY_ENDPOINT, ...(input.additionalEndpoints ?? [])]),
+  );
+
+  const rawKey = `gw_${randomBytes(32).toString('hex')}`;
+  const keyHash = createHash('sha256').update(rawKey).digest('hex');
+  const keyPrefix = rawKey.slice(0, 11);
+
+  const ownerData = hasTeam
+    ? { teamId: input.teamId! }
+    : { ownerUserId: input.ownerUserId! };
+
+  const created = await prisma.gatewayApiKey.create({
+    data: {
+      ...ownerData,
+      createdBy: input.createdBy,
+      name: input.name,
+      keyHash,
+      keyPrefix,
+      allowedEndpoints,
+      allowedIPs: [],
+      expiresAt: input.expiresAt ?? null,
+    },
+    select: { id: true, keyPrefix: true },
+  });
+
+  return { id: created.id, keyPrefix: created.keyPrefix, rawKey, allowedEndpoints };
+}

--- a/apps/web-next/src/lib/metrics/aggregate.test.ts
+++ b/apps/web-next/src/lib/metrics/aggregate.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Cross-provider aggregation guardrail (NAAP-2).
+ * Required by the catalog: "aggregation unit across ≥2 providers".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { aggregateSpendByProvider, type UsageRecordLike } from './aggregate';
+
+const records: UsageRecordLike[] = [
+  {
+    providerSlug: 'pymthouse',
+    accountId: 'acct_a',
+    appId: 'app_sb',
+    sessions: 10,
+    tickets: 100,
+    feeWei: '1000000000000000000',
+    networkFeeUsdMicros: '4000000',
+  },
+  {
+    providerSlug: 'pymthouse',
+    accountId: 'acct_a',
+    appId: 'app_cli',
+    sessions: 5,
+    tickets: 50,
+    feeWei: '2000000000000000000',
+    networkFeeUsdMicros: '2000000',
+  },
+  {
+    providerSlug: 'stub',
+    accountId: 'acct_b',
+    appId: 'app_sb',
+    sessions: 3,
+    tickets: 30,
+    feeWei: '500',
+    networkFeeUsdMicros: '1000',
+  },
+];
+
+describe('aggregateSpendByProvider', () => {
+  it('produces one row per provider (cross-provider spend view)', () => {
+    const rows = aggregateSpendByProvider(records);
+    expect(rows.map((r) => r.providerSlug)).toEqual(['pymthouse', 'stub']);
+  });
+
+  it('sums sessions/tickets and BigInt monetary fields per provider', () => {
+    const rows = aggregateSpendByProvider(records);
+    const pymt = rows.find((r) => r.providerSlug === 'pymthouse')!;
+    expect(pymt.sessions).toBe(15);
+    expect(pymt.tickets).toBe(150);
+    // 1e18 + 2e18 — exact via BigInt, no float loss
+    expect(pymt.feeWei).toBe('3000000000000000000');
+    expect(pymt.networkFeeUsdMicros).toBe('6000000');
+    expect(pymt.accounts).toBe(1);
+    expect(pymt.apps).toBe(2);
+
+    const stub = rows.find((r) => r.providerSlug === 'stub')!;
+    expect(stub.feeWei).toBe('500');
+    expect(stub.accounts).toBe(1);
+    expect(stub.apps).toBe(1);
+  });
+
+  it('treats missing numeric/monetary fields as zero and ignores null appId', () => {
+    const rows = aggregateSpendByProvider([
+      { providerSlug: 'stub', accountId: 'acct_x', appId: null },
+      { providerSlug: 'stub', accountId: 'acct_x', tickets: 7 },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sessions).toBe(0);
+    expect(rows[0].tickets).toBe(7);
+    expect(rows[0].feeWei).toBe('0');
+    expect(rows[0].apps).toBe(0);
+    expect(rows[0].accounts).toBe(1);
+  });
+
+  it('returns an empty view for no records', () => {
+    expect(aggregateSpendByProvider([])).toEqual([]);
+  });
+
+  it('throws on a malformed monetary value (defensive)', () => {
+    expect(() =>
+      aggregateSpendByProvider([
+        { providerSlug: 'stub', accountId: 'a', feeWei: 'not-a-number' },
+      ]),
+    ).toThrow(/non-decimal/);
+  });
+});

--- a/apps/web-next/src/lib/metrics/aggregate.ts
+++ b/apps/web-next/src/lib/metrics/aggregate.ts
@@ -1,0 +1,94 @@
+/**
+ * Cross-provider usage aggregation (NAAP-2).
+ *
+ * Aggregates ingested BPP ⑥ usage records into a spend view keyed by provider
+ * (the "provider column"), so a dashboard can show spend across ANY number of
+ * billing providers side by side. Pure, DB-free logic for unit testing.
+ *
+ * Monetary fields (`feeWei`, `networkFeeUsdMicros`) are decimal strings of
+ * unbounded magnitude; sums use BigInt to avoid float precision loss.
+ */
+
+/** Minimal shape of a stored/ingested usage record needed for aggregation. */
+export interface UsageRecordLike {
+  providerSlug: string;
+  accountId: string;
+  appId?: string | null;
+  sessions?: number | null;
+  tickets?: number | null;
+  feeWei?: string | null;
+  networkFeeUsdMicros?: string | null;
+}
+
+/** One row of the cross-provider spend view. */
+export interface ProviderSpendRow {
+  providerSlug: string;
+  sessions: number;
+  tickets: number;
+  /** Decimal wei string (BigInt sum). */
+  feeWei: string;
+  /** Decimal USD-micros string (BigInt sum). */
+  networkFeeUsdMicros: string;
+  /** Distinct accounts seen for this provider. */
+  accounts: number;
+  /** Distinct apps seen for this provider (excludes records with no appId). */
+  apps: number;
+}
+
+function addDecimal(acc: bigint, value: string | null | undefined): bigint {
+  if (!value) return acc;
+  if (!/^[0-9]+$/.test(value)) {
+    throw new Error(`aggregate: non-decimal monetary value "${value}"`);
+  }
+  return acc + BigInt(value);
+}
+
+interface Accumulator {
+  sessions: number;
+  tickets: number;
+  feeWei: bigint;
+  networkFeeUsdMicros: bigint;
+  accounts: Set<string>;
+  apps: Set<string>;
+}
+
+/**
+ * Aggregate usage records into one row per provider, sorted by provider slug for
+ * stable output. Works for ≥1 providers (cross-provider when ≥2).
+ */
+export function aggregateSpendByProvider(records: UsageRecordLike[]): ProviderSpendRow[] {
+  const byProvider = new Map<string, Accumulator>();
+
+  for (const r of records) {
+    let acc = byProvider.get(r.providerSlug);
+    if (!acc) {
+      acc = {
+        sessions: 0,
+        tickets: 0,
+        feeWei: 0n,
+        networkFeeUsdMicros: 0n,
+        accounts: new Set(),
+        apps: new Set(),
+      };
+      byProvider.set(r.providerSlug, acc);
+    }
+    acc.sessions += r.sessions ?? 0;
+    acc.tickets += r.tickets ?? 0;
+    acc.feeWei = addDecimal(acc.feeWei, r.feeWei);
+    acc.networkFeeUsdMicros = addDecimal(acc.networkFeeUsdMicros, r.networkFeeUsdMicros);
+    acc.accounts.add(r.accountId);
+    if (r.appId) acc.apps.add(r.appId);
+  }
+
+  return [...byProvider.entries()]
+    .map(([providerSlug, acc]) => ({
+      providerSlug,
+      sessions: acc.sessions,
+      tickets: acc.tickets,
+      feeWei: acc.feeWei.toString(),
+      networkFeeUsdMicros: acc.networkFeeUsdMicros.toString(),
+      accounts: acc.accounts.size,
+      apps: acc.apps.size,
+    }))
+    .sort((a, b) => a.providerSlug.localeCompare(b.providerSlug));
+}

--- a/apps/web-next/src/lib/metrics/flags.ts
+++ b/apps/web-next/src/lib/metrics/flags.ts
@@ -1,0 +1,6 @@
+/**
+ * Feature flags for cross-provider usage telemetry (NAAP-2).
+ */
+
+/** Gates the usage ingest endpoint + cross-provider dashboard BFF (default OFF). */
+export const USAGE_INGEST_FLAG = 'usage_ingest';

--- a/apps/web-next/src/lib/metrics/usage-ingest.test.ts
+++ b/apps/web-next/src/lib/metrics/usage-ingest.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Contract + seam-isolation tests for BPP ⑥ usage ingest (NAAP-2).
+ *
+ * The "contract test for ingest payload" required by the catalog:
+ *  - sample payloads that pass the C0 JSON Schema also pass the runtime parser
+ *    (and vice-versa), so the runtime never drifts from the contract;
+ *  - provider-internal field names (⑨) are rejected on the seam, and the
+ *    runtime FORBIDDEN list stays a superset of the contract's.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  compileAllSchemas,
+  getForbiddenInternalFieldNames,
+} from '@/lib/billing/bpp/conformance';
+import {
+  FORBIDDEN_INTERNAL_FIELDS,
+  findLeakedInternalFields,
+  parseUsageIngest,
+} from './usage-ingest';
+
+const schemaValidate = compileAllSchemas()['usage-ingest.schema.json'];
+
+const validPayload = {
+  providerSlug: 'pymthouse',
+  accountId: 'acct_123',
+  appId: 'app_sb',
+  window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+  sessions: 12,
+  tickets: 340,
+  feeWei: '1000000000000000',
+  networkFeeUsdMicros: '4200000',
+  byCapability: {
+    'text-to-image:sdxl': { tickets: 300, networkFeeUsdMicros: '4000000' },
+  },
+};
+
+describe('usage ingest — contract conformance', () => {
+  it('a payload valid under the runtime parser is valid under the C0 schema', () => {
+    const parsed = parseUsageIngest(validPayload);
+    expect(parsed.ok).toBe(true);
+    expect(schemaValidate(validPayload)).toBe(true);
+  });
+
+  it('the minimal required payload (providerSlug, accountId, window) conforms both ways', () => {
+    const minimal = {
+      providerSlug: 'stub',
+      accountId: 'acct_min',
+      window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-02T00:00:00.000Z' },
+    };
+    expect(parseUsageIngest(minimal).ok).toBe(true);
+    expect(schemaValidate(minimal)).toBe(true);
+  });
+
+  it('rejects unknown top-level fields both ways (strict / additionalProperties:false)', () => {
+    const withExtra = { ...validPayload, somethingExtra: true };
+    expect(schemaValidate(withExtra)).toBe(false);
+    const parsed = parseUsageIngest(withExtra);
+    expect(parsed.ok).toBe(false);
+  });
+
+  it('rejects a missing required field both ways', () => {
+    const { accountId, ...noAccount } = validPayload;
+    void accountId;
+    expect(schemaValidate(noAccount)).toBe(false);
+    expect(parseUsageIngest(noAccount).ok).toBe(false);
+  });
+});
+
+describe('usage ingest — seam isolation (⑨ must not leak)', () => {
+  it('runtime FORBIDDEN list is a superset of the contract list', () => {
+    const contractList = getForbiddenInternalFieldNames();
+    for (const name of contractList) {
+      expect(FORBIDDEN_INTERNAL_FIELDS).toContain(name);
+    }
+  });
+
+  it('detects provider-internal field names anywhere in the payload', () => {
+    expect(findLeakedInternalFields({ openmeter_subscription_id: 'x' })).toContain(
+      'openmeter_subscription_id',
+    );
+    expect(
+      findLeakedInternalFields({ data: { nested: { network_fee_usd_micros: '1' } } }),
+    ).toContain('network_fee_usd_micros');
+  });
+
+  it('rejects a leaked-field payload before shape validation', () => {
+    const leaky = { ...validPayload, openmeter_subscription_id: '01J...' };
+    const parsed = parseUsageIngest(leaky);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok && parsed.reason === 'leaked_internal_fields') {
+      expect(parsed.leaked).toContain('openmeter_subscription_id');
+    } else {
+      throw new Error('expected leaked_internal_fields rejection');
+    }
+  });
+});

--- a/apps/web-next/src/lib/metrics/usage-ingest.ts
+++ b/apps/web-next/src/lib/metrics/usage-ingest.ts
@@ -1,0 +1,106 @@
+/**
+ * BPP ⑥ usage ingest — runtime validation + seam isolation (NAAP-2).
+ *
+ * Providers push a NEUTRAL usage payload to
+ * `POST {NAAP_METRICS_URL}/api/v1/metrics/ingest`. This is the authoritative
+ * cross-provider usage path (NOT `validate`). NaaP must never learn about a
+ * provider's internal metering (e.g. OpenMeter): provider-internal field names
+ * (BPP ⑨) must never appear on this seam.
+ *
+ * The zod schema mirrors `contracts/billing-provider-protocol/usage-ingest.schema.json`
+ * (the C0 contract); a conformance test asserts they stay in sync.
+ */
+
+import { z } from 'zod';
+
+const decimalString = z.string().regex(/^[0-9]+$/, 'must be a non-negative integer string');
+
+const capabilityUsageSchema = z
+  .object({
+    tickets: z.number().int().min(0).optional(),
+    networkFeeUsdMicros: decimalString.optional(),
+  })
+  .strict();
+
+/** Neutral usage payload (BPP ⑥). `additionalProperties: false` → `.strict()`. */
+export const usageIngestSchema = z
+  .object({
+    providerSlug: z.string().min(1),
+    accountId: z.string().min(1),
+    appId: z.string().min(1).optional(),
+    window: z
+      .object({
+        from: z.string().datetime({ offset: true }),
+        to: z.string().datetime({ offset: true }),
+      })
+      .strict(),
+    sessions: z.number().int().min(0).optional(),
+    tickets: z.number().int().min(0).optional(),
+    feeWei: decimalString.optional(),
+    networkFeeUsdMicros: decimalString.optional(),
+    byCapability: z.record(z.string(), capabilityUsageSchema).optional(),
+  })
+  .strict();
+
+export type UsageIngestPayload = z.infer<typeof usageIngestSchema>;
+
+/**
+ * Provider-internal field names that MUST NOT leak through the BPP seam (⑨).
+ * Kept in sync with `provider-internal-openmeter.schema.json`'s
+ * `x-bpp-forbidden-field-names` (asserted by the conformance test).
+ */
+export const FORBIDDEN_INTERNAL_FIELDS: readonly string[] = [
+  'openmeter_subscription_id',
+  'openmeter_customer_id',
+  'network_fee_usd_micros',
+  'fee_wei',
+  'eth_usd_price',
+  'eth_usd_round_id',
+  'eth_usd_observed_at',
+  'external_user_id',
+  'client_id',
+  'model_id',
+  'gateway_request_id',
+  'specversion',
+];
+
+const FORBIDDEN_SET = new Set(FORBIDDEN_INTERNAL_FIELDS);
+
+/** Recursively collect any provider-internal field names present in the payload. */
+export function findLeakedInternalFields(value: unknown, acc: Set<string> = new Set()): string[] {
+  if (Array.isArray(value)) {
+    for (const item of value) findLeakedInternalFields(item, acc);
+  } else if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (FORBIDDEN_SET.has(key)) acc.add(key);
+      findLeakedInternalFields(child, acc);
+    }
+  }
+  return [...acc];
+}
+
+export type ParseUsageIngestResult =
+  | { ok: true; data: UsageIngestPayload }
+  | { ok: false; reason: 'leaked_internal_fields'; leaked: string[] }
+  | { ok: false; reason: 'invalid'; errors: Record<string, string> };
+
+/**
+ * Validate a raw ingest payload: reject provider-internal leaks first (seam
+ * isolation), then validate the neutral shape.
+ */
+export function parseUsageIngest(payload: unknown): ParseUsageIngestResult {
+  const leaked = findLeakedInternalFields(payload);
+  if (leaked.length > 0) {
+    return { ok: false, reason: 'leaked_internal_fields', leaked };
+  }
+
+  const parsed = usageIngestSchema.safeParse(payload);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      errors: Object.fromEntries(parsed.error.errors.map((e) => [e.path.join('.'), e.message])),
+    };
+  }
+  return { ok: true, data: parsed.data };
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/static-fleet.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/static-fleet.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { mergeStaticFleet, staticFleetGaps } from '../static-fleet';
+
+describe('mergeStaticFleet', () => {
+  it('keeps discovered order first, appends only missing static fallbacks', () => {
+    const merged = mergeStaticFleet(
+      ['https://a:8935', 'https://b:8935'],
+      ['https://b:8935', 'https://c:8935'],
+    );
+    expect(merged).toEqual(['https://a:8935', 'https://b:8935', 'https://c:8935']);
+  });
+
+  it('de-duplicates and trims (first occurrence wins)', () => {
+    const merged = mergeStaticFleet([' https://a:8935 ', 'https://a:8935'], ['https://a:8935', '']);
+    expect(merged).toEqual(['https://a:8935']);
+  });
+
+  it('returns the full static fleet when nothing was discovered (fallback)', () => {
+    const merged = mergeStaticFleet([], ['https://x:8935', 'https://y:8935']);
+    expect(merged).toEqual(['https://x:8935', 'https://y:8935']);
+  });
+});
+
+describe('staticFleetGaps', () => {
+  it('reports static fallbacks missing from the discovered set', () => {
+    expect(
+      staticFleetGaps(['https://a:8935'], ['https://a:8935', 'https://b:8935', 'https://b:8935']),
+    ).toEqual(['https://b:8935']);
+  });
+
+  it('reports no gaps when the discovered set already covers the fleet', () => {
+    expect(staticFleetGaps(['https://a:8935', 'https://b:8935'], ['https://a:8935'])).toEqual([]);
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.test.ts
@@ -4,6 +4,7 @@ import {
   effectiveDiscoveryTierCount,
   tierIndexRanges,
   tieredShuffleDiscoveryAddresses,
+  tieredShuffleWithStaticFallback,
 } from './discovery-order';
 
 describe('effectiveDiscoveryTierCount', () => {
@@ -69,5 +70,23 @@ describe('tieredShuffleDiscoveryAddresses', () => {
     });
     expect(new Set(out)).toEqual(new Set(input));
     expect(out).not.toEqual(input);
+  });
+});
+
+describe('tieredShuffleWithStaticFallback', () => {
+  it('includes static fallback addresses missing from the discovered set', () => {
+    const out = tieredShuffleWithStaticFallback(
+      ['https://a', 'https://b'],
+      ['https://b', 'https://c'],
+      { random: () => 0.999999 },
+    );
+    expect(new Set(out)).toEqual(new Set(['https://a', 'https://b', 'https://c']));
+  });
+
+  it('returns the static fleet when discovery is empty (fallback joins the shuffle)', () => {
+    const out = tieredShuffleWithStaticFallback([], ['https://x', 'https://y'], {
+      random: () => 0,
+    });
+    expect(new Set(out)).toEqual(new Set(['https://x', 'https://y']));
   });
 });

--- a/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/discovery-order.ts
@@ -93,3 +93,19 @@ export function tieredShuffleDiscoveryAddresses(
 
   return unique;
 }
+
+/**
+ * Tiered shuffle where a static-fleet fallback joins the shuffle (NAAP-9).
+ *
+ * Live-ranked `discovered` addresses keep their order and are tiered first;
+ * `staticFallback` addresses not already discovered are appended so they land
+ * in the lowest tier — present (never silently dropped) but not displacing
+ * live-ranked orchestrators. De-duplication is first-occurrence wins.
+ */
+export function tieredShuffleWithStaticFallback(
+  discovered: string[],
+  staticFallback: string[],
+  options?: TieredShuffleDiscoveryOptions,
+): string[] {
+  return tieredShuffleDiscoveryAddresses([...discovered, ...staticFallback], options);
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/static-fleet.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/static-fleet.ts
@@ -1,0 +1,68 @@
+/**
+ * NAAP-9 — Static-fleet fallback.
+ *
+ * ClickHouse discovery (`semantic.network_capabilities`, warm rows in the last
+ * hour) silently drops orchestrators that lack warm rows for a requested
+ * capability — e.g. the scope staging orchs (`orch-staging-1/2/3`) when they
+ * have no warm `scope` rows. The static fleet is the known-good fallback set
+ * (mirrors `simple-infra/discovery/staging.json` + `fleet.yaml`, plus the BYOC
+ * tool host) so the Daydream→NaaP switch never loses an orchestrator.
+ *
+ * The static fleet is a property of the PLAN (provider-agnostic), not of
+ * Storyboard. The addresses come from each plan category's `staticOrchestrators`.
+ */
+
+/** Normalize an address: trim and drop empties. */
+function normalizeAddress(raw: string): string {
+  return raw.trim();
+}
+
+/**
+ * Merge a discovered, ranked address list with a static-fleet fallback.
+ *
+ * Discovered addresses keep their (ranked) order and come first; static-fleet
+ * addresses not already discovered are appended (so they land in the lowest
+ * tier of the subsequent tier shuffle, never displacing live-ranked orchs).
+ * The result is de-duplicated, first-occurrence wins.
+ */
+export function mergeStaticFleet(
+  discovered: readonly string[],
+  staticFallback: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const raw of [...discovered, ...staticFallback]) {
+    const address = normalizeAddress(raw);
+    if (!address || seen.has(address)) {
+      continue;
+    }
+    seen.add(address);
+    merged.push(address);
+  }
+
+  return merged;
+}
+
+/**
+ * Returns the static-fleet addresses that are MISSING from the discovered set.
+ * Useful for structured logging (how many fallbacks were injected) without
+ * leaking the full address list.
+ */
+export function staticFleetGaps(
+  discovered: readonly string[],
+  staticFallback: readonly string[],
+): string[] {
+  const discoveredSet = new Set(discovered.map(normalizeAddress).filter(Boolean));
+  const gaps: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of staticFallback) {
+    const address = normalizeAddress(raw);
+    if (!address || discoveredSet.has(address) || seen.has(address)) {
+      continue;
+    }
+    seen.add(address);
+    gaps.push(address);
+  }
+  return gaps;
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
@@ -1,0 +1,202 @@
+/**
+ * NAAP-9 — Storyboard Default discovery builder.
+ *
+ * Pure(ish) orchestration of the default plan: union ClickHouse results across
+ * each category's capabilities, merge the static-fleet fallback per category,
+ * apply the provider denylist (pymthouse only), dedupe, and tier-shuffle into
+ * the bare `[{ address }]` discovery payload.
+ *
+ * The fetch step is injected (`fetchCapabilityAddresses`) so this module stays
+ * unit-testable without ClickHouse and so the golden-set parity test can mock
+ * the leaderboard per capability.
+ */
+
+import {
+  STORYBOARD_DEFAULT_CATEGORY_KEYS,
+  STORYBOARD_DEFAULT_PLAN,
+  type StoryboardDefaultCategory,
+  type StoryboardDefaultCategoryKey,
+  type StoryboardDefaultPlan,
+} from './storyboard-default-plan';
+import { mergeStaticFleet, staticFleetGaps } from './static-fleet';
+import {
+  tieredShuffleDiscoveryAddresses,
+  tieredShuffleWithStaticFallback,
+  type RandomSource,
+} from './discovery-order';
+import { isCapabilityAllowedForProvider } from './provider-restrictions';
+
+/** Result of fetching one capability's ranked orchestrators. */
+export interface CapabilityFetchResult {
+  addresses: string[];
+  fromCache: boolean;
+  cachedAt: number;
+}
+
+export type FetchCapabilityAddresses = (
+  leaderboardCap: string,
+) => Promise<CapabilityFetchResult>;
+
+export interface StoryboardDefaultByKind {
+  /** Scope ORCHESTRATOR addresses (identity matters): live + static fleet. */
+  scope: string[];
+  /** BYOC CAPABILITIES included after the provider denylist. */
+  byoc: string[];
+  /** Tool CAPABILITIES included after the provider denylist. */
+  tool: string[];
+}
+
+export interface StoryboardDefaultDiscoveryResult {
+  /** Flattened, tier-shuffled discovery payload addresses. */
+  addresses: string[];
+  byKind: StoryboardDefaultByKind;
+  meta: {
+    fromCache: boolean;
+    cacheAgeMs: number;
+    staticFleetInjected: number;
+  };
+}
+
+export interface BuildStoryboardDefaultDiscoveryArgs {
+  fetchCapabilityAddresses: FetchCapabilityAddresses;
+  /** Resolved billing provider slug; pymthouse triggers the denylist. */
+  billingProviderSlug?: string | null;
+  plan?: StoryboardDefaultPlan;
+  topN?: number;
+  random?: RandomSource;
+}
+
+/** Split a full cap path into the short leaderboard capability (after `/`). */
+function leaderboardCapFromPath(raw: string): string {
+  const value = raw.trim();
+  const slash = value.lastIndexOf('/');
+  return slash >= 0 ? value.slice(slash + 1).trim() : value;
+}
+
+/**
+ * Collect live, ranked addresses for a category's capabilities, honoring the
+ * provider denylist. Returns the discovered addresses plus the list of caps
+ * that were actually queried (provider-allowed).
+ */
+async function collectCategory(
+  category: StoryboardDefaultCategory,
+  billingProviderSlug: string | null | undefined,
+  fetchCapabilityAddresses: FetchCapabilityAddresses,
+  topN: number,
+): Promise<{
+  discovered: string[];
+  allowedCapabilities: string[];
+  fromCache: boolean;
+  cacheAgeMs: number;
+}> {
+  const discovered: string[] = [];
+  const seen = new Set<string>();
+  const allowedCapabilities: string[] = [];
+  let fromCache = true;
+  let cacheAgeMs = 0;
+
+  for (const raw of category.capabilities) {
+    if (!isCapabilityAllowedForProvider(raw, billingProviderSlug)) {
+      continue;
+    }
+    allowedCapabilities.push(raw);
+
+    const leaderboardCap = leaderboardCapFromPath(raw);
+    const result = await fetchCapabilityAddresses(leaderboardCap);
+    fromCache = fromCache && result.fromCache;
+    cacheAgeMs = Math.max(cacheAgeMs, Date.now() - result.cachedAt);
+
+    for (const addr of result.addresses) {
+      const address = addr.trim();
+      if (!address || seen.has(address)) {
+        continue;
+      }
+      seen.add(address);
+      discovered.push(address);
+      if (discovered.length >= topN) {
+        break;
+      }
+    }
+    if (discovered.length >= topN) {
+      break;
+    }
+  }
+
+  return { discovered, allowedCapabilities, fromCache, cacheAgeMs };
+}
+
+/**
+ * Build the Storyboard Default discovery bundle.
+ *
+ * - scope: live + static-fleet merge (static fleet joins the tier shuffle),
+ *   guaranteeing all known staging orchs (incl. orch-staging-3) are present.
+ * - byoc/tool: union of live results across caps + their static fleet.
+ * - provider denylist applied only when `billingProviderSlug === 'pymthouse'`.
+ */
+export async function buildStoryboardDefaultDiscovery(
+  args: BuildStoryboardDefaultDiscoveryArgs,
+): Promise<StoryboardDefaultDiscoveryResult> {
+  const plan = args.plan ?? STORYBOARD_DEFAULT_PLAN;
+  const topN = args.topN ?? plan.topN;
+  const random = args.random;
+  const provider = args.billingProviderSlug ?? null;
+
+  let fromCache = true;
+  let cacheAgeMs = 0;
+  let staticFleetInjected = 0;
+
+  const perCategoryAddresses: Record<StoryboardDefaultCategoryKey, string[]> = {
+    scope: [],
+    byoc: [],
+    tool: [],
+  };
+  const byKind: StoryboardDefaultByKind = { scope: [], byoc: [], tool: [] };
+
+  for (const key of STORYBOARD_DEFAULT_CATEGORY_KEYS) {
+    const category = plan[key];
+    const collected = await collectCategory(
+      category,
+      provider,
+      args.fetchCapabilityAddresses,
+      topN,
+    );
+    fromCache = fromCache && collected.fromCache;
+    cacheAgeMs = Math.max(cacheAgeMs, collected.cacheAgeMs);
+
+    const staticFleet = [...category.staticOrchestrators];
+    staticFleetInjected += staticFleetGaps(collected.discovered, staticFleet).length;
+
+    const merged = mergeStaticFleet(collected.discovered, staticFleet);
+    perCategoryAddresses[key] = merged;
+
+    if (key === 'scope') {
+      // Scope identity matters: report the merged orchestrator addresses.
+      byKind.scope = merged;
+    } else {
+      // byoc/tool: the capability set that was included is what parity checks.
+      byKind[key] = collected.allowedCapabilities;
+    }
+  }
+
+  // Scope addresses get static fleet shuffled in; flatten all categories.
+  const scopeShuffled = tieredShuffleWithStaticFallback(
+    perCategoryAddresses.scope,
+    [],
+    random ? { random } : undefined,
+  );
+  const flattened = [
+    ...scopeShuffled,
+    ...perCategoryAddresses.byoc,
+    ...perCategoryAddresses.tool,
+  ];
+  const addresses = tieredShuffleDiscoveryAddresses(
+    flattened,
+    random ? { random } : undefined,
+  );
+
+  return {
+    addresses,
+    byKind,
+    meta: { fromCache, cacheAgeMs, staticFleetInjected },
+  };
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
@@ -1,0 +1,123 @@
+/**
+ * NAAP-9 — Storyboard Default discovery bundle (Daydream parity).
+ *
+ * The DEFAULT PLAN: the concrete instance of the generic capability gate
+ * (NAAP-E). It guarantees a non-disruptive switch from the live Daydream
+ * discovery path to NaaP discovery by returning ⊇ the orchestrator/capability
+ * set Storyboard's MCP currently uses (scope staging + BYOC + tool), with a
+ * static-fleet fallback merged into the tier shuffle so no orchestrator is
+ * silently dropped when ClickHouse lacks warm rows.
+ *
+ * The byoc/tool capability arrays and static orchestrators below are the
+ * committed-staging BASELINE. Per Decision D7 they MUST be reconciled at build
+ * time against the live `sdk.daydream.monster/capabilities` snapshot (the
+ * golden set) — they are not authoritative on their own. The golden-set parity
+ * test guards drift in both directions.
+ *
+ * Everything here is generic: `storyboard-default` is just the first plan to
+ * ride the capability gate; the static-fleet fallback is a property of the
+ * plan, not of Storyboard.
+ */
+
+export const STORYBOARD_DEFAULT_PLAN_ID = 'storyboard-default';
+
+/** Env flag gating the bundle. Default OFF → existing per-cap behavior. */
+export const STORYBOARD_DEFAULT_DISCOVERY_FLAG = 'STORYBOARD_DEFAULT_DISCOVERY_ENABLED';
+
+export interface StoryboardDefaultCategory {
+  /** Leaderboard capability ids queried for this category. */
+  readonly capabilities: readonly string[];
+  /** Static-fleet fallback orchestrator addresses for this category. */
+  readonly staticOrchestrators: readonly string[];
+}
+
+export interface StoryboardDefaultPlan {
+  readonly id: string;
+  readonly name: string;
+  /** No pymthouse denylist until a real provider plan (PYMT-5) enforces. */
+  readonly billingProviderSlug: string;
+  readonly scope: StoryboardDefaultCategory;
+  readonly byoc: StoryboardDefaultCategory;
+  readonly tool: StoryboardDefaultCategory;
+  readonly topN: number;
+}
+
+export const STORYBOARD_DEFAULT_PLAN: StoryboardDefaultPlan = {
+  id: STORYBOARD_DEFAULT_PLAN_ID,
+  name: 'Storyboard Default (Daydream parity)',
+  billingProviderSlug: 'daydream',
+  scope: {
+    capabilities: ['live-video-to-video/scope'],
+    staticOrchestrators: [
+      'https://orch-staging-1.daydream.monster:8935',
+      'https://orch-staging-2.daydream.monster:8935',
+      'https://orch-staging-3.daydream.monster:8935',
+    ],
+  },
+  byoc: {
+    capabilities: [
+      'nano-banana',
+      'recraft-v4',
+      'flux-schnell',
+      'flux-dev',
+      'ltx-t2v',
+      'ltx-i2v',
+      'kontext-edit',
+      'bg-remove',
+      'topaz-upscale',
+      'chatterbox-tts',
+      'gemini-image',
+      'gemini-text',
+    ],
+    staticOrchestrators: ['https://byoc-staging-1.daydream.monster:8935'],
+  },
+  tool: {
+    capabilities: [
+      'ffmpeg-concat',
+      'ffmpeg-trim',
+      'ffmpeg-overlay',
+      'ffmpeg-export',
+      'ffmpeg-audio-mix',
+      'ffmpeg-loop',
+      'ffmpeg-burn-subtitles',
+      'ffmpeg-grid',
+      'ffmpeg-mux',
+      'pillow-resize',
+      'pillow-watermark',
+      'pillow-format',
+      'pillow-palette',
+      'pillow-grid',
+      'obscura-extract-text',
+      'obscura-extract-markdown',
+      'obscura-extract-links',
+      'hyperframes-caption',
+      'hyperframes-lower-third',
+      'hyperframes-render',
+      'yolo-detect',
+      'yolo-segment',
+      'cad-render',
+      'cad-validate',
+    ],
+    staticOrchestrators: ['https://byoc-staging-1.daydream.monster:8935'],
+  },
+  topN: 100,
+} as const;
+
+export type StoryboardDefaultCategoryKey = 'scope' | 'byoc' | 'tool';
+
+export const STORYBOARD_DEFAULT_CATEGORY_KEYS: readonly StoryboardDefaultCategoryKey[] = [
+  'scope',
+  'byoc',
+  'tool',
+];
+
+/**
+ * Reads the feature flag. Default OFF: any value other than a truthy string
+ * (`"true"`/`"1"`) leaves the Daydream path authoritative.
+ */
+export function isStoryboardDefaultDiscoveryEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env[STORYBOARD_DEFAULT_DISCOVERY_FLAG]?.trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}

--- a/apps/web-next/src/lib/teams/billing-account-ref.test.ts
+++ b/apps/web-next/src/lib/teams/billing-account-ref.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  isBoundProviderConfigured,
+  isProviderResolvable,
+  normalizeBillingAccountRef,
+  teamBillingAccountRef,
+} from './billing-account-ref';
+
+describe('normalizeBillingAccountRef', () => {
+  it('normalizes a valid ref (lowercases slug, trims)', () => {
+    expect(normalizeBillingAccountRef({ providerSlug: ' Pymthouse ', accountId: ' acct_1 ' })).toEqual({
+      providerSlug: 'pymthouse',
+      accountId: 'acct_1',
+    });
+  });
+  it('rejects non-object / missing fields', () => {
+    expect(normalizeBillingAccountRef(null)).toBeNull();
+    expect(normalizeBillingAccountRef('x')).toBeNull();
+    expect(normalizeBillingAccountRef({ providerSlug: 'pymthouse' })).toBeNull();
+    expect(normalizeBillingAccountRef({ accountId: 'a' })).toBeNull();
+  });
+  it('rejects invalid slug or empty/oversized accountId', () => {
+    expect(normalizeBillingAccountRef({ providerSlug: 'Bad_Slug', accountId: 'a' })).toBeNull();
+    expect(normalizeBillingAccountRef({ providerSlug: 'ok', accountId: '' })).toBeNull();
+    expect(normalizeBillingAccountRef({ providerSlug: 'ok', accountId: 'x'.repeat(257) })).toBeNull();
+  });
+});
+
+describe('isProviderResolvable — uses the NAAP-A adapter registry', () => {
+  it('resolves registered providers (pymthouse AND the C0 stub)', () => {
+    expect(isProviderResolvable({ providerSlug: 'pymthouse', accountId: 'a' })).toBe(true);
+    expect(isProviderResolvable({ providerSlug: 'stub', accountId: 'a' })).toBe(true);
+  });
+  it('rejects an unknown provider (stays generic)', () => {
+    expect(isProviderResolvable({ providerSlug: 'nope', accountId: 'a' })).toBe(false);
+  });
+});
+
+describe('isBoundProviderConfigured', () => {
+  it('is true for the in-memory stub adapter', () => {
+    expect(isBoundProviderConfigured({ providerSlug: 'stub', accountId: 'a' })).toBe(true);
+  });
+  it('is false for an unknown provider', () => {
+    expect(isBoundProviderConfigured({ providerSlug: 'nope', accountId: 'a' })).toBe(false);
+  });
+});
+
+describe('teamBillingAccountRef', () => {
+  it('reads a fully-bound team', () => {
+    expect(
+      teamBillingAccountRef({
+        id: 't1',
+        billingAccountProviderSlug: 'pymthouse',
+        billingAccountId: 'acct_1',
+      }),
+    ).toEqual({ providerSlug: 'pymthouse', accountId: 'acct_1' });
+  });
+  it('treats a partial binding as unbound', () => {
+    expect(
+      teamBillingAccountRef({ id: 't1', billingAccountProviderSlug: 'pymthouse', billingAccountId: null }),
+    ).toBeNull();
+    expect(
+      teamBillingAccountRef({ id: 't1', billingAccountProviderSlug: null, billingAccountId: 'acct_1' }),
+    ).toBeNull();
+  });
+});

--- a/apps/web-next/src/lib/teams/billing-account-ref.ts
+++ b/apps/web-next/src/lib/teams/billing-account-ref.ts
@@ -1,0 +1,94 @@
+/**
+ * Provider-agnostic billing-account reference (NAAP-1).
+ *
+ * A NaaP team binds to exactly ONE billing account through a provider-agnostic
+ * pointer — the BPP `billingAccountRef`:
+ *
+ *     billingAccountRef = { providerSlug, accountId }
+ *
+ * `providerSlug` selects a `BillingProviderAdapter` from the registry (NAAP-A);
+ * `accountId` is the provider's OWN opaque customer/subscription id (e.g. an
+ * OpenMeter customer id behind the pymthouse adapter). NaaP never interprets
+ * `accountId` — it is resolved back through the adapter. This module is
+ * DB-free so the binding rules can be unit-tested in isolation.
+ *
+ * IMPORTANT (Decision D2): there is NO separate NaaP-side billing-account
+ * entity (PYMT-1 is retired). The team row stores the ref directly and the
+ * provider owns the account.
+ */
+
+import {
+  getBillingProviderAdapter,
+  hasBillingProviderAdapter,
+} from '@/lib/billing/registry';
+
+/** Feature flag gating the team-seats + billing-account-binding surface (default OFF). */
+export const TEAM_SEATS_FLAG = 'team_seats';
+
+/** Provider-agnostic pointer to the paying account (BPP ⑤ `billingAccountRef`). */
+export interface BillingAccountRef {
+  providerSlug: string;
+  accountId: string;
+}
+
+/** Lowercase slug, 1–63 chars; mirrors the generic billing route's slug rule. */
+const PROVIDER_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+/** Defensive upper bound on the opaque provider account id. */
+const MAX_ACCOUNT_ID_LEN = 256;
+
+/**
+ * Validate + normalize a raw billing-account-ref payload. Returns the trimmed
+ * ref, or `null` when the shape is invalid. Does NOT check adapter
+ * registration — call {@link isProviderResolvable} for that.
+ */
+export function normalizeBillingAccountRef(input: unknown): BillingAccountRef | null {
+  if (!input || typeof input !== 'object') return null;
+  const { providerSlug, accountId } = input as Record<string, unknown>;
+  if (typeof providerSlug !== 'string' || typeof accountId !== 'string') return null;
+
+  const slug = providerSlug.trim().toLowerCase();
+  const id = accountId.trim();
+  if (!PROVIDER_SLUG_RE.test(slug)) return null;
+  if (id.length === 0 || id.length > MAX_ACCOUNT_ID_LEN) return null;
+
+  return { providerSlug: slug, accountId: id };
+}
+
+/**
+ * True when the ref's provider has a registered adapter (NAAP-A) — the binding
+ * is resolvable. Keeps NaaP generic: any provider with an adapter (pymthouse,
+ * the C0 stub, …) is bindable; an unknown provider is rejected.
+ */
+export function isProviderResolvable(ref: BillingAccountRef): boolean {
+  return hasBillingProviderAdapter(ref.providerSlug);
+}
+
+/** Minimal team shape needed to read its binding (subset of the Prisma row). */
+export interface TeamBillingBinding {
+  id: string;
+  billingAccountProviderSlug: string | null;
+  billingAccountId: string | null;
+}
+
+/**
+ * Read a team's `billingAccountRef`, or `null` when the team is unbound.
+ * A partially-populated binding (one column set, the other null) is treated as
+ * unbound — the API only ever writes both columns together.
+ */
+export function teamBillingAccountRef(team: TeamBillingBinding): BillingAccountRef | null {
+  const slug = team.billingAccountProviderSlug?.trim().toLowerCase();
+  const id = team.billingAccountId?.trim();
+  if (!slug || !id) return null;
+  return { providerSlug: slug, accountId: id };
+}
+
+/**
+ * Whether the bound provider is currently configured to serve requests. Used to
+ * fail safe / surface a clear error when a team is bound to a provider whose
+ * adapter lacks configuration (lag tolerance, D6).
+ */
+export function isBoundProviderConfigured(ref: BillingAccountRef): boolean {
+  const adapter = getBillingProviderAdapter(ref.providerSlug);
+  return Boolean(adapter?.isConfigured());
+}

--- a/apps/web-next/src/lib/teams/seats.test.ts
+++ b/apps/web-next/src/lib/teams/seats.test.ts
@@ -1,0 +1,113 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_SEAT_KEY_LIMIT,
+  MAX_SEAT_KEY_LIMIT,
+  allSeatsResolveToSingleRef,
+  isSeatRole,
+  isSeatStatus,
+  normalizeKeyLimit,
+  resolveSeatBillingAccountRef,
+  seatCanMintKey,
+} from './seats';
+import type { TeamBillingBinding } from './billing-account-ref';
+
+const boundTeam: TeamBillingBinding = {
+  id: 'team-1',
+  billingAccountProviderSlug: 'pymthouse',
+  billingAccountId: 'acct_om_123',
+};
+
+const stubTeam: TeamBillingBinding = {
+  id: 'team-2',
+  billingAccountProviderSlug: 'stub',
+  billingAccountId: 'acct_stub_1',
+};
+
+const unboundTeam: TeamBillingBinding = {
+  id: 'team-3',
+  billingAccountProviderSlug: null,
+  billingAccountId: null,
+};
+
+describe('seat role/status guards', () => {
+  it('accepts known roles and statuses', () => {
+    expect(isSeatRole('admin')).toBe(true);
+    expect(isSeatRole('member')).toBe(true);
+    expect(isSeatRole('viewer')).toBe(true);
+    expect(isSeatRole('owner')).toBe(false);
+    expect(isSeatStatus('active')).toBe(true);
+    expect(isSeatStatus('pending')).toBe(true);
+    expect(isSeatStatus('revoked')).toBe(true);
+    expect(isSeatStatus('deleted')).toBe(false);
+  });
+});
+
+describe('normalizeKeyLimit', () => {
+  it('accepts integers within bounds', () => {
+    expect(normalizeKeyLimit(0)).toBe(0);
+    expect(normalizeKeyLimit(DEFAULT_SEAT_KEY_LIMIT)).toBe(DEFAULT_SEAT_KEY_LIMIT);
+    expect(normalizeKeyLimit(MAX_SEAT_KEY_LIMIT)).toBe(MAX_SEAT_KEY_LIMIT);
+  });
+  it('rejects out-of-range or non-integers', () => {
+    expect(normalizeKeyLimit(-1)).toBeNull();
+    expect(normalizeKeyLimit(MAX_SEAT_KEY_LIMIT + 1)).toBeNull();
+    expect(normalizeKeyLimit(1.5)).toBeNull();
+    expect(normalizeKeyLimit('3')).toBeNull();
+  });
+});
+
+describe('resolveSeatBillingAccountRef', () => {
+  it('resolves a seat through its bound team', () => {
+    expect(resolveSeatBillingAccountRef({ teamId: 'team-1' }, boundTeam)).toEqual({
+      providerSlug: 'pymthouse',
+      accountId: 'acct_om_123',
+    });
+  });
+  it('returns null when the seat does not belong to the team', () => {
+    expect(resolveSeatBillingAccountRef({ teamId: 'other' }, boundTeam)).toBeNull();
+  });
+  it('returns null for an unbound team', () => {
+    expect(resolveSeatBillingAccountRef({ teamId: 'team-3' }, unboundTeam)).toBeNull();
+  });
+});
+
+describe('guardrail: all seats in a team resolve to one billingAccountRef', () => {
+  it('holds for many seats on a pymthouse-bound team', () => {
+    const seats = [{ teamId: 'team-1' }, { teamId: 'team-1' }, { teamId: 'team-1' }];
+    expect(allSeatsResolveToSingleRef(boundTeam, seats)).toBe(true);
+  });
+
+  it('holds for the C0 stub provider too (provider-agnostic)', () => {
+    const seats = [{ teamId: 'team-2' }, { teamId: 'team-2' }];
+    expect(allSeatsResolveToSingleRef(stubTeam, seats)).toBe(true);
+  });
+
+  it('holds (vacuously) for an unbound team', () => {
+    const seats = [{ teamId: 'team-3' }, { teamId: 'team-3' }];
+    expect(allSeatsResolveToSingleRef(unboundTeam, seats)).toBe(true);
+  });
+
+  it('fails if a foreign seat is mixed in', () => {
+    const seats = [{ teamId: 'team-1' }, { teamId: 'foreign' }];
+    expect(allSeatsResolveToSingleRef(boundTeam, seats)).toBe(false);
+  });
+});
+
+describe('seatCanMintKey', () => {
+  it('allows minting under the limit on an active seat', () => {
+    expect(seatCanMintKey({ status: 'active', keyLimit: 5 }, 4)).toBe(true);
+  });
+  it('blocks at/over the limit', () => {
+    expect(seatCanMintKey({ status: 'active', keyLimit: 5 }, 5)).toBe(false);
+  });
+  it('blocks a zero-limit seat', () => {
+    expect(seatCanMintKey({ status: 'active', keyLimit: 0 }, 0)).toBe(false);
+  });
+  it('blocks revoked/pending seats', () => {
+    expect(seatCanMintKey({ status: 'revoked', keyLimit: 5 }, 0)).toBe(false);
+    expect(seatCanMintKey({ status: 'pending', keyLimit: 5 }, 0)).toBe(false);
+  });
+});

--- a/apps/web-next/src/lib/teams/seats.ts
+++ b/apps/web-next/src/lib/teams/seats.ts
@@ -1,0 +1,104 @@
+/**
+ * Team-seat domain logic (NAAP-1) — DB-free so it can be unit-tested in
+ * isolation. The HTTP routes under `src/app/api/v1/teams/[teamId]/seats/*`
+ * persist `Seat` rows and delegate the rules here.
+ *
+ * Core invariant (guardrail): EVERY seat in a team resolves to the SAME
+ * `billingAccountRef`, because the ref is a property of the team, not the seat.
+ * {@link allSeatsResolveToSingleRef} proves this holds for pymthouse and the
+ * C0 stub provider alike.
+ */
+
+import {
+  type BillingAccountRef,
+  type TeamBillingBinding,
+  teamBillingAccountRef,
+} from './billing-account-ref';
+
+/** Roles a seat may hold (mirrors team-member roles, excluding `owner`). */
+export const SEAT_ROLES = ['admin', 'member', 'viewer'] as const;
+export type SeatRole = (typeof SEAT_ROLES)[number];
+
+/** Lifecycle states for a seat. */
+export const SEAT_STATUSES = ['active', 'pending', 'revoked'] as const;
+export type SeatStatus = (typeof SEAT_STATUSES)[number];
+
+/** Default per-seat cap on active API keys (NAAP-B issues keys to seats). */
+export const DEFAULT_SEAT_KEY_LIMIT = 5;
+/** Defensive upper bound an admin may set for a single seat. */
+export const MAX_SEAT_KEY_LIMIT = 100;
+
+/** Minimal seat shape the domain logic needs (subset of the Prisma row). */
+export interface SeatShape {
+  id: string;
+  teamId: string;
+  userId: string | null;
+  role: string;
+  status: string;
+  keyLimit: number;
+}
+
+export function isSeatRole(value: unknown): value is SeatRole {
+  return typeof value === 'string' && (SEAT_ROLES as readonly string[]).includes(value);
+}
+
+export function isSeatStatus(value: unknown): value is SeatStatus {
+  return typeof value === 'string' && (SEAT_STATUSES as readonly string[]).includes(value);
+}
+
+/** Clamp/validate a requested per-seat key limit; returns null when invalid. */
+export function normalizeKeyLimit(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return null;
+  if (value < 0 || value > MAX_SEAT_KEY_LIMIT) return null;
+  return value;
+}
+
+/**
+ * Resolve the `billingAccountRef` a seat bills to. A seat always resolves
+ * through its TEAM, so the seat itself carries no provider coupling. Returns
+ * null when the seat does not belong to the given team, or the team is unbound.
+ */
+export function resolveSeatBillingAccountRef(
+  seat: Pick<SeatShape, 'teamId'>,
+  team: TeamBillingBinding,
+): BillingAccountRef | null {
+  if (seat.teamId !== team.id) return null;
+  return teamBillingAccountRef(team);
+}
+
+/**
+ * Guardrail: assert that every seat in a team resolves to exactly ONE
+ * `billingAccountRef`. True for an unbound team only when it has zero seats
+ * resolving to a ref (i.e. all resolve to null → still "single": none).
+ */
+export function allSeatsResolveToSingleRef(
+  team: TeamBillingBinding,
+  seats: Array<Pick<SeatShape, 'teamId'>>,
+): boolean {
+  const refs = seats.map((s) => resolveSeatBillingAccountRef(s, team));
+  // Any seat not belonging to this team is a programming error → not single.
+  if (refs.some((r, i) => seats[i].teamId !== team.id)) return false;
+  const distinct = new Set(
+    refs
+      .filter((r): r is BillingAccountRef => r !== null)
+      .map((r) => `${r.providerSlug}:${r.accountId}`),
+  );
+  return distinct.size <= 1;
+}
+
+/** Whether a seat is currently usable (active and not revoked). */
+export function isSeatActive(seat: Pick<SeatShape, 'status'>): boolean {
+  return seat.status === 'active';
+}
+
+/**
+ * Whether an active seat may mint another API key given how many active keys it
+ * already holds. A `keyLimit` of 0 means "no keys allowed".
+ */
+export function seatCanMintKey(
+  seat: Pick<SeatShape, 'status' | 'keyLimit'>,
+  activeKeyCount: number,
+): boolean {
+  if (!isSeatActive(seat)) return false;
+  return activeKeyCount < seat.keyLimit;
+}

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,42 @@
+# Contracts — Billing Provider Protocol (BPP)
+
+This directory holds the **provider-neutral** cross-repo contracts (C0) for the
+NaaP × billing-provider × application integration. They are the *seams* every
+billing provider implements and that NaaP reaches **only** through the
+`BillingProviderAdapter` SPI (NAAP-A).
+
+`pymthouse` is the reference provider; a tiny in-memory **stub provider** is the
+second implementation that proves the abstraction in CI. The
+[conformance test](../apps/web-next/src/lib/billing/bpp/conformance.test.ts)
+validates any provider's payloads against these schemas.
+
+## Files (`billing-provider-protocol/`)
+
+| Seam | File | Direction | Part of BPP? |
+|---|---|---|---|
+| ② `validate` response | `validate.schema.json` | provider → NaaP (via adapter) | ✅ yes |
+| ④ plans + capability bundles | `plans.schema.json` | provider → NaaP | ✅ yes |
+| ⑤ account + member + `billingAccountRef` | `account.schema.json` | provider-internal → NaaP ref | ✅ yes (ref only) |
+| ⑥ usage ingest | `usage-ingest.schema.json` | provider → NaaP `/metrics/ingest` | ✅ yes |
+| ⑦ discovery response | `discovery.schema.json` | NaaP → gateway | ✅ yes |
+| ⑧ curated list + token bundle | `curated-list.schema.json` | NaaP → provider | ✅ yes |
+| ⑨ provider-internal metering (OpenMeter) | `provider-internal-openmeter.schema.json` | **provider-internal** | ❌ **NOT BPP** |
+
+> **Seam isolation (hard rule).** The BPP payloads (② and ⑥ especially) must
+> never carry provider-internal field names from ⑨ (e.g.
+> `openmeter_subscription_id`, raw `network_fee_usd_micros` OM shapes,
+> `source: "openmeter"`). The conformance suite asserts this. If a provider needs
+> to surface a subscription pointer it returns a **neutral opaque**
+> `subscriptionRef` (the provider decides its meaning).
+
+## Schema dialect
+
+All schemas use JSON Schema **2020-12**. They are *additive-only*: never change an
+existing field's meaning — add new optional fields / new schema versions. The
+conformance suite compiles every schema (a schema-lint guardrail) and validates
+the stub provider against them.
+
+## Versioning
+
+These are v1 of the BPP. Breaking changes require a new file
+(`*.v2.schema.json`) so old consumers keep validating against v1.

--- a/contracts/billing-provider-protocol/account.schema.json
+++ b/contracts/billing-provider-protocol/account.schema.json
@@ -3,6 +3,7 @@
   "$id": "https://naap.livepeer.org/contracts/bpp/account.schema.json",
   "title": "BPP ⑤ account + member + billingAccountRef",
   "description": "The billing account is provider-internal; NaaP only ever stores the neutral billingAccountRef pointer. account and account_member are documented so providers expose a consistent shape.",
+  "$comment": "Identity invariant (enforced by the BPP conformance suite, not plain JSON Schema 2020-12): account.id MUST equal billingAccountRef.accountId and account.providerSlug MUST equal billingAccountRef.providerSlug, so the persisted neutral ref can never point at a different account than the one described.",
   "type": "object",
   "required": ["account", "billingAccountRef"],
   "additionalProperties": false,

--- a/contracts/billing-provider-protocol/account.schema.json
+++ b/contracts/billing-provider-protocol/account.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/account.schema.json",
+  "title": "BPP ⑤ account + member + billingAccountRef",
+  "description": "The billing account is provider-internal; NaaP only ever stores the neutral billingAccountRef pointer. account and account_member are documented so providers expose a consistent shape.",
+  "type": "object",
+  "required": ["account", "billingAccountRef"],
+  "additionalProperties": false,
+  "$defs": {
+    "account": {
+      "type": "object",
+      "required": ["id", "ownerSub", "providerSlug", "billingMode"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ownerSub": { "type": "string", "minLength": 1 },
+        "providerSlug": { "type": "string", "minLength": 1 },
+        "planId": { "type": "string" },
+        "creditBalanceWei": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "description": "Decimal wei string."
+        },
+        "billingMode": { "type": "string", "enum": ["delegated", "prepay"] }
+      }
+    },
+    "account_member": {
+      "type": "object",
+      "required": ["accountId", "sub", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "accountId": { "type": "string", "minLength": 1 },
+        "sub": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["admin", "member"] }
+      }
+    },
+    "billingAccountRef": {
+      "type": "object",
+      "description": "Provider-agnostic pointer stored NaaP-side. The ONLY account shape NaaP persists.",
+      "required": ["providerSlug", "accountId"],
+      "additionalProperties": false,
+      "properties": {
+        "providerSlug": { "type": "string", "minLength": 1 },
+        "accountId": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "properties": {
+    "account": { "$ref": "#/$defs/account" },
+    "members": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/account_member" }
+    },
+    "billingAccountRef": { "$ref": "#/$defs/billingAccountRef" }
+  }
+}

--- a/contracts/billing-provider-protocol/curated-list.schema.json
+++ b/contracts/billing-provider-protocol/curated-list.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/curated-list.schema.json",
+  "title": "BPP ⑧ curated list + optional token bundle",
+  "description": "NaaP → provider via adapter.receiveCuratedOrchestrators(plan, list). The token bundle is OPTIONAL and only used for the direct python-gateway path (Option 2). Headers in the token bundle are opaque to apps.",
+  "type": "object",
+  "required": ["plan", "version", "orchestrators"],
+  "additionalProperties": false,
+  "$defs": {
+    "headers": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "tokenBundle": {
+      "type": "object",
+      "required": ["signer", "signer_headers", "discovery", "discovery_headers"],
+      "additionalProperties": false,
+      "properties": {
+        "signer": { "type": "string", "format": "uri" },
+        "signer_headers": { "$ref": "#/$defs/headers" },
+        "discovery": { "type": "string", "format": "uri" },
+        "discovery_headers": { "$ref": "#/$defs/headers" }
+      }
+    }
+  },
+  "properties": {
+    "plan": { "type": "string", "minLength": 1 },
+    "version": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO timestamp identifying this curated revision."
+    },
+    "orchestrators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["address", "capabilities"],
+        "additionalProperties": false,
+        "properties": {
+          "address": { "type": "string", "format": "uri" },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "score": { "type": "number" }
+        }
+      }
+    },
+    "tokenBundle": { "$ref": "#/$defs/tokenBundle" }
+  }
+}

--- a/contracts/billing-provider-protocol/discovery.schema.json
+++ b/contracts/billing-provider-protocol/discovery.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/discovery.schema.json",
+  "title": "BPP ⑦ discovery response",
+  "description": "NaaP → gateway. GET /api/v1/orchestrator-leaderboard/python-gateway?caps=… (auth: Bearer gw_…). The list is already filtered by the plan's capabilities.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["address"],
+    "additionalProperties": false,
+    "properties": {
+      "address": {
+        "type": "string",
+        "format": "uri",
+        "description": "Orchestrator endpoint, e.g. https://orch.example:8935"
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/plans.schema.json
+++ b/contracts/billing-provider-protocol/plans.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/plans.schema.json",
+  "title": "BPP ④ plans + capability bundles",
+  "description": "Provider plan catalogue. Each plan declares the capabilities it enables and their SLA / price ceiling. NaaP enforces key → seat → account → plan → capabilities.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "bundles"],
+    "additionalProperties": false,
+    "properties": {
+      "id": { "type": "string", "minLength": 1 },
+      "name": { "type": "string" },
+      "price": {
+        "type": "object",
+        "required": ["amount", "interval"],
+        "additionalProperties": false,
+        "properties": {
+          "amount": { "type": "number", "minimum": 0 },
+          "interval": { "type": "string", "enum": ["month", "year", "once"] },
+          "currency": { "type": "string", "description": "ISO 4217 code; defaults to USD when omitted." }
+        }
+      },
+      "bundles": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["capability"],
+          "additionalProperties": false,
+          "properties": {
+            "capability": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Generic capability id, e.g. text-to-image:sdxl or tool:byoc-foo."
+            },
+            "sla": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "uptime": { "type": "number", "minimum": 0, "maximum": 1 },
+                "p95Ms": { "type": "number", "minimum": 0 }
+              }
+            },
+            "maxPriceWeiPerUnit": {
+              "type": "string",
+              "pattern": "^[0-9]+$",
+              "description": "Decimal wei string price ceiling per unit."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/plans.schema.json
+++ b/contracts/billing-provider-protocol/plans.schema.json
@@ -18,7 +18,7 @@
         "properties": {
           "amount": { "type": "number", "minimum": 0 },
           "interval": { "type": "string", "enum": ["month", "year", "once"] },
-          "currency": { "type": "string", "description": "ISO 4217 code; defaults to USD when omitted." }
+          "currency": { "type": "string", "pattern": "^[A-Z]{3}$", "description": "ISO 4217 code; defaults to USD when omitted." }
         }
       },
       "bundles": {

--- a/contracts/billing-provider-protocol/provider-internal-openmeter.schema.json
+++ b/contracts/billing-provider-protocol/provider-internal-openmeter.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/provider-internal-openmeter.schema.json",
+  "title": "⑨ Provider-internal metering (OpenMeter) — NOT part of the BPP",
+  "description": "DOCUMENTATION ONLY. This is the reference provider's (pymthouse, PR #133) internal metering shape. NaaP MUST NEVER depend on it — it consumes the neutral ⑥ usage-ingest payload only. The conformance suite uses this file's `x-bpp-forbidden-field-names` to assert these names never leak through the BPP seams (② and ⑥).",
+  "x-bpp": "non-bpp",
+  "x-bpp-forbidden-field-names": [
+    "openmeter_subscription_id",
+    "openmeter_customer_id",
+    "network_fee_usd_micros",
+    "fee_wei",
+    "eth_usd_price",
+    "eth_usd_round_id",
+    "eth_usd_observed_at",
+    "external_user_id",
+    "client_id",
+    "model_id",
+    "gateway_request_id",
+    "specversion"
+  ],
+  "type": "object",
+  "required": ["specversion", "type", "source", "data"],
+  "properties": {
+    "specversion": { "type": "string", "const": "1.0" },
+    "type": { "type": "string", "const": "create_signed_ticket" },
+    "source": { "type": "string", "const": "go-livepeer-remote-signer" },
+    "subject": { "type": "string", "description": "<client_id>:<external_user_id>" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "client_id": { "type": "string" },
+        "external_user_id": { "type": "string" },
+        "network_fee_usd_micros": { "type": "string" },
+        "fee_wei": { "type": "string" },
+        "pixels": { "type": "number" },
+        "pipeline": { "type": "string" },
+        "model_id": { "type": "string" },
+        "gateway_request_id": { "type": "string" },
+        "eth_usd_price": { "type": "string" },
+        "eth_usd_round_id": { "type": "string" },
+        "eth_usd_observed_at": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/usage-ingest.schema.json
+++ b/contracts/billing-provider-protocol/usage-ingest.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/usage-ingest.schema.json",
+  "title": "BPP ⑥ usage ingest",
+  "description": "Neutral usage payload pushed provider → NaaP at POST {NAAP_METRICS_URL}/api/v1/metrics/ingest. The authoritative cross-provider usage path (NOT validate). OM-backed providers must map their internal meters into this shape; raw OpenMeter field names MUST NOT appear here.",
+  "type": "object",
+  "required": ["providerSlug", "accountId", "window"],
+  "additionalProperties": false,
+  "$defs": {
+    "capabilityUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tickets": { "type": "integer", "minimum": 0 },
+        "networkFeeUsdMicros": { "type": "string", "pattern": "^[0-9]+$" }
+      }
+    }
+  },
+  "properties": {
+    "providerSlug": { "type": "string", "minLength": 1 },
+    "accountId": { "type": "string", "minLength": 1 },
+    "appId": { "type": "string", "minLength": 1 },
+    "window": {
+      "type": "object",
+      "required": ["from", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "from": { "type": "string", "format": "date-time" },
+        "to": { "type": "string", "format": "date-time" }
+      }
+    },
+    "sessions": { "type": "integer", "minimum": 0 },
+    "tickets": { "type": "integer", "minimum": 0 },
+    "feeWei": { "type": "string", "pattern": "^[0-9]+$" },
+    "networkFeeUsdMicros": {
+      "type": "string",
+      "pattern": "^[0-9]+$",
+      "description": "USD micros; for OM-backed providers that meter in fiat."
+    },
+    "byCapability": {
+      "type": "object",
+      "description": "Keyed by generic capability id <pipeline>:<model>.",
+      "additionalProperties": { "$ref": "#/$defs/capabilityUsage" }
+    }
+  }
+}

--- a/contracts/billing-provider-protocol/validate.schema.json
+++ b/contracts/billing-provider-protocol/validate.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://naap.livepeer.org/contracts/bpp/validate.schema.json",
+  "title": "BPP ② validate response",
+  "description": "Provider-neutral response for resolving an opaque key into identity, capabilities, billing account, and an optional provider-issued signer session. Exercised by NaaP through the BillingProviderAdapter. MUST NOT leak provider-internal metering identifiers (see provider-internal-openmeter.schema.json).",
+  "type": "object",
+  "required": ["valid"],
+  "additionalProperties": false,
+  "properties": {
+    "valid": {
+      "type": "boolean",
+      "description": "Whether the presented key is valid."
+    },
+    "user": {
+      "type": "object",
+      "required": ["sub"],
+      "additionalProperties": false,
+      "properties": {
+        "sub": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable subject identifier for the resolved user."
+        }
+      }
+    },
+    "billing_account": {
+      "type": "object",
+      "required": ["id", "providerSlug", "billingMode"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "providerSlug": { "type": "string", "minLength": 1 },
+        "billingMode": { "type": "string", "enum": ["delegated", "prepay"] }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "Either the wildcard [\"*\"] or a list of generic capability ids in the form <pipeline>:<model> or tool:<name>.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "quota": {
+      "description": "Remaining quota, or null when not metered/unbounded.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["remaining"],
+          "additionalProperties": false,
+          "properties": {
+            "remaining": { "type": "number" },
+            "resetAt": { "type": "string", "format": "date-time" }
+          }
+        },
+        { "type": "null" }
+      ]
+    },
+    "subscriptionRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "OPTIONAL neutral opaque subscription pointer. The provider decides its meaning; it MUST NOT encode a provider-internal identifier name (e.g. openmeter_subscription_id)."
+    },
+    "signerSession": {
+      "type": "object",
+      "required": ["url", "headers"],
+      "additionalProperties": false,
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "headers": {
+          "type": "object",
+          "description": "Opaque-to-apps headers, e.g. { \"Authorization\": \"Bearer <provider-token>\" }.",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,8 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.0.18",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^2.1.1",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.16.0",
         "eslint-config-next": "15.5.12",

--- a/packages/database/prisma/migrations/20260617120000_add_application_registry/migration.sql
+++ b/packages/database/prisma/migrations/20260617120000_add_application_registry/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable: Application registry (NAAP-D). Expand-only, additive.
+CREATE TABLE "public"."Application" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'app',
+    "teamId" TEXT,
+    "ownerUserId" TEXT,
+    "allowedScopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "allowedCapabilities" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Application_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Application_slug_key" ON "public"."Application"("slug");
+CREATE INDEX "Application_teamId_idx" ON "public"."Application"("teamId");
+CREATE INDEX "Application_ownerUserId_idx" ON "public"."Application"("ownerUserId");
+CREATE INDEX "Application_slug_idx" ON "public"."Application"("slug");

--- a/packages/database/prisma/migrations/20260617123000_add_provider_usage_record/migration.sql
+++ b/packages/database/prisma/migrations/20260617123000_add_provider_usage_record/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable: ProviderUsageRecord — cross-provider BPP ⑥ usage telemetry (NAAP-2).
+-- Expand-only, additive.
+CREATE TABLE "public"."ProviderUsageRecord" (
+    "id" TEXT NOT NULL,
+    "providerSlug" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "appId" TEXT,
+    "windowFrom" TIMESTAMP(3) NOT NULL,
+    "windowTo" TIMESTAMP(3) NOT NULL,
+    "sessions" INTEGER NOT NULL DEFAULT 0,
+    "tickets" INTEGER NOT NULL DEFAULT 0,
+    "feeWei" TEXT,
+    "networkFeeUsdMicros" TEXT,
+    "byCapability" JSONB,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProviderUsageRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProviderUsageRecord_providerSlug_windowTo_idx" ON "public"."ProviderUsageRecord"("providerSlug", "windowTo");
+CREATE INDEX "ProviderUsageRecord_accountId_windowTo_idx" ON "public"."ProviderUsageRecord"("accountId", "windowTo");
+CREATE INDEX "ProviderUsageRecord_appId_windowTo_idx" ON "public"."ProviderUsageRecord"("appId", "windowTo");

--- a/packages/database/prisma/migrations/20260617130000_naap1_team_seats/migration.sql
+++ b/packages/database/prisma/migrations/20260617130000_naap1_team_seats/migration.sql
@@ -1,0 +1,51 @@
+-- NAAP-1: Team Seats + provider-agnostic billing-account binding.
+-- Expand-only / additive: every column added is nullable or has a default, and
+-- the new Seat table is unreferenced by existing code paths. With the
+-- `team_seats` feature flag OFF this migration is a no-op for runtime behavior
+-- (no existing query reads these columns/table). No destructive change.
+
+-- Team: provider-agnostic billingAccountRef = {providerSlug, accountId}.
+ALTER TABLE "public"."Team" ADD COLUMN IF NOT EXISTS "billingAccountProviderSlug" TEXT;
+ALTER TABLE "public"."Team" ADD COLUMN IF NOT EXISTS "billingAccountId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "Team_billingAccountProviderSlug_idx"
+    ON "public"."Team"("billingAccountProviderSlug");
+
+-- Seat: a developer's place in a team. Keys (NAAP-B) are issued to a seat.
+CREATE TABLE IF NOT EXISTS "public"."Seat" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT,
+    "email" TEXT,
+    "role" TEXT NOT NULL DEFAULT 'member',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "keyLimit" INTEGER NOT NULL DEFAULT 5,
+    "invitedBy" TEXT,
+    "inviteToken" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Seat_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Seat_inviteToken_key" ON "public"."Seat"("inviteToken");
+CREATE UNIQUE INDEX IF NOT EXISTS "Seat_teamId_userId_key" ON "public"."Seat"("teamId", "userId");
+CREATE INDEX IF NOT EXISTS "Seat_teamId_idx" ON "public"."Seat"("teamId");
+CREATE INDEX IF NOT EXISTS "Seat_userId_idx" ON "public"."Seat"("userId");
+CREATE INDEX IF NOT EXISTS "Seat_teamId_status_idx" ON "public"."Seat"("teamId", "status");
+
+-- FK to Team (cascade) and User (set null) — both reference existing public tables.
+ALTER TABLE "public"."Seat"
+    ADD CONSTRAINT "Seat_teamId_fkey" FOREIGN KEY ("teamId")
+    REFERENCES "public"."Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."Seat"
+    ADD CONSTRAINT "Seat_userId_fkey" FOREIGN KEY ("userId")
+    REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- DevApiKey: optional seat/team attribution (scalar, no cross-schema FK).
+ALTER TABLE "plugin_developer_api"."DevApiKey" ADD COLUMN IF NOT EXISTS "seatId" TEXT;
+ALTER TABLE "plugin_developer_api"."DevApiKey" ADD COLUMN IF NOT EXISTS "teamId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "DevApiKey_seatId_idx" ON "plugin_developer_api"."DevApiKey"("seatId");
+CREATE INDEX IF NOT EXISTS "DevApiKey_teamId_idx" ON "plugin_developer_api"."DevApiKey"("teamId");

--- a/packages/database/prisma/migrations/20260617140000_naapb_native_key_session_ref/migration.sql
+++ b/packages/database/prisma/migrations/20260617140000_naapb_native_key_session_ref/migration.sql
@@ -1,0 +1,7 @@
+-- NAAP-B: encrypted provider-session ref for native `naap_` keys.
+-- Expand-only / additive: nullable columns only; existing keys leave them null
+-- and behave exactly as before. With the `native_keys` flag OFF nothing writes
+-- or reads these columns. No destructive change.
+
+ALTER TABLE "plugin_developer_api"."DevApiKey" ADD COLUMN IF NOT EXISTS "providerSessionRefEnc" TEXT;
+ALTER TABLE "plugin_developer_api"."DevApiKey" ADD COLUMN IF NOT EXISTS "providerSessionRefIv" TEXT;

--- a/packages/database/prisma/migrations/20260617150000_naapadb_billing_provider_adapter_type/migration.sql
+++ b/packages/database/prisma/migrations/20260617150000_naapadb_billing_provider_adapter_type/migration.sql
@@ -1,0 +1,9 @@
+-- NAAP-A-db: DB-driven billing-provider adapter registry (EXPAND-ONLY).
+--
+-- Adds nullable `adapterType` + `config` columns to BillingProvider so the
+-- adapter registry can resolve a provider's adapter implementation from the DB
+-- instead of a static slug→adapter map. Purely additive: existing rows keep
+-- adapterType = NULL and continue to resolve by `slug`, so flag-OFF behavior is
+-- unchanged (zero regression). No backfill here (expand → migrate → contract).
+ALTER TABLE "public"."BillingProvider" ADD COLUMN IF NOT EXISTS "adapterType" TEXT;
+ALTER TABLE "public"."BillingProvider" ADD COLUMN IF NOT EXISTS "config" JSONB;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1721,6 +1721,12 @@ model DevApiKey {
   // before. NAAP-B issues native `naap_` keys bound to a seat + team.
   seatId            String?
   teamId            String?
+  // NAAP-B: encrypted, provider-OPAQUE session ref (AES-256-GCM via
+  // @/lib/gateway/encryption). A native `naap_` key maps server-side to the
+  // backing provider session; apps never see provider tokens/URLs. Nullable +
+  // additive — only native keys populate it.
+  providerSessionRefEnc String?
+  providerSessionRefIv  String?
   createdAt         DateTime            @default(now())
   lastUsedAt        DateTime?
   revokedAt         DateTime?

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -293,6 +293,37 @@ model UserRole {
 }
 
 // ============================================
+// CORE PLATFORM - APPLICATION REGISTRY (NAAP-D)
+// ============================================
+
+/// Provider-agnostic registry of any application or service that uses NaaP.
+/// Each app presents its `id` (appId) so usage and rate limits attribute per
+/// app. Polymorphic ownership mirrors GatewayApiKey: exactly one of `teamId`
+/// or `ownerUserId` is set. No app is hardcoded — Storyboard is one row here.
+model Application {
+  id                  String   @id @default(uuid())
+  slug                String   @unique
+  name                String
+  type                String   @default("app") // app | service | cli
+
+  teamId              String? // set for team-scoped apps
+  ownerUserId         String? // set for personal-scoped apps
+
+  allowedScopes       String[] @default([]) // discovery | gateway | llm | billing | usage
+  allowedCapabilities String[] @default([]) // generic capability ids, or "*"
+  status              String   @default("active") // active | disabled
+
+  createdBy           String
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  @@index([teamId])
+  @@index([ownerUserId])
+  @@index([slug])
+  @@schema("public")
+}
+
+// ============================================
 // CORE PLATFORM - MONITORING & ANALYTICS
 // ============================================
 

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -181,6 +181,12 @@ model BillingProvider {
   authType    String   @default("oauth")
   enabled     Boolean  @default(true)
   sortOrder   Int      @default(0)
+  // NAAP-A-db: DB-driven adapter registry. `adapterType` selects which
+  // BillingProviderAdapter implementation backs this provider (many provider
+  // rows may share one adapterType, differentiated by `config`). NULL ⇒ resolve
+  // by `slug` (the pre-NAAP-A-db behavior), so existing rows are unaffected.
+  adapterType String?
+  config      Json?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -60,6 +60,7 @@ model User {
   // Team relations
   ownedTeams      Team[]       @relation("TeamOwner")
   teamMemberships TeamMember[]
+  seats           Seat[]       @relation("UserSeats")
 
   // Platform relations
   pluginReviews    PluginReview[]
@@ -226,10 +227,50 @@ model Team {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  // NAAP-1: provider-agnostic billing-account binding.
+  // A team binds to exactly ONE billing account via {providerSlug, accountId}
+  // (the BPP `billingAccountRef`), resolved through the BillingProviderAdapter
+  // registry (NAAP-A) — never a provider-specific FK. `accountId` is the
+  // provider's opaque customer/subscription id (e.g. an OpenMeter customer id).
+  // Both nullable + additive: a team with no binding behaves exactly as before.
+  billingAccountProviderSlug String?
+  billingAccountId           String?
+
   members        TeamMember[]
   pluginInstalls TeamPluginInstall[]
+  seats          Seat[]
 
   @@index([ownerId])
+  @@index([billingAccountProviderSlug])
+  @@schema("public")
+}
+
+// NAAP-1: A seat is a developer's place in a team. API keys (NAAP-B) are issued
+// to a seat, and a seat resolves (via its team) to a single `billingAccountRef`.
+// Seats are additive: with the `team_seats` flag OFF nothing reads this table.
+model Seat {
+  id          String   @id @default(uuid())
+  teamId      String
+  team        Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  // null while an invite is pending (no NaaP user has accepted the seat yet).
+  userId      String?
+  user        User?    @relation("UserSeats", fields: [userId], references: [id], onDelete: SetNull)
+  // Invite target email while pending; informational once accepted.
+  email       String?
+  role        String   @default("member") // admin | member | viewer
+  status      String   @default("active") // active | pending | revoked
+  // Per-seat cap on the number of active API keys (NAAP-B).
+  keyLimit    Int      @default(5)
+  invitedBy   String?
+  // Opaque single-use token for the pending-invite accept flow.
+  inviteToken String?  @unique
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([teamId, userId])
+  @@index([teamId])
+  @@index([userId])
+  @@index([teamId, status])
   @@schema("public")
 }
 
@@ -1675,6 +1716,11 @@ model DevApiKey {
   projectName       String?
   keyHash           String?             @unique
   status            DevApiKeyStatus     @default(ACTIVE)
+  // NAAP-1: optional seat/team attribution for keys. Scalar (no cross-schema FK)
+  // and additive — existing user-scoped keys leave these null and behave as
+  // before. NAAP-B issues native `naap_` keys bound to a seat + team.
+  seatId            String?
+  teamId            String?
   createdAt         DateTime            @default(now())
   lastUsedAt        DateTime?
   revokedAt         DateTime?
@@ -1687,6 +1733,8 @@ model DevApiKey {
   @@index([status])
   @@index([keyHash])
   @@index([keyLookupId])
+  @@index([seatId])
+  @@index([teamId])
   @@schema("plugin_developer_api")
 }
 

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -309,6 +309,33 @@ model HistoricalStat {
   @@schema("public")
 }
 
+/// Cross-provider usage telemetry ingested via the BPP ⑥ seam (NAAP-2).
+/// Stores the NEUTRAL provider → NaaP usage payload only — never any
+/// provider-internal metering shape. Aggregated into a cross-provider spend
+/// view (provider column). Write-only on ingest; read by the dashboard BFF.
+model ProviderUsageRecord {
+  id                  String   @id @default(uuid())
+  providerSlug        String
+  accountId           String
+  appId               String?
+
+  windowFrom          DateTime
+  windowTo            DateTime
+
+  sessions            Int      @default(0)
+  tickets             Int      @default(0)
+  feeWei              String? // decimal wei string
+  networkFeeUsdMicros String? // decimal USD-micros string
+  byCapability        Json? // { "<pipeline>:<model>": { tickets, networkFeeUsdMicros } }
+
+  receivedAt          DateTime @default(now())
+
+  @@index([providerSlug, windowTo])
+  @@index([accountId, windowTo])
+  @@index([appId, windowTo])
+  @@schema("public")
+}
+
 model JobFeed {
   id             String   @id @default(uuid())
   gatewayId      String

--- a/plugins/orchestrator-leaderboard/docs/data-sources.md
+++ b/plugins/orchestrator-leaderboard/docs/data-sources.md
@@ -101,6 +101,41 @@ same orchestrator, the resolver builds a cross-reference map to join them.
 
 ---
 
+## Storyboard Default discovery bundle (NAAP-9, Daydream parity)
+
+Default ClickHouse discovery is **per-requested-capability** and only returns
+orchestrators with **warm rows in the last hour** (`semantic.network_capabilities`,
+`warm_bool = 1`). Orchestrators without warm rows for a requested capability are
+**silently dropped** — e.g. the scope staging orchs
+(`orch-staging-1/2/3`, capability `live-video-to-video/scope`).
+
+The **Storyboard Default plan** (`storyboard-default`) is the concrete instance
+of the generic capability gate (NAAP-E). It guarantees a **non-disruptive
+Daydream→NaaP discovery switch** by returning ⊇ the live Daydream set across
+three categories — **scope**, **BYOC**, and **tool** — with a **static-fleet
+fallback** merged into the tier shuffle so no known orchestrator is dropped.
+
+- **Endpoint**: `GET /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway`
+  (also reachable via the default endpoint with `?plan=storyboard-default`).
+- **Static fleet**: the plan's per-category `staticOrchestrators` (mirrors
+  `simple-infra/discovery/staging.json` + `fleet.yaml`, plus the BYOC tool host).
+  Live-ranked orchs keep their order; missing static-fleet addresses are
+  appended into the lowest tier (`tieredShuffleWithStaticFallback`) — present,
+  never displacing live-ranked orchs.
+- **Feature flag**: `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default **OFF**).
+  When OFF the dedicated endpoint returns `404` and the `?plan=` param is
+  ignored, so the live Daydream path stays authoritative until parity is proven.
+- **Provider-agnostic**: the pymthouse capability denylist is applied **only**
+  when `billingProviderSlug=pymthouse`; the static-fleet fallback is a property
+  of the *plan*, not of Storyboard.
+- **Golden-set parity test**: the bundle is guarded by a bidirectional
+  golden-set test (`storyboard-default/__tests__/golden-set.test.ts` +
+  `__snapshots__/golden-set.json`) — captured empirically from the live
+  Daydream path (Decision D7) — that fails if any scope address or BYOC/tool
+  capability is silently dropped **or** added.
+
+---
+
 ## Audit log
 
 Every refresh writes a `LeaderboardRefreshAudit` record to the database with:

--- a/plugins/orchestrator-leaderboard/docs/openapi.yaml
+++ b/plugins/orchestrator-leaderboard/docs/openapi.yaml
@@ -328,6 +328,16 @@ paths:
           in: query
           required: false
           schema: { type: integer, minimum: 1, maximum: 1000, default: 100 }
+        - name: plan
+          in: query
+          required: false
+          schema: { type: string, enum: [storyboard-default] }
+          description: |
+            NAAP-9. When `plan=storyboard-default` AND the
+            `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` flag is ON, returns the fixed
+            Storyboard Default bundle (Daydream parity) with a static-fleet
+            fallback merged into the tier shuffle. When the flag is OFF (default)
+            the param is ignored and the per-cap behavior is used.
         - $ref: "#/components/parameters/BillingProviderSlugQuery"
         - name: billingProvider
           in: query
@@ -345,7 +355,7 @@ paths:
             X-Cache-Age:
               schema: { type: integer }
             X-Discovery-Mode:
-              schema: { type: string, enum: [default] }
+              schema: { type: string, enum: [default, storyboard-default] }
           content:
             application/json:
               schema:
@@ -358,6 +368,62 @@ paths:
               schema: { type: string }
         "401":
           description: Unauthorized
+          content:
+            text/plain:
+              schema: { type: string }
+        "500":
+          description: Upstream failure
+          content:
+            text/plain:
+              schema: { type: string }
+
+  /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway:
+    get:
+      tags: [Python Gateway Discovery]
+      summary: Storyboard Default discovery bundle (Daydream parity) — NAAP-9
+      description: |
+        Returns the fixed default-plan orchestrator/capability set (scope
+        staging + BYOC + tool) with a static-fleet fallback merged into the tier
+        shuffle, guaranteeing a non-disruptive Daydream→NaaP discovery switch
+        (golden-set parity). The default plan is the concrete instance of the
+        generic capability gate (NAAP-E), not a Storyboard special-case.
+
+        Gated by `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default OFF): when OFF
+        the endpoint returns `404` and the live Daydream path stays
+        authoritative. The pymthouse denylist is applied only when
+        `billingProviderSlug=pymthouse`.
+      operationId: getStoryboardDefaultPythonGateway
+      parameters:
+        - $ref: "#/components/parameters/BillingProviderSlugQuery"
+        - name: billingProvider
+          in: query
+          required: false
+          schema: { $ref: "#/components/schemas/BillingProviderSlug" }
+          description: Alias for `billingProviderSlug`.
+      responses:
+        "200":
+          description: Default-plan orchestrator addresses (BYOC + tool + scope)
+          headers:
+            Cache-Control:
+              schema: { type: string, example: "private, no-store, must-revalidate" }
+            X-Cache:
+              schema: { type: string, enum: [HIT, MISS] }
+            X-Cache-Age:
+              schema: { type: integer }
+            X-Discovery-Mode:
+              schema: { type: string, enum: [storyboard-default] }
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/PythonGatewayAddress" }
+        "401":
+          description: Unauthorized
+          content:
+            text/plain:
+              schema: { type: string }
+        "404":
+          description: Disabled (flag OFF — Daydream path authoritative)
           content:
             text/plain:
               schema: { type: string }


### PR DESCRIPTION
> 🚫 **DO NOT MERGE** — throwaway integration vehicle for Phase-2 (APP-2 / STUB-deploy / INT-G). Force-pushed at will. All new feature flags ship **default OFF**.

## Coordination
```
Plan PR ID:   (integration vehicle — APP-2, STUB, INT-0/1/G)
Repo:         NaaP (livepeer/naap)
Base:         origin/main
Merges:       C0, NAAP-0, NAAP-A, NAAP-1, NAAP-B, NAAP-C, NAAP-D, NAAP-2, NAAP-4, NAAP-9, NAAP-A-db
Feature flags: provider_adapters, team_seats, native_keys, key_validation_front_door,
               app_registry, usage_ingest, db_adapter_registry  (ALL default OFF)
Merge-safety: every flag OFF ⇒ no-op vs current main; migrations expand-only; INV-1 green.
```

## What this is
A consolidated branch created off `origin/main` with **all open NaaP Phase-0/2 feature branches** merged sequentially via `git merge --no-ff` (additive-union conflict resolution). It is the substrate for **APP-2**, **STUB-deploy** and the **INT-0 / INT-1 / INT-G** generalization proof. Not for merge to main — the individual feature PRs merge on their own.

## Branches merged (in order)
| # | Plan ID | Branch |
|---|---|---|
| 1 | C0 | `feat/bpp-contracts` |
| 2 | NAAP-0 | `feat/naap-pymthouse-provider-config` |
| 3 | NAAP-A | `feat/billing-provider-adapter-spi` |
| 4 | NAAP-1 | `feat/naap-1-team-seats` |
| 5 | NAAP-B | `feat/naap-b-native-keys` |
| 6 | NAAP-C | `feat/naap-c-validation-front-door` |
| 7 | NAAP-D | `feat/naap-d-app-registry` |
| 8 | NAAP-2 | `feat/naap-2-usage-dashboard` |
| 9 | NAAP-4 | `feat/naap-4-discovery-gw-key` |
| 10 | NAAP-9 | `feat/naap-9-discovery-default-plan` |
| 11 | NAAP-A-db | `feat/naap-a-db-adapter-registry` |

## Conflicts resolved (additive unions)
- `apps/web-next/src/lib/feature-flags.ts` — 3 conflicts (NAAP-D, NAAP-2, NAAP-A-db). Resolved by **keeping every flag from both sides** (no flag dropped). Final flag set: `provider_adapters`, `team_seats`, `native_keys`, `key_validation_front_door`, `app_registry`, `usage_ingest`, `db_adapter_registry` — all default OFF.
- `packages/database/prisma/schema.prisma` — auto-merged (additive models/fields only): `Seat`, `Application`, `ProviderUsageRecord`, `BillingProvider.adapterType`, `Team.billingAccountProviderSlug/billingAccountId`, `DevApiKey.seatId/teamId`. `npx prisma validate` ✅; migrations compose expand-only.

## Integration-only wiring added here
Both sides of these seams are now on one branch, so the single-branch PRs' deferred wiring is completed:
- **NAAP-C ↔ NAAP-D**: the front door registry-checks the presented `X-App-Id` against the `Application` registry (unknown/disabled → 403; ownership-scoped; capabilities gated to the app grant ∩ provider caps). Gated by `app_registry` (default OFF) ⇒ zero regression.
- **NAAP-C ↔ C0**: `validateAgainstBppSchema()` lets INT-0/INT-G assert producer payloads against the canonical `contracts/billing-provider-protocol/validate.schema.json`.

## Validation
- `npx prisma validate` ✅
- Unit/contract suites for touched areas (billing, teams, apps, dev-api, gateway, bpp, metrics, discovery, keys/apps/teams/billing routes): **green**.
- `tsc` clean for all touched files (remaining full-project `tsc` errors are pre-existing on `main`, in files this branch does not modify).
- All cross-system feature flags **default OFF** ⇒ INV-1 (no-regression) preserved.

## DoD
- [x] Additive-union merges; no side dropped
- [x] Migrations expand-only; `prisma validate` green
- [x] All new flags default OFF (no-op vs main)
- [ ] **DO NOT MERGE** (intentional)

Made with [Cursor](https://cursor.com)