### PR TITLE
[STUB-deploy] Register C0 stub as a resolvable BillingProvider — DO NOT MERGE

### DIFF
--- a/apps/web-next/.env.local.example
+++ b/apps/web-next/.env.local.example
@@ -182,6 +182,14 @@ FACADE_USE_STUBS=true
 # returns the user to PymtHouse /oidc/device after sign-in. Requires PYMTHOUSE_ISSUER_URL (and
 # PYMTHOUSE_BASE_URL only if you need a separate site origin from the issuer for marketplace URLs).
 
+# ─── Stub billing provider (STUB-deploy / INT-G) ─────────────────────────
+# The C0 in-memory stub is the SECOND BillingProvider implementation; it proves
+# the seam is provider-agnostic. It holds no secrets and needs no provisioning.
+# It is registered in the catalog as `enabled:false` so it stays out of the prod
+# provider picker. Set this to 1/true (staging only) to surface opt-in affordances
+# (e.g. binding a team to the stub). Front-door resolution does NOT require it.
+# NAAP_ENABLE_STUB_PROVIDER=false
+
 # ─── Playwright E2E (optional) ───────────────────────────────────────────
 # Used by tests/auth.setup.ts and tests/auth-flows.spec.ts for logged-in journeys.
 # E2E_USER_EMAIL=test@example.com

--- a/apps/web-next/prisma/seed.ts
+++ b/apps/web-next/prisma/seed.ts
@@ -711,6 +711,7 @@ async function main() {
         authType: provider.authType,
         enabled: provider.enabled,
         sortOrder: provider.sortOrder,
+        adapterType: provider.adapterType,
       },
       create: provider,
     });

--- a/apps/web-next/src/lib/billing/stub-provider-config.test.ts
+++ b/apps/web-next/src/lib/billing/stub-provider-config.test.ts
@@ -1,0 +1,102 @@
+/** @vitest-environment node */
+
+/**
+ * STUB-deploy guardrail tests.
+ *
+ * Proves the C0 stub is a *registered, resolvable* billing provider that sits
+ * alongside pymthouse — the Phase-0 "registry resolves ≥2 providers" bar and the
+ * substrate for INT-G (a naap_ key resolving against BOTH providers).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { BILLING_PROVIDERS } from '@naap/database';
+import {
+  STUB_PROVIDER_SLUG,
+  findStubSeed,
+  isStubSeedRegistered,
+  isStubAdapterResolvable,
+  isStubProviderDeployEnabled,
+  logStubDeployStatus,
+} from './stub-provider-config';
+import {
+  getBillingProviderAdapter,
+  listBillingProviderSlugs,
+} from './registry';
+import {
+  resolveBillingProviderAdapter,
+  resetAdapterFactoriesForTests,
+} from './registry-db';
+
+describe('stub catalog registration', () => {
+  it('registers the stub as a BillingProvider with a stub-resolving adapterType', () => {
+    const seed = findStubSeed(BILLING_PROVIDERS);
+    expect(seed).toBeDefined();
+    expect(seed?.slug).toBe('stub');
+    expect(seed?.adapterType).toBe('stub');
+    expect(isStubSeedRegistered(BILLING_PROVIDERS)).toBe(true);
+  });
+
+  it('keeps the stub catalog-disabled so it stays out of the prod provider picker', () => {
+    expect(findStubSeed(BILLING_PROVIDERS)?.enabled).toBe(false);
+  });
+
+  it('still registers pymthouse alongside it (≥2 providers)', () => {
+    const slugs = BILLING_PROVIDERS.map((p) => p.slug);
+    expect(slugs).toContain('pymthouse');
+    expect(slugs).toContain('stub');
+  });
+});
+
+describe('stub adapter resolution (static registry)', () => {
+  it('resolves the stub adapter from the registry', () => {
+    expect(isStubAdapterResolvable()).toBe(true);
+    expect(getBillingProviderAdapter(STUB_PROVIDER_SLUG)?.slug).toBe('stub');
+  });
+
+  it('registry resolves BOTH pymthouse and stub (provider-agnostic seam)', () => {
+    const slugs = listBillingProviderSlugs();
+    expect(slugs).toContain('pymthouse');
+    expect(slugs).toContain('stub');
+  });
+});
+
+describe('stub adapter resolution (DB registry, NAAP-A-db)', () => {
+  it('resolves slug "stub" → StubAdapter when the DB registry flag is ON', async () => {
+    resetAdapterFactoriesForTests();
+    vi.doMock('@/lib/feature-flags', () => ({
+      isFeatureEnabled: vi.fn(async () => true),
+    }));
+    // resolveBillingProviderAdapter falls back to the static map when the DB row
+    // is absent (adapterType ?? slug = "stub"), so the stub stays resolvable
+    // even before the catalog row is seeded — zero-regression by construction.
+    const adapter = await resolveBillingProviderAdapter('stub');
+    expect(adapter?.slug).toBe('stub');
+    vi.doUnmock('@/lib/feature-flags');
+  });
+});
+
+describe('deploy gate + structured logging', () => {
+  it('defaults the deploy env gate OFF', () => {
+    const prev = process.env.NAAP_ENABLE_STUB_PROVIDER;
+    delete process.env.NAAP_ENABLE_STUB_PROVIDER;
+    expect(isStubProviderDeployEnabled()).toBe(false);
+    if (prev !== undefined) process.env.NAAP_ENABLE_STUB_PROVIDER = prev;
+  });
+
+  it('logs a structured status line without secrets', () => {
+    const lines: string[] = [];
+    const status = logStubDeployStatus(BILLING_PROVIDERS, {
+      info: (m) => lines.push(m),
+      warn: (m) => lines.push(m),
+    });
+    expect(status.adapterResolvable).toBe(true);
+    expect(status.seedRegistered).toBe(true);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.event).toBe('billing.provider.stub.deploy_status');
+    expect(parsed.level).toBe('info');
+    // No secret-bearing keys.
+    expect(JSON.stringify(parsed)).not.toMatch(/secret|token|password/i);
+  });
+});

--- a/apps/web-next/src/lib/billing/stub-provider-config.ts
+++ b/apps/web-next/src/lib/billing/stub-provider-config.ts
@@ -1,0 +1,117 @@
+/**
+ * STUB-deploy — register the C0 stub as a resolvable BillingProvider.
+ *
+ * The stub is the SECOND Billing Provider Protocol implementation (after the
+ * reference provider, pymthouse). Standing it up as a registered provider proves
+ * a NaaP team can bind to a *different* provider with no NaaP/app code change
+ * (generalization scenario E8; enforced by INT-G).
+ *
+ * "Deploy" here means: a `BillingProvider{slug:"stub", adapterType:"stub"}`
+ * catalog row + the in-process `StubAdapter` in the registry. The stub holds NO
+ * secrets and talks to NO external service, so there is nothing to provision —
+ * unlike pymthouse it needs no env wiring. It is `enabled:false` in the catalog
+ * so it never appears in the production provider picker; binding a team's
+ * `billingAccountRef.providerSlug` to "stub" is an explicit, opt-in action.
+ */
+
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+
+import { getBillingProviderAdapter, hasBillingProviderAdapter } from './registry';
+import { STUB_ADAPTER_SLUG } from './stub-adapter';
+
+export const STUB_PROVIDER_SLUG = STUB_ADAPTER_SLUG; // "stub"
+
+/**
+ * Env gate for surfacing the stub in non-catalog contexts (e.g. an admin
+ * "switch team to stub" affordance). Default OFF — production never enables it.
+ * Resolution through the front door does NOT depend on this; it is a UX gate.
+ */
+export const STUB_PROVIDER_DEPLOY_ENV = 'NAAP_ENABLE_STUB_PROVIDER';
+
+/** True when an operator has explicitly opted the stub in (non-prod / staging). */
+export function isStubProviderDeployEnabled(): boolean {
+  const v = process.env[STUB_PROVIDER_DEPLOY_ENV];
+  return typeof v === 'string' && /^(1|true|yes|on)$/i.test(v.trim());
+}
+
+/** Minimal shape of a seeded `BillingProvider` row. */
+export interface SeedProviderLike {
+  readonly slug: string;
+  readonly enabled: boolean;
+  readonly adapterType?: string | null;
+}
+
+/** Find the stub entry in a seed/catalog list. */
+export function findStubSeed(
+  providers: readonly SeedProviderLike[],
+): SeedProviderLike | undefined {
+  return providers.find((p) => p.slug === STUB_PROVIDER_SLUG);
+}
+
+/**
+ * True when the catalog declares the stub as a registered provider whose
+ * `adapterType` resolves to the stub adapter. (We do not require `enabled:true`
+ * — the stub is intentionally catalog-disabled but still resolvable.)
+ */
+export function isStubSeedRegistered(providers: readonly SeedProviderLike[]): boolean {
+  const seed = findStubSeed(providers);
+  if (!seed) return false;
+  const adapterType = seed.adapterType ?? seed.slug;
+  return adapterType === STUB_PROVIDER_SLUG;
+}
+
+/** True when the registry can resolve the stub adapter (BPP ② surface present). */
+export function isStubAdapterResolvable(): boolean {
+  return hasBillingProviderAdapter(STUB_PROVIDER_SLUG);
+}
+
+export interface StubDeployStatus {
+  /** The stub adapter is registered and resolvable in the registry. */
+  adapterResolvable: boolean;
+  /** The catalog seed registers the stub with a stub-resolving adapterType. */
+  seedRegistered: boolean;
+  /** Operator has opted the stub in for non-catalog UX (default false). */
+  deployEnabled: boolean;
+}
+
+/** Minimal structured logger surface (console satisfies it). */
+export interface StructuredLogger {
+  info?: (message: string) => void;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Emit a single structured log line describing the stub deploy status. The stub
+ * has no secrets/PII, so nothing is redacted. Returns the status for assertions.
+ */
+export function logStubDeployStatus(
+  providers: readonly SeedProviderLike[],
+  logger: StructuredLogger = console,
+  correlationId: string = randomUUID(),
+): StubDeployStatus {
+  const status: StubDeployStatus = {
+    adapterResolvable: isStubAdapterResolvable(),
+    seedRegistered: isStubSeedRegistered(providers),
+    deployEnabled: isStubProviderDeployEnabled(),
+  };
+  const line = JSON.stringify({
+    level: status.adapterResolvable && status.seedRegistered ? 'info' : 'warn',
+    event: 'billing.provider.stub.deploy_status',
+    correlationId,
+    ...status,
+  });
+  const emit =
+    status.adapterResolvable && status.seedRegistered
+      ? (logger.info ?? logger.log)
+      : (logger.warn ?? logger.log);
+  emit?.call(logger, line);
+  return status;
+}
+
+/** The stub adapter instance (for callers that resolve it explicitly). */
+export function getStubAdapter() {
+  return getBillingProviderAdapter(STUB_PROVIDER_SLUG);
+}

--- a/bin/sync-plugin-registry.ts
+++ b/bin/sync-plugin-registry.ts
@@ -333,6 +333,7 @@ async function main(): Promise<void> {
           authType: bp.authType,
           enabled: bp.enabled,
           sortOrder: bp.sortOrder,
+          adapterType: bp.adapterType,
         },
         create: bp,
       });

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -26,6 +26,7 @@ async function seedBillingProviders() {
         authType: provider.authType,
         enabled: provider.enabled,
         sortOrder: provider.sortOrder,
+        adapterType: provider.adapterType,
       },
       create: provider,
     });

--- a/packages/database/src/billing-providers.ts
+++ b/packages/database/src/billing-providers.ts
@@ -7,6 +7,9 @@ export const BILLING_PROVIDERS = [
     authType: 'oauth',
     enabled: true,
     sortOrder: 0,
+    // `adapterType` selects the BillingProviderAdapter (NAAP-A-db). Daydream is
+    // the legacy direct path, not a BPP adapter, so it has none.
+    adapterType: null as string | null,
   },
   {
     slug: 'pymthouse',
@@ -16,5 +19,22 @@ export const BILLING_PROVIDERS = [
     authType: 'oauth',
     enabled: true,
     sortOrder: 1,
+    adapterType: 'pymthouse' as string | null,
+  },
+  {
+    // STUB-deploy: the C0 in-memory stub provider, registered as a first-class
+    // BillingProvider alongside pymthouse. It is the SECOND BPP implementation
+    // and proves the seam is provider-agnostic (INT-G / E8). `enabled:false`
+    // keeps it out of the production provider picker by default; a team can
+    // still bind its `billingAccountRef.providerSlug` to "stub" and the front
+    // door resolves it through the StubAdapter. Never carries real billing.
+    slug: 'stub',
+    displayName: 'Stub Provider (integration)',
+    description: 'In-memory C0 stub billing provider — proves the provider-agnostic seam (INT-G). Not for production billing.',
+    icon: 'Beaker',
+    authType: 'none',
+    enabled: false,
+    sortOrder: 99,
+    adapterType: 'stub' as string | null,
   },
 ] as const;


### PR DESCRIPTION
> 🚫 **DO NOT MERGE** — Phase-2 generalization artifact. Based on `preview/phase-2-integration` (the consolidated integration vehicle), **not** `main`.

## Coordination
```
Plan PR ID:   STUB-deploy
Repo:         NaaP (livepeer/naap)
Base:         preview/phase-2-integration
Depends-on:   C0, NAAP-A (+ NAAP-A-db, NAAP-B/C/1 for the resolve path)
Blocks:       INT-G
Feature flag: NAAP_ENABLE_STUB_PROVIDER (env, default OFF); catalog enabled:false
Merge-safety: stub is catalog-disabled + adapter is in-process only ⇒ no prod
              behavior change; migrations expand-only (adapterType already added
              by NAAP-A-db); INV-1 green.
```

## What
Stand up the **C0 in-memory stub** as a first-class, **registered** `BillingProvider` alongside pymthouse, so the NAAP-C front door can resolve a `naap_` key against **BOTH** providers — proving the seam is provider-agnostic (generalization **E8**, enforced by **INT-G**).

- `BillingProvider{slug:"stub", adapterType:"stub", enabled:false}` added to the catalog; `adapterType` now persisted in all three upsert paths (web-next seed, `packages/database` seed, `sync-plugin-registry`).
- `enabled:false` keeps the stub **out of the production provider picker**; binding a team's `billingAccountRef.providerSlug` to `"stub"` is an explicit, opt-in action. The stub carries **no secrets** and needs **no provisioning** (contrast pymthouse's OIDC/M2M env).
- `src/lib/billing/stub-provider-config.ts`: registration/resolution helpers, `NAAP_ENABLE_STUB_PROVIDER` env gate (default OFF), and structured deploy-status logging (no secrets/PII).

## Self-review
- The static registry (`registry.ts`) and the DB registry (`registry-db.ts`, NAAP-A-db) both resolve `"stub" → StubAdapter`; DB resolution falls back to static on any miss so it stays resolvable even before the catalog row is seeded.
- No live secrets — stub is in-memory only. Structured logs assert no secret-bearing keys.

## Guardrail tests (added)
- catalog registers stub + pymthouse (≥2 providers);
- static + DB registries resolve `"stub"`;
- deploy gate defaults OFF;
- structured log line contains no `secret|token|password`.

## DoD
- [x] Registry resolves ≥2 providers (pymthouse + stub)
- [x] No prod behavior change (catalog-disabled, env gate OFF) — INV-1 green
- [x] No secrets; stub in-memory only
- [ ] **DO NOT MERGE** (intentional)

Made with [Cursor](https://cursor.com)