### PR TITLE
[APP-2] Second reference application (NaaP Sample CLI) — DO NOT MERGE

### DIFF
--- a/apps/web-next/src/app/api/v1/keys/validate/app2-attribution.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/app2-attribution.test.ts
@@ -1,0 +1,119 @@
+/** @vitest-environment node */
+
+/**
+ * APP-2 guardrail (E9) — a second registered app attributes + gates distinctly.
+ *
+ * Drives the real NAAP-C front door (POST /api/v1/keys/validate) with the SAME
+ * native key but two different registered apps (Storyboard and APP-2, the
+ * standalone CLI). Proves:
+ *   - usage attributes to each app's own appId (distinct), and
+ *   - capabilities are gated per app's grant (APP-2 only gets what it's granted),
+ * all provider-agnostic and with no Storyboard-specific code in the path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { POST } from './route';
+import { generateNativeApiKey } from '@/lib/dev-api/native-key';
+import { hashApiKey } from '@naap/database';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+}));
+vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
+
+const getBillingProviderAdapter = vi.fn();
+vi.mock('@/lib/billing/registry', () => ({
+  getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
+}));
+
+const prisma = vi.hoisted(() => ({
+  devApiKey: { findUnique: vi.fn(), update: vi.fn() },
+  team: { findUnique: vi.fn() },
+  application: { findFirst: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+const { rawKey } = generateNativeApiKey();
+const keyHash = hashApiKey(rawKey);
+
+// Provider plan enables BOTH capabilities; per-app gating must narrow them.
+function adapter(slug = 'pymthouse') {
+  return {
+    slug,
+    isConfigured: vi.fn(() => true),
+    mintSignerSession: vi.fn(async () => ({ accessToken: 'tok', tokenType: 'Bearer', expiresIn: 3600 })),
+    validate: vi.fn(async () => ({
+      valid: true,
+      capabilities: ['text-to-image:sdxl', 'text-to-video:ltx'],
+      quota: null,
+    })),
+  };
+}
+
+const STORYBOARD_APP = {
+  id: 'app-storyboard', slug: 'storyboard', type: 'app', teamId: 'team-1', ownerUserId: null,
+  allowedScopes: ['gateway', 'llm'], allowedCapabilities: ['*'], status: 'active',
+};
+const APP2 = {
+  id: 'app-naap-cli', slug: 'naap-sample-cli', type: 'cli', teamId: 'team-1', ownerUserId: null,
+  allowedScopes: ['gateway'], allowedCapabilities: ['text-to-image:sdxl'], status: 'active',
+};
+
+function req(appId: string): NextRequest {
+  return new NextRequest('http://localhost/api/v1/keys/validate', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${rawKey}`, 'x-app-id': appId },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true); // front door + app_registry ON
+  prisma.devApiKey.findUnique.mockResolvedValue({
+    id: 'key-1', userId: 'user-1', keyHash, status: 'ACTIVE', seatId: 'seat-1', teamId: 'team-1',
+  });
+  prisma.team.findUnique.mockResolvedValue({
+    id: 'team-1', billingAccountProviderSlug: 'pymthouse', billingAccountId: 'acct_1',
+  });
+  prisma.devApiKey.update.mockResolvedValue({});
+  getBillingProviderAdapter.mockReturnValue(adapter());
+});
+
+describe('APP-2 vs Storyboard — distinct attribution + gating (E9)', () => {
+  it('attributes to Storyboard and passes caps through (wildcard grant)', async () => {
+    prisma.application.findFirst.mockResolvedValue(STORYBOARD_APP);
+    const res = await POST(req('storyboard'));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+    expect(d.app.id).toBe('storyboard');
+    expect(d.capabilities).toEqual(['text-to-image:sdxl', 'text-to-video:ltx']);
+  });
+
+  it('attributes to APP-2 distinctly and gates caps to its grant', async () => {
+    prisma.application.findFirst.mockResolvedValue(APP2);
+    const res = await POST(req('naap-sample-cli'));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+    expect(d.app.id).toBe('naap-sample-cli');
+    expect(d.app.id).not.toBe('storyboard');
+    // text-to-video filtered out; only the granted capability remains.
+    expect(d.capabilities).toEqual(['text-to-image:sdxl']);
+  });
+
+  it('works unchanged when the team is backed by the stub provider (E8)', async () => {
+    prisma.team.findUnique.mockResolvedValue({
+      id: 'team-1', billingAccountProviderSlug: 'stub', billingAccountId: 'acct_stub_1',
+    });
+    getBillingProviderAdapter.mockReturnValue(adapter('stub'));
+    prisma.application.findFirst.mockResolvedValue(APP2);
+    const res = await POST(req('naap-sample-cli'));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+    expect(d.billingAccount.providerSlug).toBe('stub');
+    expect(d.app.id).toBe('naap-sample-cli');
+    expect(d.capabilities).toEqual(['text-to-image:sdxl']);
+  });
+});

--- a/examples/app2-cli/README.md
+++ b/examples/app2-cli/README.md
@@ -1,0 +1,55 @@
+# APP-2 — NaaP Sample CLI (second reference application)
+
+A **minimal, standalone** application that uses a native `naap_` key to run an
+inference job **through the NaaP front door** (`POST /api/v1/keys/validate`,
+BPP ③). It exists to prove the generalization bar **E9**: the API key +
+capability model is **app-agnostic** — a brand-new app, sharing **zero code with
+Storyboard**, can authenticate, get its plan-gated capabilities, and run work,
+with usage attributed to **its own `appId`**.
+
+It is also **provider-agnostic**: it never sees a provider token or URL. It
+presents a `naap_` key and receives an opaque `signerSession` + a gated
+`capabilities` list — so it behaves identically whether the team is backed by
+**pymthouse** or the **stub** provider (E8 / INT-G).
+
+## Register it (NAAP-D)
+
+`app2.descriptor.json` is the registry descriptor. With the `app_registry` flag
+ON, register it once:
+
+```bash
+curl -sS -X POST "$NAAP/api/v1/apps" \
+  -H "authorization: Bearer <admin-session>" \
+  -H "content-type: application/json" \
+  --data @app2.descriptor.json
+```
+
+NaaP returns the `Application` (its `id`/`slug`). APP-2 presents that value via
+the `X-App-Id` header so usage attributes to it distinctly from Storyboard.
+
+## Run it
+
+```bash
+NAAP_FRONT_DOOR_URL="https://<naap-host>" \
+NAAP_API_KEY="naap_..." \
+NAAP_APP_ID="naap-sample-cli" \
+CAPABILITY="text-to-image:sdxl" \
+node src/cli.mjs
+```
+
+The CLI emits structured JSON logs only and always redacts the key. It does
+**not** fall back to any other path — being independent, it simply reports if the
+front door is unreachable or the capability is denied.
+
+## Test
+
+```bash
+npm test   # node --test, zero dependencies
+```
+
+## Flags / safety
+
+- Requires `key_validation_front_door` (and, for registry-checked attribution,
+  `app_registry`) enabled on the target NaaP. With them OFF the front door 404s
+  and this app reports `app2.front_door_rejected` — no production impact.
+- No secrets are stored or logged.

--- a/examples/app2-cli/app2.descriptor.json
+++ b/examples/app2-cli/app2.descriptor.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "APP-2 registration descriptor for the NaaP Application registry (NAAP-D). Register it by POSTing this to /api/v1/apps (app_registry flag ON) or seeding an Application row. The appId NaaP assigns (or this slug) is what APP-2 presents via X-App-Id so usage attributes to APP-2 distinctly from Storyboard.",
+  "slug": "naap-sample-cli",
+  "name": "NaaP Sample CLI (APP-2)",
+  "type": "cli",
+  "allowedScopes": ["gateway", "llm"],
+  "allowedCapabilities": ["text-to-image:sdxl"],
+  "status": "active"
+}

--- a/examples/app2-cli/package.json
+++ b/examples/app2-cli/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@naap-examples/app2-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "APP-2 — a minimal second reference application that uses a native naap_ key through the NaaP front door. Proves the API key + capability model is app-agnostic (shares zero code with Storyboard).",
+  "bin": {
+    "naap-app2": "./src/cli.mjs"
+  },
+  "scripts": {
+    "start": "node ./src/cli.mjs",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/examples/app2-cli/src/cli.mjs
+++ b/examples/app2-cli/src/cli.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * APP-2 — runnable CLI entry.
+ *
+ * A second reference application that uses a native `naap_` key to run an
+ * inference job through the NaaP front door. It is independent of Storyboard
+ * (shares zero code) and provider-agnostic (works the same whether the team is
+ * backed by pymthouse or the stub) — it only ever talks to the NaaP front door.
+ *
+ * Usage:
+ *   NAAP_FRONT_DOOR_URL=https://<naap>  NAAP_API_KEY=naap_...  \
+ *   NAAP_APP_ID=naap-sample-cli  CAPABILITY=text-to-image:sdxl \
+ *   node src/cli.mjs
+ *
+ * Structured JSON logs only; the API key is always redacted.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  buildInferenceRequest,
+  buildValidateRequest,
+  hasCapability,
+  parseFrontDoorResponse,
+  redactKey,
+} from './front-door-client.mjs';
+
+function log(level, event, fields) {
+  process.stdout.write(`${JSON.stringify({ level, event, ...fields })}\n`);
+}
+
+async function main() {
+  const frontDoorUrl = process.env.NAAP_FRONT_DOOR_URL;
+  const apiKey = process.env.NAAP_API_KEY;
+  const appId = process.env.NAAP_APP_ID || 'naap-sample-cli';
+  const capability = process.env.CAPABILITY || 'text-to-image:sdxl';
+  const prompt = process.env.PROMPT;
+  const requestId = randomUUID();
+
+  log('info', 'app2.start', { appId, capability, requestId, apiKey: redactKey(apiKey) });
+
+  let req;
+  try {
+    req = buildValidateRequest({ frontDoorUrl, apiKey, appId, requestId });
+  } catch (err) {
+    log('error', 'app2.config_error', { requestId, message: err.message });
+    process.exitCode = 2;
+    return;
+  }
+
+  let res;
+  try {
+    res = await fetch(req.url, { method: req.method, headers: req.headers });
+  } catch (err) {
+    // Independent app: no Storyboard/Daydream fallback — it just reports.
+    log('error', 'app2.front_door_unreachable', { requestId, message: String(err?.message ?? err) });
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!res.ok) {
+    log('error', 'app2.front_door_rejected', { requestId, status: res.status });
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = parseFrontDoorResponse(await res.json());
+  if (!result.valid) {
+    log('error', 'app2.key_invalid', { requestId });
+    process.exitCode = 1;
+    return;
+  }
+
+  log('info', 'app2.validated', {
+    requestId,
+    appId: result.app?.id ?? appId,
+    providerSlug: result.billingAccount?.providerSlug,
+    capabilityCount: result.capabilities.length,
+  });
+
+  if (!hasCapability(result.capabilities, capability)) {
+    log('warn', 'app2.capability_denied', { requestId, capability, granted: result.capabilities });
+    process.exitCode = 3;
+    return;
+  }
+
+  const inference = buildInferenceRequest({
+    signerSession: result.signerSession,
+    capability,
+    prompt,
+  });
+  if (!inference) {
+    log('error', 'app2.no_signer_session', { requestId });
+    process.exitCode = 1;
+    return;
+  }
+
+  // Mock "run": a real app would POST `inference` to the signer/inference URL.
+  log('info', 'app2.inference_ready', {
+    requestId,
+    capability,
+    target: inference.url,
+    usesProviderSession: Boolean(result.signerSession),
+  });
+  log('info', 'app2.done', { requestId, appId, providerSlug: result.billingAccount?.providerSlug });
+}
+
+main().catch((err) => {
+  log('error', 'app2.fatal', { message: String(err?.message ?? err) });
+  process.exitCode = 1;
+});

--- a/examples/app2-cli/src/front-door-client.mjs
+++ b/examples/app2-cli/src/front-door-client.mjs
@@ -1,0 +1,98 @@
+/**
+ * APP-2 front-door client — pure, dependency-free request/response logic.
+ *
+ * This module shares ZERO code with Storyboard. It speaks only the NaaP front
+ * door (BPP ③, POST /api/v1/keys/validate) using a native `naap_` key + an
+ * `X-App-Id`. It never sees provider tokens/URLs directly — it receives an
+ * opaque `signerSession` and a gated `capabilities` list, which proves the API
+ * key + capability model is app-agnostic.
+ *
+ * Kept side-effect-free so it is unit-testable without a live server; `cli.mjs`
+ * wires it to `fetch` + `process.env`.
+ */
+
+export const NATIVE_KEY_PREFIX = 'naap_';
+
+/** Redact a key for logs: keep the prefix + last 4, mask the middle. */
+export function redactKey(key) {
+  if (typeof key !== 'string' || key.length === 0) return '(none)';
+  const tail = key.slice(-4);
+  return `${NATIVE_KEY_PREFIX}…${tail}`;
+}
+
+/**
+ * Build the front-door validate request. Throws on obvious misuse (so the CLI
+ * fails fast with a clear message instead of sending a doomed request).
+ *
+ * @param {{ frontDoorUrl: string, apiKey: string, appId: string, requestId?: string }} input
+ * @returns {{ url: string, method: 'POST', headers: Record<string,string> }}
+ */
+export function buildValidateRequest({ frontDoorUrl, apiKey, appId, requestId }) {
+  if (!frontDoorUrl) throw new Error('frontDoorUrl is required');
+  if (!apiKey || !apiKey.startsWith(NATIVE_KEY_PREFIX)) {
+    throw new Error(`apiKey must be a native ${NATIVE_KEY_PREFIX} key`);
+  }
+  if (!appId) throw new Error('appId is required (X-App-Id) for per-app attribution');
+  const url = new URL('/api/v1/keys/validate', frontDoorUrl).toString();
+  const headers = {
+    authorization: `Bearer ${apiKey}`,
+    'x-app-id': appId,
+    'content-type': 'application/json',
+  };
+  if (requestId) headers['x-request-id'] = requestId;
+  return { url, method: 'POST', headers };
+}
+
+/**
+ * Normalize the front-door response envelope. NaaP wraps payloads as
+ * `{ success, data }`; tolerate a bare payload too.
+ *
+ * @param {unknown} json
+ * @returns {{ valid: boolean, user?: object, app?: object, billingAccount?: object, capabilities: string[], quota: unknown, signerSession?: object }}
+ */
+export function parseFrontDoorResponse(json) {
+  const body = json && typeof json === 'object' && 'data' in json ? json.data : json;
+  const d = body && typeof body === 'object' ? body : {};
+  return {
+    valid: d.valid === true,
+    user: d.user,
+    app: d.app,
+    billingAccount: d.billingAccount,
+    capabilities: Array.isArray(d.capabilities) ? d.capabilities : [],
+    quota: d.quota ?? null,
+    signerSession: d.signerSession,
+  };
+}
+
+/** True when the gated capability set permits the desired capability. */
+export function hasCapability(capabilities, desired) {
+  return Array.isArray(capabilities) && capabilities.includes(desired);
+}
+
+/**
+ * Build a (mock) inference request from the front-door result. The app uses the
+ * provider-issued `signerSession` opaquely — it copies the session's headers
+ * without interpreting them, which is exactly how an app-agnostic client should
+ * behave. Returns null when the capability is not granted (caller should stop).
+ *
+ * @returns {{ url: string, method: 'POST', headers: Record<string,string>, body: object } | null}
+ */
+export function buildInferenceRequest({ signerSession, capability, prompt }) {
+  if (!signerSession || typeof signerSession !== 'object') return null;
+  const headers = { 'content-type': 'application/json' };
+  // signerSession is opaque to the app: forward its headers verbatim if present,
+  // else use a bearer access token if that's how the provider issued it.
+  if (signerSession.headers && typeof signerSession.headers === 'object') {
+    for (const [k, v] of Object.entries(signerSession.headers)) headers[k] = String(v);
+  } else if (signerSession.accessToken) {
+    const type = signerSession.tokenType || 'Bearer';
+    headers.authorization = `${type} ${signerSession.accessToken}`;
+  }
+  const url = signerSession.url || 'mock://inference/run';
+  return {
+    url,
+    method: 'POST',
+    headers,
+    body: { capability, prompt: prompt ?? 'a small robot reading a book' },
+  };
+}

--- a/examples/app2-cli/test/front-door-client.test.mjs
+++ b/examples/app2-cli/test/front-door-client.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * APP-2 guardrail tests (node:test — zero-dep, runnable via `npm test`).
+ *
+ * Proves the second app's front-door request/response logic is correct and
+ * provider-agnostic: it builds a native-key validate call with a per-app
+ * X-App-Id, enforces capability gating, and consumes the provider-issued signer
+ * session opaquely.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildInferenceRequest,
+  buildValidateRequest,
+  hasCapability,
+  parseFrontDoorResponse,
+  redactKey,
+} from '../src/front-door-client.mjs';
+
+test('redactKey masks the secret but keeps a hint', () => {
+  assert.equal(redactKey('naap_abcdef123456WXYZ'), 'naap_…WXYZ');
+  assert.equal(redactKey(''), '(none)');
+});
+
+test('buildValidateRequest targets the front door with bearer + X-App-Id', () => {
+  const req = buildValidateRequest({
+    frontDoorUrl: 'https://naap.example',
+    apiKey: 'naap_secrettoken',
+    appId: 'naap-sample-cli',
+    requestId: 'req-1',
+  });
+  assert.equal(req.url, 'https://naap.example/api/v1/keys/validate');
+  assert.equal(req.method, 'POST');
+  assert.equal(req.headers.authorization, 'Bearer naap_secrettoken');
+  assert.equal(req.headers['x-app-id'], 'naap-sample-cli');
+  assert.equal(req.headers['x-request-id'], 'req-1');
+});
+
+test('buildValidateRequest rejects a non-native key (D1: naap_ only)', () => {
+  assert.throws(
+    () =>
+      buildValidateRequest({
+        frontDoorUrl: 'https://naap.example',
+        apiKey: 'pmth_providertoken',
+        appId: 'naap-sample-cli',
+      }),
+    /native naap_ key/,
+  );
+});
+
+test('buildValidateRequest requires an appId for attribution', () => {
+  assert.throws(
+    () => buildValidateRequest({ frontDoorUrl: 'https://x', apiKey: 'naap_k', appId: '' }),
+    /appId is required/,
+  );
+});
+
+test('parseFrontDoorResponse unwraps the {success,data} envelope', () => {
+  const parsed = parseFrontDoorResponse({
+    success: true,
+    data: {
+      valid: true,
+      user: { sub: 'u1' },
+      app: { id: 'naap-sample-cli', scopes: ['gateway', 'llm'] },
+      billingAccount: { id: 'acct_stub_1', providerSlug: 'stub' },
+      capabilities: ['text-to-image:sdxl'],
+      quota: { remaining: 10 },
+      signerSession: { url: 'https://signer/x', headers: { Authorization: 'Bearer t' } },
+    },
+  });
+  assert.equal(parsed.valid, true);
+  assert.equal(parsed.app.id, 'naap-sample-cli');
+  assert.equal(parsed.billingAccount.providerSlug, 'stub');
+  assert.deepEqual(parsed.capabilities, ['text-to-image:sdxl']);
+});
+
+test('hasCapability enforces the gated capability set', () => {
+  assert.equal(hasCapability(['text-to-image:sdxl'], 'text-to-image:sdxl'), true);
+  assert.equal(hasCapability(['text-to-image:sdxl'], 'text-to-video:ltx'), false);
+});
+
+test('buildInferenceRequest forwards an opaque signer session (header style)', () => {
+  const req = buildInferenceRequest({
+    signerSession: { url: 'https://signer.stub/session', headers: { Authorization: 'Bearer stub-tok' } },
+    capability: 'text-to-image:sdxl',
+    prompt: 'hi',
+  });
+  assert.equal(req.url, 'https://signer.stub/session');
+  assert.equal(req.headers.Authorization, 'Bearer stub-tok');
+  assert.equal(req.body.capability, 'text-to-image:sdxl');
+});
+
+test('buildInferenceRequest supports accessToken-style sessions', () => {
+  const req = buildInferenceRequest({
+    signerSession: { accessToken: 'abc', tokenType: 'Bearer' },
+    capability: 'text-to-image:sdxl',
+  });
+  assert.equal(req.headers.authorization, 'Bearer abc');
+});
+
+test('buildInferenceRequest returns null without a signer session', () => {
+  assert.equal(buildInferenceRequest({ signerSession: null, capability: 'x' }), null);
+});


### PR DESCRIPTION
> 🚫 **DO NOT MERGE** — Phase-2 generalization artifact. Based on `preview/phase-2-integration`, **not** `main`.

## Coordination
```
Plan PR ID:   APP-2
Repo:         NaaP (livepeer/naap)
Base:         preview/phase-2-integration
Depends-on:   NAAP-D, NAAP-B (+ NAAP-C front door, NAAP-1 seats)
Blocks:       INT-G
Feature flag: key_validation_front_door + app_registry (default OFF)
Merge-safety: a new standalone example app + tests only; touches no runtime route;
              does nothing unless the front-door/app_registry flags are ON. INV-1 green.
```

## What
A **minimal second reference application** (`examples/app2-cli`) that uses a native `naap_` key through the **NAAP-C front door** (BPP ③) to run an inference job. Shares **zero code with Storyboard**; **provider-agnostic** (never sees a provider token/URL — only an opaque `signerSession` + gated `capabilities`). Proves the API key + capability model is **app-agnostic** (generalization **E9**).

- `examples/app2-cli/` — zero-dependency ESM front-door client + runnable CLI + `app2.descriptor.json` (NAAP-D registration) + README. Structured JSON logs only; key always redacted; `node --test` suite (9 tests, green).
- `apps/web-next/.../app2-attribution.test.ts` — drives the **real** front door with the SAME key under **two** registered apps (Storyboard + APP-2): asserts distinct per-app attribution; capabilities gated to each app's grant (`text-to-video` filtered for APP-2); same flow works under the **stub** provider (**E8**).

## Self-review
- App-agnostic: no Storyboard imports; only coupling is the front-door contract + `X-App-Id`.
- Provider-agnostic: identical under pymthouse vs stub (tested).
- Safe: needs `key_validation_front_door` (+ `app_registry`) ON to act; default OFF ⇒ no prod impact. No secrets.

## DoD
- [x] Second app registered via NAAP-D; uses a `naap_` key through the front door
- [x] Usage attributes to APP-2's appId, distinct from Storyboard
- [x] Provider-agnostic (works under stub) — E8/E9
- [x] No prod impact (flags default OFF) — INV-1 green
- [ ] **DO NOT MERGE** (intentional)

Made with [Cursor](https://cursor.com)