### PR TITLE
chore(pymthouse): upgrade builder-sdk to 0.4.3 and new API key handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "postman.settings.dotenv-detection-notification-visibility": false,
+    "snyk.advanced.organization": "cbc981c5-dab7-4df8-8d63-d7b23bab285f",
+    "snyk.advanced.autoSelectOrganization": true
+}

--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.1.0",
+    "@pymthouse/builder-sdk": "0.4.3",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/apps/web-next/src/app/api/pymthouse/keys/exchange/route.ts
+++ b/apps/web-next/src/app/api/pymthouse/keys/exchange/route.ts
@@ -1,0 +1,23 @@
+import { createApiKeyExchangeHandler } from '@pymthouse/builder-sdk/signer/server';
+
+import { readApiKeyExchangeConfig } from '@/lib/pymthouse-signer-exchange-config';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const config = readApiKeyExchangeConfig();
+  if (!config) {
+    return Response.json(
+      {
+        error: 'server_misconfigured',
+        error_description:
+          'PYMTHOUSE_ISSUER_URL, PYMTHOUSE_PUBLIC_CLIENT_ID, PYMTHOUSE_M2M_CLIENT_ID, and PYMTHOUSE_M2M_CLIENT_SECRET are required',
+      },
+      { status: 503 },
+    );
+  }
+
+  const handler = createApiKeyExchangeHandler(config);
+  return handler(request);
+}

--- a/apps/web-next/src/app/api/signer/device/exchange/route.ts
+++ b/apps/web-next/src/app/api/signer/device/exchange/route.ts
@@ -1,0 +1,23 @@
+import { createDeviceExchangeHandler } from '@pymthouse/builder-sdk/signer/server';
+
+import { readDeviceExchangeConfig } from '@/lib/pymthouse-signer-exchange-config';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const config = readDeviceExchangeConfig();
+  if (!config) {
+    return Response.json(
+      {
+        error: 'server_misconfigured',
+        error_description:
+          'PYMTHOUSE_ISSUER_URL, PYMTHOUSE_M2M_CLIENT_ID, and PYMTHOUSE_M2M_CLIENT_SECRET are required',
+      },
+      { status: 503 },
+    );
+  }
+
+  const handler = createDeviceExchangeHandler(config);
+  return handler(request);
+}

--- a/apps/web-next/src/app/api/v1/auth/providers/[providerSlug]/start/route.ts
+++ b/apps/web-next/src/app/api/v1/auth/providers/[providerSlug]/start/route.ts
@@ -3,17 +3,17 @@
  * Start a brokered billing-provider authentication session.
  *
  * - daydream: browser-redirect OAuth (unchanged).
- * - pymthouse: server-to-server Builder API + RFC 8693 token exchange (no browser popup).
- *   NaaP upserts the user, mints a short-lived internal `sign:job` JWT, exchanges it
- *   with the confidential M2M client for a long-lived opaque `pmth_…` signer session,
- *   and returns that token as `access_token`. The frontend skips popup/polling.
+ * - pymthouse: server-to-server PymtHouse user API key mint (Dashboard parity).
+ *   NaaP provisions the app user and mints a long-lived pmth_* key via the Builder
+ *   Apps API. The SDK exchanges that key for a short-lived signer JWT at runtime
+ *   via POST /api/pymthouse/keys/exchange. The frontend skips popup/polling.
  *
- *   The short-lived JWT is never exposed as the developer API key. Callers may
- *   re-mint a fresh signer session via POST /api/v1/billing/pymthouse/token.
+ *   Opaque signer sessions remain available via POST /api/v1/billing/pymthouse/token.
  */
 
 import * as crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
+import { PmtHouseError } from '@pymthouse/builder-sdk';
 import { success, errors, getAuthToken } from '@/lib/api/response';
 import { validateSession } from '@/lib/api/auth';
 import { validateCSRF } from '@/lib/api/csrf';
@@ -23,22 +23,23 @@ import {
   isPymthouseConfigured,
   PYMTHOUSE_NOT_CONFIGURED_MESSAGE,
 } from '@pymthouse/builder-sdk/config';
-import type { SignerSessionToken } from '@pymthouse/builder-sdk/tokens';
-import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import { SIGN_JOB_SCOPE } from '@pymthouse/builder-sdk';
+import { createPymthouseApiKey } from '@/lib/pymthouse-keys-bff';
 import { isRedirectFlowBillingProvider } from '@/lib/billing-providers';
 
 const LOGIN_SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
+/** Nominal OAuth-session TTL when pymthouse start completes immediately (key itself is long-lived). */
+const PYMTHOUSE_START_SESSION_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
 /**
- * PymtHouse: server-to-server Builder mint + issuer token exchange for a durable
- * opaque signer session — no browser redirect.
+ * PymtHouse: provision app user + mint long-lived pmth_* API key (exchangeable by SDK).
  */
 async function executePymthouseUserLink(
   naapUserId: string | null,
   userEmail?: string | null,
-): Promise<SignerSessionToken | null> {
+): Promise<string | null> {
   if (!isPymthouseConfigured()) {
     return null;
   }
@@ -47,10 +48,11 @@ async function executePymthouseUserLink(
     return null;
   }
 
-  return getPmtHouseServerClient().mintSignerSessionForExternalUser({
+  const { apiKey } = await createPymthouseApiKey({
     externalUserId: naapUserId,
-    email: userEmail ?? undefined,
+    email: userEmail,
   });
+  return apiKey;
 }
 
 export async function POST(
@@ -96,23 +98,23 @@ export async function POST(
 
     const loginSessionId = crypto.randomBytes(32).toString('hex');
 
-    // ── PymtHouse: Builder mint + RFC 8693 exchange (opaque pmth session) ───
+    // ── PymtHouse: Builder user API key (pmth_*, SDK exchangeable) ─────────
     if (providerSlug === 'pymthouse') {
-      let token: SignerSessionToken | null;
+      let apiKey: string | null;
       try {
-        token = await executePymthouseUserLink(
+        apiKey = await executePymthouseUserLink(
           naapUserId,
           authenticatedUser?.email,
         );
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Unknown error';
+        const msg = err instanceof PmtHouseError ? err.message : err instanceof Error ? err.message : 'Unknown error';
         console.error('[billing-auth:pymthouse] Builder API error:', { msg, err });
         return errors.badRequest(
           'User linking failed; please try again or contact support.',
         );
       }
 
-      if (!token) {
+      if (!apiKey) {
         return errors.badRequest(PYMTHOUSE_NOT_CONFIGURED_MESSAGE);
       }
 
@@ -128,7 +130,7 @@ export async function POST(
           accessToken: null,
           providerUserId: naapUserId,
           redeemedAt: new Date(),
-          expiresAt: new Date(Date.now() + token.expiresIn * 1000),
+          expiresAt: new Date(Date.now() + PYMTHOUSE_START_SESSION_TTL_MS),
         },
       });
 
@@ -136,11 +138,11 @@ export async function POST(
 
       const tokenRes = success({
         auth_url: null,
-        access_token: token.accessToken,
-        token_type: token.tokenType,
-        scope: token.scope,
+        access_token: apiKey,
+        token_type: 'Bearer',
+        scope: SIGN_JOB_SCOPE,
         login_session_id: loginSessionId,
-        expires_in: token.expiresIn,
+        expires_in: Math.floor(PYMTHOUSE_START_SESSION_TTL_MS / 1000),
         poll_after_ms: 0,
       });
       tokenRes.headers.set('Cache-Control', 'no-store');

--- a/apps/web-next/src/app/api/v1/billing/pymthouse/config/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/pymthouse/config/route.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /api/v1/billing/pymthouse/config
+ * Public PymtHouse integration settings for the Developer API UI (no secrets).
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  isPymthouseConfigured,
+  PYMTHOUSE_NOT_CONFIGURED_MESSAGE,
+} from '@pymthouse/builder-sdk/config';
+
+import { errors, success } from '@/lib/api/response';
+import { resolvePymthouseSignerUrl } from '@/lib/pymthouse-signer-exchange-config';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  if (!isPymthouseConfigured()) {
+    return errors.badRequest(PYMTHOUSE_NOT_CONFIGURED_MESSAGE);
+  }
+
+  const signerUrl = resolvePymthouseSignerUrl();
+  if (!signerUrl) {
+    return errors.badRequest(PYMTHOUSE_NOT_CONFIGURED_MESSAGE);
+  }
+
+  const res = success({ signerUrl });
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}

--- a/apps/web-next/src/app/api/v1/billing/pymthouse/token/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/pymthouse/token/route.ts
@@ -11,7 +11,7 @@ import { success, errors, getAuthToken } from '@/lib/api/response';
 import { validateSession } from '@/lib/api/auth';
 import { validateCSRF } from '@/lib/api/csrf';
 import { enforceRateLimit } from '@/lib/api/rate-limit';
-import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import { mintSignerSessionForExternalUser } from '@/lib/pymthouse-client';
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_PER_USER = 30;
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     try {
-      const session = await getPmtHouseServerClient().mintSignerSessionForExternalUser({
+      const session = await mintSignerSessionForExternalUser({
         externalUserId: authUser.id,
         email: authUser.email ?? undefined,
       });

--- a/apps/web-next/src/app/api/v1/billing/pymthouse/usage/route.test.ts
+++ b/apps/web-next/src/app/api/v1/billing/pymthouse/usage/route.test.ts
@@ -91,6 +91,7 @@ describe('GET /api/v1/billing/pymthouse/usage', () => {
     expect(fetchUsageForExternalUser).toHaveBeenCalledWith(
       expect.objectContaining({
         externalUserId: 'user-naap-1',
+        includeRetail: true,
       }),
     );
     const json = await res.json();

--- a/apps/web-next/src/app/api/v1/billing/pymthouse/usage/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/pymthouse/usage/route.ts
@@ -125,6 +125,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
           externalUserId: sessionUser.id,
           startDate,
           endDate,
+          includeRetail: true,
         });
         return noStore(success(stripCryptoUnitFields(body)));
       } catch (e) {

--- a/apps/web-next/src/app/api/v1/developer/keys/[id]/route.ts
+++ b/apps/web-next/src/app/api/v1/developer/keys/[id]/route.ts
@@ -9,9 +9,6 @@ import { prisma } from '@/lib/db';
 import { validateSession } from '@/lib/api/auth';
 import { success, errors, getAuthToken } from '@/lib/api/response';
 import { validateCSRF } from '@/lib/api/csrf';
-import { computeSignerSessionExpiry } from '@pymthouse/builder-sdk/tokens';
-
-const PYMTHOUSE_PROVIDER_SLUG = 'pymthouse';
 
 /**
  * Strip credential-derived material (`keyHash`, `keyLookupId`) before
@@ -63,26 +60,10 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
       return errors.notFound('API key');
     }
 
-    if (apiKey.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG) {
-      const expiredByAge =
-        apiKey.status === 'ACTIVE' &&
-        computeSignerSessionExpiry(apiKey.createdAt).getTime() <= Date.now();
-      const alreadyExpired = apiKey.status === 'EXPIRED';
-      if (expiredByAge || alreadyExpired) {
-        await prisma.devApiKey.deleteMany({
-          where: { id: apiKey.id },
-        });
-        return errors.notFound('API key');
-      }
-    }
-
     return success({
       key: {
         ...toSafeDevApiKey(apiKey),
-        expiresAt:
-          apiKey.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-            ? computeSignerSessionExpiry(apiKey.createdAt).toISOString()
-            : null,
+        expiresAt: null,
       },
     });
   } catch (err) {

--- a/apps/web-next/src/app/api/v1/developer/keys/[id]/route.ts
+++ b/apps/web-next/src/app/api/v1/developer/keys/[id]/route.ts
@@ -60,6 +60,13 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
       return errors.notFound('API key');
     }
 
+    // Hide EXPIRED PymtHouse keys so this single-key endpoint stays consistent
+    // with the list endpoint (which filters them) and the plugin backend GET
+    // /:id handler (which 404s them). Non-PymtHouse keys are unaffected.
+    if (apiKey.billingProvider?.slug === 'pymthouse' && apiKey.status === 'EXPIRED') {
+      return errors.notFound('API key');
+    }
+
     return success({
       key: {
         ...toSafeDevApiKey(apiKey),

--- a/apps/web-next/src/app/api/v1/developer/keys/route.ts
+++ b/apps/web-next/src/app/api/v1/developer/keys/route.ts
@@ -18,49 +18,11 @@ import {
   hashApiKey,
 } from '@naap/database';
 import {
-  computeSignerSessionExpiry,
   decodeJwtExp,
   isLikelyOidcJwt,
-  SIGNER_SESSION_TTL_MS,
 } from '@pymthouse/builder-sdk/tokens';
 
 const PYMTHOUSE_PROVIDER_SLUG = 'pymthouse';
-
-// Throttle window for opportunistic cleanup off the GET path. We must not
-// run a database delete on every list request — GETs should be safe per
-// HTTP semantics, and an unthrottled delete on every read produces
-// unpredictable response times, non-atomic delete+findMany ordering
-// surprises, and elevated connection use under load. A scheduled cron
-// (`/api/cron/cleanup-expired-keys` behind `CRON_SECRET`) should own the
-// authoritative cleanup; this fallback only fires at most once per
-// process per window, and only if we haven't seen a cleanup recently.
-const EXPIRED_KEY_CLEANUP_THROTTLE_MS = 15 * 60 * 1000;
-let lastExpiredKeyCleanupAt = 0;
-
-async function maybeCleanupExpiredPymthouseKeys(userId: string): Promise<void> {
-  const now = Date.now();
-  if (now - lastExpiredKeyCleanupAt < EXPIRED_KEY_CLEANUP_THROTTLE_MS) {
-    return;
-  }
-  lastExpiredKeyCleanupAt = now;
-
-  const expiryCutoff = new Date(now - SIGNER_SESSION_TTL_MS);
-  try {
-    await prisma.devApiKey.deleteMany({
-      where: {
-        userId,
-        billingProvider: { slug: PYMTHOUSE_PROVIDER_SLUG },
-        OR: [
-          { status: 'ACTIVE', createdAt: { lte: expiryCutoff } },
-          { status: 'EXPIRED' },
-        ],
-      },
-    });
-  } catch (err) {
-    // Cleanup is best-effort. Never let a failure here break the read path.
-    console.warn('[developer/keys] Background expired-key cleanup failed:', err);
-  }
-}
 
 /**
  * Strip credential-derived material before returning a DevApiKey to the
@@ -80,10 +42,7 @@ function toSafeDevApiKey<
   const { keyHash: _keyHash, keyLookupId: _keyLookupId, ...rest } = key;
   return {
     ...rest,
-    expiresAt:
-      key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-        ? computeSignerSessionExpiry(key.createdAt).toISOString()
-        : null,
+    expiresAt: null,
   };
 }
 
@@ -99,26 +58,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return errors.unauthorized('Invalid or expired session');
     }
 
-    // Fire-and-forget throttled cleanup so the read path remains fast and
-    // mostly side-effect free; expired keys are filtered out of the
-    // response regardless of whether cleanup ran this request.
-    void maybeCleanupExpiredPymthouseKeys(user.id);
-
     const searchParams = request.nextUrl.searchParams;
     const { page, pageSize, skip } = parsePagination(searchParams);
 
-    // Exclude expired PymtHouse keys at the DB layer (mirrors
-    // isExpiredPymthouseKey) so total/totalPages stay aligned with the rows
-    // actually returned, instead of filtering after pagination.
-    const expiryCutoff = new Date(Date.now() - SIGNER_SESSION_TTL_MS);
     const listWhere: Prisma.DevApiKeyWhereInput = {
       userId: user.id,
       NOT: {
         billingProvider: { slug: PYMTHOUSE_PROVIDER_SLUG },
-        OR: [
-          { status: 'EXPIRED' },
-          { status: 'ACTIVE', createdAt: { lte: expiryCutoff } },
-        ],
+        status: 'EXPIRED',
       },
     };
 
@@ -263,7 +210,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       rawApiKey,
       warning:
         provider.slug === PYMTHOUSE_PROVIDER_SLUG
-          ? 'Store this key securely. It expires after about 90 days and will not be shown again.'
+          ? 'Store this key securely. It is long-lived until revoked and will not be shown again.'
           : 'Store this key securely. It will not be shown again.',
     });
   } catch (err) {

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -85,6 +85,8 @@ async function exchangeUserJwtForOpaqueSignerSession(
     },
     body: params.toString(),
     cache: 'no-store',
+    // Fail fast instead of hanging if the PymtHouse token endpoint is unresponsive.
+    signal: AbortSignal.timeout(15_000),
   });
 
   let body: Record<string, unknown>;
@@ -125,7 +127,10 @@ async function exchangeUserJwtForOpaqueSignerSession(
   return parseSignerSessionExchange({
     access_token: accessToken,
     token_type: 'Bearer',
-    expires_in: expiresIn ?? 0,
+    // Fall back to a conservative 5-minute TTL when the provider omits
+    // `expires_in`; a 0 here would mark the session as immediately expired and
+    // disable the SDK's proactive (80%-of-TTL) refresh / reuse.
+    expires_in: expiresIn ?? 300,
     scope: scopeOut,
     issued_token_type: issuedTokenType ?? REQUESTED_ACCESS_TOKEN_TYPE,
   });

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -5,8 +5,21 @@
 
 import 'server-only';
 
+import {
+  loadAuthorizationServer,
+  PmtHouseError,
+  PYMTHOUSE_NOT_CONFIGURED_MESSAGE,
+  readPymthouseEnv,
+  SIGN_JOB_SCOPE,
+  parseSignerSessionExchange,
+  type SignerSessionToken,
+} from '@pymthouse/builder-sdk';
 import { createPmtHouseClientFromEnv } from '@pymthouse/builder-sdk/env';
 import type { PmtHouseClient } from '@pymthouse/builder-sdk';
+
+const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const SUBJECT_ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
+const REQUESTED_ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
 
 let cached: PmtHouseClient | null = null;
 
@@ -20,4 +33,123 @@ export function getPmtHouseServerClient(): PmtHouseClient {
 /** Vitest / isolated tests: clear module-level singleton. */
 export function resetPmtHouseServerClientForTests(): void {
   cached = null;
+}
+
+/**
+ * Exchange a short-lived user JWT for an opaque `pmth_…` signer session.
+ *
+ * `@pymthouse/builder-sdk@0.4.3` `PmtHouseClient.mintSignerSessionForExternalUser` sets
+ * `resource` to the OIDC issuer URL. Current PymtHouse routes that to signer-JWT
+ * exchange (no `issued_token_type`, returns another JWT). Omitting `resource` selects
+ * gateway opaque-session exchange instead.
+ */
+async function exchangeUserJwtForOpaqueSignerSession(
+  userJwt: string,
+  scope: string = SIGN_JOB_SCOPE,
+): Promise<SignerSessionToken> {
+  const env = readPymthouseEnv();
+  if (!env) {
+    throw new PmtHouseError(PYMTHOUSE_NOT_CONFIGURED_MESSAGE, {
+      status: 400,
+      code: 'pymthouse_required',
+    });
+  }
+
+  const allowInsecureHttp =
+    process.env.PYMTHOUSE_ALLOW_INSECURE_HTTP === '1' || env.issuerUrl.startsWith('http:');
+
+  const as = await loadAuthorizationServer(env.issuerUrl, fetch, { allowInsecureHttp });
+  const tokenEndpoint = as.token_endpoint;
+  if (!tokenEndpoint) {
+    throw new PmtHouseError('OIDC discovery document is missing token_endpoint', {
+      status: 502,
+      code: 'oidc_discovery_invalid',
+    });
+  }
+
+  const params = new URLSearchParams();
+  params.set('grant_type', TOKEN_EXCHANGE_GRANT);
+  params.set('subject_token', userJwt);
+  params.set('subject_token_type', SUBJECT_ACCESS_TOKEN_TYPE);
+  params.set('requested_token_type', REQUESTED_ACCESS_TOKEN_TYPE);
+  if (scope.trim()) {
+    params.set('scope', scope.trim());
+  }
+
+  const response = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${env.m2mClientId}:${env.m2mClientSecret}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: params.toString(),
+    cache: 'no-store',
+  });
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await response.json()) as Record<string, unknown>;
+  } catch {
+    throw new PmtHouseError('Token exchange returned invalid JSON', {
+      status: 502,
+      code: 'invalid_token_response',
+    });
+  }
+
+  if (!response.ok) {
+    const description =
+      typeof body.error_description === 'string'
+        ? body.error_description
+        : typeof body.error === 'string'
+          ? body.error
+          : `Token exchange failed (${response.status})`;
+    throw new PmtHouseError(description, {
+      status: response.status,
+      code: typeof body.error === 'string' ? body.error : 'token_exchange_failed',
+      details: body,
+    });
+  }
+
+  const accessToken =
+    typeof body.access_token === 'string' ? body.access_token.trim() : '';
+  const expiresIn =
+    typeof body.expires_in === 'number' && Number.isFinite(body.expires_in)
+      ? body.expires_in
+      : undefined;
+  const scopeOut =
+    typeof body.scope === 'string' && body.scope.trim() ? body.scope.trim() : scope;
+  const issuedTokenType =
+    typeof body.issued_token_type === 'string' ? body.issued_token_type : undefined;
+
+  return parseSignerSessionExchange({
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: expiresIn ?? 0,
+    scope: scopeOut,
+    issued_token_type: issuedTokenType ?? REQUESTED_ACCESS_TOKEN_TYPE,
+  });
+}
+
+/** Mint an opaque `pmth_…` signer session for a NaaP user (workaround for SDK 0.4.3 routing). */
+export async function mintSignerSessionForExternalUser(input: {
+  externalUserId: string;
+  email?: string;
+  scope?: string;
+}): Promise<SignerSessionToken> {
+  const client = getPmtHouseServerClient();
+  const scope = input.scope?.trim() || SIGN_JOB_SCOPE;
+
+  await client.upsertAppUser({
+    externalUserId: input.externalUserId,
+    email: input.email,
+    status: 'active',
+  });
+
+  const userToken = await client.mintUserAccessToken({
+    externalUserId: input.externalUserId,
+    scope,
+  });
+
+  return exchangeUserJwtForOpaqueSignerSession(userToken.access_token, scope);
 }

--- a/apps/web-next/src/lib/pymthouse-keys-bff.ts
+++ b/apps/web-next/src/lib/pymthouse-keys-bff.ts
@@ -84,6 +84,8 @@ export async function ensureAppUserProvisioned(
         status: 'active',
       }),
       cache: 'no-store',
+      // Fail fast instead of hanging if the Builder Apps API is unresponsive.
+      signal: AbortSignal.timeout(10_000),
     },
   );
   if (!response.ok && response.status !== 409) {
@@ -111,6 +113,8 @@ export async function createPymthouseApiKey(input: {
     },
     body: JSON.stringify(input.label ? { label: input.label } : {}),
     cache: 'no-store',
+    // Fail fast instead of hanging if the Builder Apps API is unresponsive.
+    signal: AbortSignal.timeout(10_000),
   });
 
   if (!response.ok) {

--- a/apps/web-next/src/lib/pymthouse-keys-bff.ts
+++ b/apps/web-next/src/lib/pymthouse-keys-bff.ts
@@ -1,0 +1,144 @@
+/**
+ * PymtHouse user API key helpers (Dashboard parity).
+ * Mints long-lived pmth_* keys via PymtHouse Builder Apps API for SDK/CLI exchange.
+ */
+
+import 'server-only';
+
+import { PmtHouseError } from '@pymthouse/builder-sdk';
+
+export type PymthouseApiKeyRow = {
+  id: string;
+  label: string | null;
+  prefix: string;
+  suffix: string;
+  status: string;
+  createdAt: string;
+  revokedAt: string | null;
+};
+
+function readPublicClientId(): string {
+  const id = process.env.PYMTHOUSE_PUBLIC_CLIENT_ID?.trim();
+  if (!id) {
+    throw new PmtHouseError('PYMTHOUSE_PUBLIC_CLIENT_ID is required', {
+      status: 503,
+      code: 'pymthouse_required',
+    });
+  }
+  return id;
+}
+
+function readM2mAuthHeader(): string {
+  const m2mId = process.env.PYMTHOUSE_M2M_CLIENT_ID?.trim();
+  const m2mSecret = process.env.PYMTHOUSE_M2M_CLIENT_SECRET?.trim();
+  if (!m2mId || !m2mSecret) {
+    throw new PmtHouseError(
+      'PYMTHOUSE_M2M_CLIENT_ID and PYMTHOUSE_M2M_CLIENT_SECRET are required',
+      { status: 503, code: 'pymthouse_required' },
+    );
+  }
+  return `Basic ${Buffer.from(`${m2mId}:${m2mSecret}`).toString('base64')}`;
+}
+
+function appsOrigin(): string {
+  const issuerUrl = process.env.PYMTHOUSE_ISSUER_URL?.trim();
+  if (!issuerUrl) {
+    throw new PmtHouseError('PYMTHOUSE_ISSUER_URL is required', {
+      status: 503,
+      code: 'pymthouse_required',
+    });
+  }
+  return issuerUrl.replace(/\/api\/v1\/oidc\/?$/i, '').replace(/\/+$/, '');
+}
+
+function userKeysUrl(publicClientId: string, externalUserId: string): string {
+  return `${appsOrigin()}/api/v1/apps/${encodeURIComponent(publicClientId)}/users/${encodeURIComponent(externalUserId)}/keys`;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: string; error_description?: string };
+    return body.error_description ?? body.error ?? `Request failed (${response.status})`;
+  } catch {
+    return `Request failed (${response.status})`;
+  }
+}
+
+export async function ensureAppUserProvisioned(
+  publicClientId: string,
+  externalUserId: string,
+  email?: string | null,
+): Promise<void> {
+  const response = await fetch(
+    `${appsOrigin()}/api/v1/apps/${encodeURIComponent(publicClientId)}/users`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: readM2mAuthHeader(),
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        externalUserId,
+        email: email?.trim() || externalUserId,
+        status: 'active',
+      }),
+      cache: 'no-store',
+    },
+  );
+  if (!response.ok && response.status !== 409) {
+    throw new PmtHouseError(await readErrorMessage(response), {
+      status: response.status,
+      code: 'app_user_provision_failed',
+    });
+  }
+}
+
+export async function createPymthouseApiKey(input: {
+  externalUserId: string;
+  email?: string | null;
+  label?: string;
+}): Promise<{ apiKey: string; row: PymthouseApiKeyRow }> {
+  const publicClientId = readPublicClientId();
+  await ensureAppUserProvisioned(publicClientId, input.externalUserId, input.email);
+
+  const response = await fetch(userKeysUrl(publicClientId, input.externalUserId), {
+    method: 'POST',
+    headers: {
+      Authorization: readM2mAuthHeader(),
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(input.label ? { label: input.label } : {}),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new PmtHouseError(await readErrorMessage(response), {
+      status: response.status,
+      code: 'api_key_create_failed',
+    });
+  }
+
+  const body = (await response.json()) as {
+    apiKey: string;
+    id: string;
+    prefix: string;
+    suffix: string;
+    label: string | null;
+    createdAt: string;
+  };
+
+  return {
+    apiKey: body.apiKey,
+    row: {
+      id: body.id,
+      label: body.label,
+      prefix: body.prefix,
+      suffix: body.suffix,
+      status: 'active',
+      createdAt: body.createdAt,
+      revokedAt: null,
+    },
+  };
+}

--- a/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
+++ b/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared env config for `@pymthouse/builder-sdk/signer/server` exchange handlers.
+ */
+
+import 'server-only';
+
+import { getPymthouseIssuerUrlFromEnv } from '@pymthouse/builder-sdk/config';
+
+function issuerOriginFromIssuerUrl(issuerUrl: string): string {
+  return issuerUrl.replace(/\/api\/v1\/oidc\/?$/i, '').replace(/\/+$/, '');
+}
+
+/** Public signer facade URL from `PYMTHOUSE_SIGNER_URL` or `{issuerOrigin}/api/signer`. */
+export function resolvePymthouseSignerUrl(): string | null {
+  const fromEnv = process.env.PYMTHOUSE_SIGNER_URL?.trim();
+  if (fromEnv) {
+    return fromEnv.replace(/\/+$/, '');
+  }
+  const issuerUrl = getPymthouseIssuerUrlFromEnv();
+  if (!issuerUrl) {
+    return null;
+  }
+  return `${issuerOriginFromIssuerUrl(issuerUrl)}/api/signer`;
+}
+
+function readM2mBaseConfig():
+  | {
+      issuerUrl: string;
+      m2mClientId: string;
+      m2mClientSecret: string;
+      allowInsecureHttp: boolean;
+      signerUrl: string;
+    }
+  | null {
+  const issuerUrl = process.env.PYMTHOUSE_ISSUER_URL?.trim();
+  const m2mClientId = process.env.PYMTHOUSE_M2M_CLIENT_ID?.trim();
+  const m2mClientSecret = process.env.PYMTHOUSE_M2M_CLIENT_SECRET?.trim();
+  if (!issuerUrl || !m2mClientId || !m2mClientSecret) {
+    return null;
+  }
+  const signerUrl = resolvePymthouseSignerUrl();
+  if (!signerUrl) {
+    return null;
+  }
+  return {
+    issuerUrl,
+    m2mClientId,
+    m2mClientSecret,
+    allowInsecureHttp: process.env.PYMTHOUSE_ALLOW_INSECURE_HTTP === '1',
+    signerUrl,
+  };
+}
+
+export function readDeviceExchangeConfig() {
+  return readM2mBaseConfig();
+}
+
+export function readApiKeyExchangeConfig() {
+  const base = readM2mBaseConfig();
+  const publicClientId = process.env.PYMTHOUSE_PUBLIC_CLIENT_ID?.trim();
+  if (!base || !publicClientId) {
+    return null;
+  }
+  return {
+    ...base,
+    publicClientId,
+  };
+}

--- a/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
+++ b/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
@@ -6,6 +6,23 @@ import 'server-only';
 
 import { getPymthouseIssuerUrlFromEnv } from '@pymthouse/builder-sdk/config';
 
+/**
+ * Validate and normalize an http(s) URL, trimming any trailing slashes.
+ * Returns `null` for malformed values so misconfiguration surfaces at config
+ * time rather than as an opaque fetch failure at request time.
+ */
+function normalizeHttpUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+}
+
 function issuerOriginFromIssuerUrl(issuerUrl: string): string {
   return issuerUrl.replace(/\/api\/v1\/oidc\/?$/i, '').replace(/\/+$/, '');
 }
@@ -14,7 +31,7 @@ function issuerOriginFromIssuerUrl(issuerUrl: string): string {
 export function resolvePymthouseSignerUrl(): string | null {
   const fromEnv = process.env.PYMTHOUSE_SIGNER_URL?.trim();
   if (fromEnv) {
-    return fromEnv.replace(/\/+$/, '');
+    return normalizeHttpUrl(fromEnv);
   }
   const issuerUrl = getPymthouseIssuerUrlFromEnv();
   if (!issuerUrl) {
@@ -32,7 +49,7 @@ function readM2mBaseConfig():
       signerUrl: string;
     }
   | null {
-  const issuerUrl = process.env.PYMTHOUSE_ISSUER_URL?.trim();
+  const issuerUrl = normalizeHttpUrl(process.env.PYMTHOUSE_ISSUER_URL?.trim() ?? '');
   const m2mClientId = process.env.PYMTHOUSE_M2M_CLIENT_ID?.trim();
   const m2mClientSecret = process.env.PYMTHOUSE_M2M_CLIENT_SECRET?.trim();
   if (!issuerUrl || !m2mClientId || !m2mClientSecret) {

--- a/docs/pymthouse-integration.md
+++ b/docs/pymthouse-integration.md
@@ -4,7 +4,7 @@ Official Builder API contract: [PymtHouse `docs/builder-api.md`](https://github.
 
 Server-to-server calls use the published npm package [`@pymthouse/builder-sdk`](https://www.npmjs.com/package/@pymthouse/builder-sdk) (source: [pymthouse/builder-sdk](https://github.com/pymthouse/builder-sdk)), wrapped in [apps/web-next/src/lib/pymthouse-client.ts](apps/web-next/src/lib/pymthouse-client.ts) with `import "server-only"` so M2M secrets never ship to the browser.
 
-**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **exact `0.1.0`** from the npm registry in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Treat this as a pre-release SDK: review the [builder-sdk CHANGELOG](https://github.com/pymthouse/builder-sdk/blob/main/CHANGELOG.md) before bumping, run `npm install` at the repo root, and re-verify billing/OIDC routes after any upgrade.
+**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **exact `0.4.3`** from the npm registry in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root, and re-verify billing/OIDC routes after any upgrade.
 
 ## Plan-builder data (PymtHouse → NaaP)
 
@@ -49,25 +49,28 @@ NaaP server                                              PymtHouse
 - **Confidential M2M** (`m2m_…`) credentials are **`PYMTHOUSE_M2M_CLIENT_ID`** + **`PYMTHOUSE_M2M_CLIENT_SECRET`**. A single OIDC client cannot be both public (device flow) and confidential; PymtHouse provisions two clients per developer app when you enable **Backend device helper** in Auth & Scopes.
 - **End-user scope** is only **`sign:job`** on the token request.
 - The M2M client must allow **`users:read`**, **`users:write`**, **`users:token`**, and **`sign:job`** in its allowed scopes (defaults for the backend helper).
-- Short-lived Builder-minted user JWTs are **not** surfaced as NaaP developer API keys; NaaP exchanges them server-side for opaque **`pmth_…`** signer sessions (~90 days).
+- Short-lived Builder-minted user JWTs are **not** surfaced as NaaP developer API keys for the Create API Key flow. That flow mints long-lived **`pmth_*`** API keys via the Builder Apps **`…/users/{externalUserId}/keys`** route (Dashboard parity). Opaque signer sessions (~90 days) remain available via **`POST /api/v1/billing/pymthouse/token`** only.
 
 ### NaaP endpoints
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| `POST` | `/api/v1/auth/providers/pymthouse/start` | First-time link from the **Create API Key** UI. Returns `{ access_token, token_type, expires_in, scope, login_session_id, auth_url: null, poll_after_ms: 0 }` where `access_token` is an opaque **`pmth_…`** signer session (~90 days). |
-| `POST` | `/api/v1/billing/pymthouse/token` | Mint-on-demand signer session. Returns `{ access_token, token_type, expires_in, scope }` where `access_token` is an opaque **`pmth_…`** token (~90 days). Auth: NaaP session + CSRF. Rate limited per user. Internally mints a short-lived JWT then RFC 8693 token-exchanges with the M2M client. |
+| `POST` | `/api/v1/auth/providers/pymthouse/start` | First-time link from the **Create API Key** UI. Returns `{ access_token, token_type, expires_in, scope, login_session_id, auth_url: null, poll_after_ms: 0 }` where `access_token` is a long-lived **`pmth_*`** API key (Builder Apps user key). |
+| `POST` | `/api/v1/billing/pymthouse/token` | Mint-on-demand opaque signer session. Returns `{ access_token, token_type, expires_in, scope }` where `access_token` is an opaque **`pmth_…`** signer session (~90 days). Auth: NaaP session + CSRF. Rate limited per user. Internally mints a short-lived JWT then RFC 8693 token-exchanges with the M2M client. |
 | `GET` | `/api/v1/billing/pymthouse/usage` | Session BFF over PymtHouse **Usage API** (see below). Auth: NaaP session cookie / bearer. `Cache-Control: no-store`. |
+| `GET` | `/api/v1/billing/pymthouse/config` | Public integration settings for the Developer API UI (`signerUrl` from `PYMTHOUSE_SIGNER_URL`). Auth: NaaP session cookie / bearer. |
+| `POST` | `/api/pymthouse/keys/exchange` | Public exchange: PymtHouse **`pmth_*`** API key → short-lived signer JWT. No NaaP session. Uses `@pymthouse/builder-sdk/signer/server` `createApiKeyExchangeHandler`. Same contract as Dashboard. |
+| `POST` | `/api/signer/device/exchange` | Public exchange: device token → signer session. No NaaP session. Uses `createDeviceExchangeHandler`. Complements the browser device-approve step below. |
 
 ### Developer API manager SDK token
 
 The Developer API manager's **Create API Key** flow returns the normal billing API key and, for providers that support python-gateway discovery (`pymthouse` and `daydream`), also creates an optional SDK token for `python-gateway --token`.
 
-That SDK token is **base64-encoded JSON**, not a JWT. It bundles two independent credentials so python-gateway can separate signing from discovery:
+That SDK token is **base64-encoded JSON**, not a JWT. It bundles signer and discovery credentials:
 
 ```json
 {
-  "signer": "https://pymthouse.com/api/signer",
+  "signer": "https://pymthouse-preview.up.railway.app",
   "discovery": "https://naap.example.com/api/v1/orchestrator-leaderboard/plans/{planId}/python-gateway",
   "signer_headers": {
     "Authorization": "Bearer pmth_..."
@@ -78,12 +81,13 @@ That SDK token is **base64-encoded JSON**, not a JWT. It bundles two independent
 }
 ```
 
-- `signer_headers.Authorization` uses the billing-provider signer session returned by PymtHouse (`pmth_…`). This is the same secret shown as the API key in the success dialog.
-- `discovery_headers.Authorization` uses a separate NaaP service-gateway key (`gw_…`) minted during the same dialog via `/api/v1/gw/admin/keys`. It is scoped to NaaP's discovery endpoint and should not be reused as the billing signer credential.
-- If the user selects a saved discovery plan, the token points at `/api/v1/orchestrator-leaderboard/plans/{planId}/python-gateway`; otherwise it points at `/api/v1/orchestrator-leaderboard/python-gateway` for default model-based discovery.
+- `signer_headers.Authorization` carries the long-lived **`pmth_*`** API key (same value as the billing key in the success dialog). **livepeer-python-gateway** detects `pmth_*` in `signer_headers`, infers the NaaP billing origin from the `discovery` URL host, and exchanges via **`POST /api/pymthouse/keys/exchange`** before calling the signer DMZ (same outcome as `--billing-url` + `--api-key`).
+- `discovery_headers.Authorization` uses a separate NaaP service-gateway key (`gw_…`) minted during the same dialog via `/api/v1/gw/admin/keys`.
+- The `signer` field comes from **`PYMTHOUSE_SIGNER_URL`** when set (via `GET /api/v1/billing/pymthouse/config`), otherwise `{issuerOrigin}/api/signer`. Exchange may override the effective signer URL with the value returned from the exchange response.
+- If the user selects a saved discovery plan, the token points at `/api/v1/orchestrator-leaderboard/plans/{planId}/python-gateway`; otherwise it points at `/api/v1/orchestrator-leaderboard/python-gateway` for default model-based discovery (append `?billingProvider=pymthouse` for PymtHouse default discovery).
 - If NaaP cannot mint the `gw_…` key, the UI still shows the billing API key and explains that the user must create a gateway key manually and populate `discovery_headers`.
 
-This keeps token auth explicit: the signer remains a PymtHouse-issued billing secret, while discovery remains a NaaP-authenticated request that can use curated orchestrator-leaderboard plans.
+**Daydream** uses the same token shape with `signer: https://signer.daydream.live` and a Daydream bearer in `signer_headers` (passed through without exchange).
 
 ### Network Price discovery allowlist (PymtHouse → NaaP)
 
@@ -105,7 +109,7 @@ PymtHouse usage is **tenant-wide** (M2M). A NaaP session alone must not expose r
 
 | Query | Behavior |
 |-------|-----------|
-| `scope=me` (default) | Delegates to `@pymthouse/builder-sdk` **`fetchUsageForExternalUser`** with the logged-in NaaP user id (`session.user.id`). Returns the SDK-shaped response for that external user (period, request counts, pipeline/model breakdown). App-wide totals and raw `byUser` / `byPipelineModel` arrays are omitted. |
+| `scope=me` (default) | Delegates to `@pymthouse/builder-sdk` **`fetchUsageForExternalUser`** with `includeRetail: true` and the logged-in NaaP user id (`session.user.id`). Returns the SDK-shaped response for that external user (period, request counts, pipeline/model breakdown). App-wide totals and raw `byUser` / `byPipelineModel` arrays are omitted. |
 | `scope=app` | **Requires** role `system:admin`. Passes through `groupBy` (`none` \| `user`) and internal PymtHouse `userId` (end user id) to the SDK and returns the **raw** `UsageApiResponse` from upstream. |
 
 **Dates:** Optional `startDate` and `endDate` (ISO strings, validated with `Date.parse`). Both must be set together, or both omitted. If omitted, the BFF uses the **current calendar month in UTC** (same default as the Developer plugin Usage tab).
@@ -128,6 +132,8 @@ These match [`createPmtHouseClientFromEnv`](https://github.com/pymthouse/builder
 | `PYMTHOUSE_PUBLIC_CLIENT_ID` | **Public** app **`client_id`** (`app_…`) — device flow + Builder URL paths. **Required.** |
 | `PYMTHOUSE_M2M_CLIENT_ID` | **Confidential** backend client (`m2m_…`) for Builder API and token-endpoint flows used by the SDK. **Required.** |
 | `PYMTHOUSE_M2M_CLIENT_SECRET` | Secret for the M2M client. **Required.** |
+| `PYMTHOUSE_SIGNER_URL` | Optional; upstream signer facade URL (e.g. `http://localhost:3001/api/signer`). Returned in exchange route responses; defaults to `{issuerOrigin}/api/signer`. |
+| `PYMTHOUSE_ALLOW_INSECURE_HTTP` | Set to `1` for local dev when issuer uses `http://` (exchange handlers; complements SDK auto-detect in `createPmtHouseClientFromEnv`). |
 | `PMTHOUSE_BASE_URL` | Optional; site origin for marketplace link (`{base}/marketplace`) when `PYMTHOUSE_MARKETPLACE_URL` is unset. Used by middleware/device-initiate helpers where a separate site origin from the issuer is needed. |
 
 `BILLING_PROVIDER_OAUTH_CALLBACK_ORIGIN` is **not needed** for PymtHouse (no redirect URI).
@@ -148,19 +154,21 @@ Legacy **`naap/link-user`**, **`naap-service`** seed-only flows, and **`gateway`
 - `PYMTHOUSE_PUBLIC_CLIENT_ID` is the public **`app_...`** id; `PYMTHOUSE_M2M_CLIENT_ID` is the confidential **`m2m_...`** id.
 - `PYMTHOUSE_M2M_CLIENT_SECRET` matches the M2M client’s secret.
 - NaaP logs show `[billing-auth:pymthouse] Linked user …` (no browser popup).
-- Provider start and billing token routes return an opaque **`pmth_…`** signer session (`expires_in` ≈ 90 days); the short-lived subject JWT is used only server-side during exchange.
+- **Create API Key** (`/api/v1/auth/providers/pymthouse/start`) returns a long-lived **`pmth_*`** user API key (exchangeable via `/api/pymthouse/keys/exchange`).
+- **`POST /api/v1/billing/pymthouse/token`** still returns an opaque signer session (~90 days) for session/BFF use; implementation uses [`pymthouse-client.ts`](../apps/web-next/src/lib/pymthouse-client.ts) `mintSignerSessionForExternalUser` (omits token-exchange `resource` so PymtHouse selects gateway opaque-session exchange).
+- python-gateway `--token` with `signer_headers` carrying **`pmth_*`** logs `API-key signer exchange at {discovery-origin}` and receives a signer JWT + `signerUrl` from the exchange response.
 
 ## Device login (RFC 8628) — Option B (NaaP-side approval)
 
-When PymtHouse redirects the browser to NaaP with `iss` + `target_link_uri` (third-party initiated login), NaaP stores a short-lived cookie, completes sign-in, then the server runs **`PmtHouseClient`**: mint user JWT via Builder, then **`completeDeviceApproval`** (RFC 8693 token exchange at `{issuer}/token` via oauth4webapi).
+When PymtHouse redirects the browser to NaaP with `iss` + `target_link_uri` (third-party initiated login), NaaP stores a short-lived cookie, completes sign-in, then the server runs **`PmtHouseClient.approveDeviceLogin`** (upsert user, mint JWT, complete device approval via RFC 8693 token exchange).
 
-NaaP treats success from `completeDeviceApproval` as authorized and clears the cookie; the CLI keeps polling PymtHouse **`POST .../token`** with the `device_code` as usual until it receives tokens.
+NaaP treats success from `approveDeviceLogin` as authorized and clears the cookie; the CLI keeps polling PymtHouse **`POST .../token`** with the `device_code` as usual until it receives tokens. Clients may then call **`POST /api/signer/device/exchange`** with the device token to obtain a signer session.
 
 Requires: **`PYMTHOUSE_ISSUER_URL`** (must match the `iss` query param, e.g. `http://localhost:3001/api/v1/oidc`), **`PYMTHOUSE_PUBLIC_CLIENT_ID`**, **`PYMTHOUSE_M2M_CLIENT_ID`**, **`PYMTHOUSE_M2M_CLIENT_SECRET`**, and PymtHouse app settings with device third-party login + initiate URI pointing at NaaP. Device initiate validation uses the **issuer URL’s origin** for `target_link_uri` (so **`PMTHOUSE_BASE_URL`** is not required for that check; avoid pointing `PMTHOUSE_BASE_URL` at NaaP if you also rely on it for PymtHouse site URLs elsewhere).
 
 ## Database
 
-`BillingProviderOAuthSession` is still created for audit purposes on each link but the opaque API key itself is never stored in this row: `accessToken` is always `null` for PymtHouse, `redeemedAt` is set immediately, and the row `expiresAt` follows the returned signer session TTL (~90 days). PymtHouse does not use browser OAuth redirect on this path (no PKCE verifier column).
+`BillingProviderOAuthSession` is still created for audit purposes on each link but the raw API key itself is never stored in this row: `accessToken` is always `null` for PymtHouse, `redeemedAt` is set immediately. PymtHouse does not use browser OAuth redirect on this path (no PKCE verifier column).
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.1.0",
+        "@pymthouse/builder-sdk": "0.4.3",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -8709,9 +8709,9 @@
       }
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.1.0.tgz",
-      "integrity": "sha512-1x1OGVqANWJdd1iMcTeYPGo+gE97gPWP+UXvdadouU9g1dQ55RA0JOqAhrog/PYn7qgfO8EHIVbKsAEYGylMjQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.3.tgz",
+      "integrity": "sha512-1cwK78PDekyd2BYC59OJeSorT8XT+laNp7dQj+JC9FNcO4TmJs32Yz4EzhWZohUXszIpejas3J+KXWh9HR8hrw==",
       "license": "MIT",
       "dependencies": {
         "oauth4webapi": "^3.8.5"
@@ -25303,7 +25303,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -31920,7 +31919,7 @@
         "@naap/database": "*",
         "@naap/plugin-server-sdk": "*",
         "@naap/types": "*",
-        "@pymthouse/builder-sdk": "0.1.0",
+        "@pymthouse/builder-sdk": "0.4.3",
         "cors": "^2.8.6",
         "dotenv": "^16.6.1",
         "express": "^4.21.0",
@@ -31967,7 +31966,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.1.0",
+        "@pymthouse/builder-sdk": "0.4.3",
         "framer-motion": "^12.0.0",
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",

--- a/plugins/developer-api/backend/package.json
+++ b/plugins/developer-api/backend/package.json
@@ -12,7 +12,7 @@
     "@naap/database": "*",
     "@naap/plugin-server-sdk": "*",
     "@naap/types": "*",
-    "@pymthouse/builder-sdk": "0.1.0",
+    "@pymthouse/builder-sdk": "0.4.3",
     "cors": "^2.8.6",
     "dotenv": "^16.6.1",
     "express": "^4.21.0",

--- a/plugins/developer-api/backend/src/server.ts
+++ b/plugins/developer-api/backend/src/server.ts
@@ -9,10 +9,8 @@ import {
   formatBillingKeyPublicPrefix,
 } from '@naap/database';
 import {
-  computeSignerSessionExpiry,
   decodeJwtExp,
   isLikelyOidcJwt,
-  SIGNER_SESSION_TTL_MS,
 } from '@pymthouse/builder-sdk/tokens';
 
 const backendRoot = resolve(import.meta.dirname ?? '.', '..');
@@ -96,38 +94,6 @@ let deriveKeyLookupId: (rawKey: string) => string = (_key: string) => crypto.ran
 let hashApiKey: (key: string) => string = (key: string) => crypto.scryptSync(key, 'naap-api-key-v1', 32).toString('hex');
 
 const PYMTHOUSE_PROVIDER_SLUG = 'pymthouse';
-
-// Match web-next developer/keys: throttle opportunistic cleanup off GET.
-const EXPIRED_KEY_CLEANUP_THROTTLE_MS = 15 * 60 * 1000;
-let lastExpiredKeyCleanupAt = 0;
-
-async function maybeCleanupExpiredPymthouseKeys(userId: string): Promise<void> {
-  const now = Date.now();
-  if (now - lastExpiredKeyCleanupAt < EXPIRED_KEY_CLEANUP_THROTTLE_MS) {
-    return;
-  }
-  lastExpiredKeyCleanupAt = now;
-
-  if (!prisma) {
-    return;
-  }
-
-  const expiryCutoff = new Date(now - SIGNER_SESSION_TTL_MS);
-  try {
-    await prisma.devApiKey.deleteMany({
-      where: {
-        userId,
-        billingProvider: { slug: PYMTHOUSE_PROVIDER_SLUG },
-        OR: [
-          { status: 'ACTIVE', createdAt: { lte: expiryCutoff } },
-          { status: 'EXPIRED' },
-        ],
-      },
-    });
-  } catch (err) {
-    console.warn('[developer-api] Background expired-key cleanup failed:', err);
-  }
-}
 
 function getRequestUserId(req: express.Request): string {
   const user = (req as any).user;
@@ -674,8 +640,6 @@ app.get('/api/v1/developer/keys', async (req, res) => {
     const userId = getRequestUserId(req);
 
     if (prisma) {
-      void maybeCleanupExpiredPymthouseKeys(userId);
-
       const keys = await prisma.devApiKey.findMany({
         where: { userId },
         orderBy: { createdAt: 'desc' },
@@ -687,12 +651,9 @@ app.get('/api/v1/developer/keys', async (req, res) => {
           model: { select: { id: true, name: true } },
         },
       });
-      const nowMs = Date.now();
       const visibleKeys = keys.filter((k: any) => {
         if (k.billingProvider?.slug !== PYMTHOUSE_PROVIDER_SLUG) return true;
-        if (String(k.status).toUpperCase() === 'EXPIRED') return false;
-        if (String(k.status).toUpperCase() !== 'ACTIVE') return true;
-        return computeSignerSessionExpiry(k.createdAt).getTime() > nowMs;
+        return String(k.status).toUpperCase() !== 'EXPIRED';
       });
       const formatted = visibleKeys.map((k: any) => ({
         id: k.id,
@@ -703,39 +664,22 @@ app.get('/api/v1/developer/keys', async (req, res) => {
         keyPrefix: k.keyPrefix,
         status: k.status,
         createdAt: k.createdAt.toISOString(),
-        expiresAt:
-          k.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-            ? computeSignerSessionExpiry(k.createdAt).toISOString()
-            : null,
+        expiresAt: null,
         lastUsedAt: k.lastUsedAt?.toISOString() || null,
       }));
       return res.json({ keys: formatted, total: formatted.length });
     }
 
-    const nowMs = Date.now();
-    for (let i = inMemoryApiKeys.length - 1; i >= 0; i -= 1) {
-      const key = inMemoryApiKeys[i];
-      const shouldRemove =
-        key.userId === userId &&
-        key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG &&
-        (
-          String(key.status || '').toUpperCase() === 'EXPIRED' ||
-          (
-            String(key.status || '').toUpperCase() === 'ACTIVE' &&
-            computeSignerSessionExpiry(key.createdAt).getTime() <= nowMs
-          )
-        );
-      if (shouldRemove) {
-        inMemoryApiKeys.splice(i, 1);
-      }
-    }
-    const keys = inMemoryApiKeys.filter((k: any) => k.userId === userId).map((k: any) => ({
-      ...k,
-      expiresAt:
-        k.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-          ? computeSignerSessionExpiry(k.createdAt).toISOString()
-          : null,
-    }));
+    const keys = inMemoryApiKeys
+      .filter((k: any) => k.userId === userId)
+      .filter((k: any) => {
+        if (k.billingProvider?.slug !== PYMTHOUSE_PROVIDER_SLUG) return true;
+        return String(k.status || '').toUpperCase() !== 'EXPIRED';
+      })
+      .map((k: any) => ({
+        ...k,
+        expiresAt: null,
+      }));
     res.json({ keys, total: keys.length });
   } catch (error) {
     console.error('Error fetching keys:', error);
@@ -762,20 +706,11 @@ app.get('/api/v1/developer/keys/:id', async (req, res) => {
         },
       });
       if (!key) return res.status(404).json({ error: 'API key not found' });
-      if (key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG) {
-        const expiredByAge =
-          key.status === 'ACTIVE' &&
-          computeSignerSessionExpiry(key.createdAt).getTime() <= Date.now();
-        const alreadyExpired = key.status === 'EXPIRED';
-        if (expiredByAge || alreadyExpired) {
-          if (expiredByAge) {
-            await prisma.devApiKey.update({
-              where: { id: key.id },
-              data: { status: 'EXPIRED' },
-            });
-          }
-          return res.status(404).json({ error: 'API key not found' });
-        }
+      if (
+        key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG &&
+        key.status === 'EXPIRED'
+      ) {
+        return res.status(404).json({ error: 'API key not found' });
       }
       return res.json({
         id: key.id,
@@ -786,35 +721,22 @@ app.get('/api/v1/developer/keys/:id', async (req, res) => {
         keyPrefix: key.keyPrefix,
         status: key.status,
         createdAt: key.createdAt.toISOString(),
-        expiresAt:
-          key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-            ? computeSignerSessionExpiry(key.createdAt).toISOString()
-            : null,
+        expiresAt: null,
         lastUsedAt: key.lastUsedAt?.toISOString() || null,
       });
     }
 
     const key = inMemoryApiKeys.find((k: any) => k.id === req.params.id && k.userId === userId);
     if (!key) return res.status(404).json({ error: 'API key not found' });
-    if (key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG) {
-      const expiredByAge =
-        String(key.status || '').toUpperCase() === 'ACTIVE' &&
-        computeSignerSessionExpiry(key.createdAt).getTime() <= Date.now();
-      const alreadyExpired = String(key.status || '').toUpperCase() === 'EXPIRED';
-      if (expiredByAge || alreadyExpired) {
-        const keyIndex = inMemoryApiKeys.findIndex((k: any) => k.id === key.id);
-        if (keyIndex >= 0) {
-          inMemoryApiKeys.splice(keyIndex, 1);
-        }
-        return res.status(404).json({ error: 'API key not found' });
-      }
+    if (
+      key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG &&
+      String(key.status || '').toUpperCase() === 'EXPIRED'
+    ) {
+      return res.status(404).json({ error: 'API key not found' });
     }
     res.json({
       ...key,
-      expiresAt:
-        key.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-          ? computeSignerSessionExpiry(key.createdAt).toISOString()
-          : null,
+      expiresAt: null,
     });
   } catch (error) {
     console.error('Error fetching key:', error);
@@ -911,20 +833,12 @@ app.post('/api/v1/developer/keys', async (req, res) => {
           label: newKey.label,
           status: newKey.status,
           createdAt: newKey.createdAt.toISOString(),
-          expiresAt:
-            newKey.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-              ? new Date(
-                  Math.min(
-                    (pymthouseTokenExpiry ?? computeSignerSessionExpiry(newKey.createdAt)).getTime(),
-                    computeSignerSessionExpiry(newKey.createdAt).getTime(),
-                  ),
-                ).toISOString()
-              : null,
+          expiresAt: null,
         },
         rawApiKey,
         warning:
           provider.slug === PYMTHOUSE_PROVIDER_SLUG
-            ? 'Store this key securely. It expires after about 90 days and will not be shown again.'
+            ? 'Store this key securely. It is long-lived until revoked and will not be shown again.'
             : 'Store this key securely. It will not be shown again.',
       });
     }
@@ -962,23 +876,12 @@ app.post('/api/v1/developer/keys', async (req, res) => {
     res.status(201).json({
       key: {
         ...newKey,
-        expiresAt:
-          newKey.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-            ? new Date(
-                Math.min(
-                  (
-                    fallbackPymthouseTokenExpiry ??
-                    computeSignerSessionExpiry(newKey.createdAt)
-                  ).getTime(),
-                  computeSignerSessionExpiry(newKey.createdAt).getTime(),
-                ),
-              ).toISOString()
-            : null,
+        expiresAt: null,
       },
       rawApiKey,
       warning:
         newKey.billingProvider?.slug === PYMTHOUSE_PROVIDER_SLUG
-          ? 'Store this key securely. It expires after about 90 days and will not be shown again.'
+          ? 'Store this key securely. It is long-lived until revoked and will not be shown again.'
           : 'Store this key securely. It will not be shown again.',
     });
   } catch (error) {

--- a/plugins/developer-api/frontend/package.json
+++ b/plugins/developer-api/frontend/package.json
@@ -17,7 +17,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.1.0",
+    "@pymthouse/builder-sdk": "0.4.3",
     "framer-motion": "^12.0.0",
     "lucide-react": "^0.575.0",
     "react": "^19.0.0",

--- a/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
+++ b/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
@@ -24,7 +24,6 @@ ChevronUp,
 } from 'lucide-react';
 import { Card, Badge, Modal, Tooltip } from '@naap/ui';
 import type { NetworkModel } from '@naap/plugin-sdk';
-import { computeSignerSessionExpiry } from '@pymthouse/builder-sdk/tokens';
 
 const PIPELINE_COLOR: Record<string, string> = {
   'text-to-image':           '#f59e0b',
@@ -135,25 +134,12 @@ interface ApiKey {
 }
 
 /**
- * TODO(backend): return actual token expiry for PymtHouse keys in `expiresAt`
- * (not only the default 90-day TTL fallback) so frontend can rely on server data.
- *
- * Prefer server `expiresAt`; for PymtHouse keys without it, derive from `createdAt`.
+ * Prefer server `expiresAt` when provided. PymtHouse developer keys are long-lived
+ * until revoked (no client-side TTL fallback).
  */
 function resolveApiKeyExpiresAt(key: ApiKey): string | null {
   if (key.expiresAt != null && String(key.expiresAt).trim() !== '') {
     return key.expiresAt;
-  }
-  if (key.billingProvider?.slug === 'pymthouse') {
-    try {
-      const created = new Date(key.createdAt);
-      if (Number.isNaN(created.getTime())) return null;
-      const expiry = computeSignerSessionExpiry(created);
-      if (Number.isNaN(expiry.getTime())) return null;
-      return expiry.toISOString();
-    } catch {
-      return null;
-    }
   }
   return null;
 }
@@ -311,9 +297,16 @@ const PYTHON_GATEWAY_DISCOVERY_BILLING_SLUGS = new Set(['pymthouse', 'daydream']
 
 const DEFAULT_PYMTHOUSE_SIGNER_BASE_URL = 'https://pymthouse.com/api/signer';
 
-function getSignerBaseUrlForBillingProvider(slug: string): string {
+function getSignerBaseUrlForBillingProvider(
+  slug: string,
+  pymthouseSignerUrl?: string | null,
+): string {
   if (slug === 'daydream') {
     return 'https://signer.daydream.live';
+  }
+  const configured = pymthouseSignerUrl?.trim();
+  if (configured) {
+    return configured.replace(/\/+$/, '');
   }
   return DEFAULT_PYMTHOUSE_SIGNER_BASE_URL;
 }
@@ -393,6 +386,7 @@ export const DeveloperView: React.FC = () => {
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [billingProviders, setBillingProviders] = useState<BillingProviderInfo[] | null>(null);
   const [billingProvidersError, setBillingProvidersError] = useState(false);
+  const [pymthouseSignerUrl, setPymthouseSignerUrl] = useState<string | null>(null);
   const [modalDataLoading, setModalDataLoading] = useState(false);
   const [selectedProjectId, setSelectedProjectId] = useState('');
   const [newProjectName, setNewProjectName] = useState('');
@@ -714,9 +708,28 @@ result = [...result].sort((a, b) => {
     }
   }, []);
 
+  const loadPymthouseSignerConfig = useCallback(async () => {
+    try {
+      const res = await fetch('/api/v1/billing/pymthouse/config', { credentials: 'include' });
+      if (!res.ok) {
+        return;
+      }
+      const json = await res.json();
+      const signerUrl = (json.data ?? json)?.signerUrl;
+      if (typeof signerUrl === 'string' && signerUrl.trim()) {
+        setPymthouseSignerUrl(signerUrl.trim());
+      }
+    } catch (err) {
+      console.error('Failed to load PymtHouse signer config:', err);
+    }
+  }, []);
+
   useEffect(() => {
-    if (activeTab === 'usage' || activeTab === 'api-keys') loadBillingProviders();
-  }, [activeTab, loadBillingProviders]);
+    if (activeTab === 'usage' || activeTab === 'api-keys') {
+      loadBillingProviders();
+      void loadPymthouseSignerConfig();
+    }
+  }, [activeTab, loadBillingProviders, loadPymthouseSignerConfig]);
 
   useEffect(() => {
     if (usagePanelProviders.length === 0) return;
@@ -934,8 +947,8 @@ result = [...result].sort((a, b) => {
       const directAccessToken = startData.data?.access_token || startData.access_token;
       const loginSessionId = startData.data?.login_session_id || startData.login_session_id;
 
-      // Server-to-server providers (e.g. PymtHouse) return an opaque signer session
-      // token as `access_token` directly. Browser-redirect providers (e.g. Daydream)
+      // Server-to-server providers (e.g. PymtHouse) return a long-lived pmth_* API key
+      // as `access_token` directly. Browser-redirect providers (e.g. Daydream)
       // hand back only a `login_session_id`; the popup opens a same-origin NaaP
       // redirector that resolves the provider authorization URL server-side, so no
       // remote-controlled URL is ever passed into window.open.
@@ -1041,21 +1054,17 @@ result = [...result].sort((a, b) => {
       }
 
       setCreatedRawKey(providerApiKey);
-      const keyCreatedAt =
-        typeof payload.key?.createdAt === 'string' ? payload.key.createdAt : null;
       const expiresFromApi =
         typeof payload.key?.expiresAt === 'string' ? payload.key.expiresAt : null;
-      const resolvedExpires =
-        providerSlug === 'pymthouse'
-          ? expiresFromApi ||
-            (keyCreatedAt ? computeSignerSessionExpiry(keyCreatedAt).toISOString() : null)
-          : expiresFromApi;
-      setCreatedKeyExpiresAt(resolvedExpires);
+      setCreatedKeyExpiresAt(providerSlug === 'pymthouse' ? null : expiresFromApi);
       setCreatedKeyWarning(payload.warning || 'Store this key securely. It will not be shown again.');
       setCreatedPythonGatewayToken('');
       setGatewayDiscoveryKeyMintError('');
       if (billingProviderSupportsPythonGatewayDiscovery(providerSlug)) {
-        const signerBase = getSignerBaseUrlForBillingProvider(providerSlug).replace(/\/+$/, '');
+        const signerBase = getSignerBaseUrlForBillingProvider(
+          providerSlug,
+          pymthouseSignerUrl,
+        ).replace(/\/+$/, '');
         const selectedPlanId = selectedDiscoveryPlanId.trim();
         const discoveryPath = selectedPlanId
           ? `/api/v1/orchestrator-leaderboard/plans/${encodeURIComponent(selectedPlanId)}/python-gateway`
@@ -1123,7 +1132,7 @@ result = [...result].sort((a, b) => {
       pollAbortControllerRef.current = null;
       setCreating(false);
     }
-  }, [selectedProjectId, newProjectName, newKeyLabel, selectedBillingProviderId, billingProviders, selectedDiscoveryPlanId]);
+  }, [selectedProjectId, newProjectName, newKeyLabel, selectedBillingProviderId, billingProviders, selectedDiscoveryPlanId, pymthouseSignerUrl]);
 
   const handleCopyKey = useCallback(async () => {
     try {
@@ -1877,8 +1886,8 @@ result = [...result].sort((a, b) => {
                           with your app&apos;s Network Price allowlist (
                           <code className="text-slate-300">GET …/manifest</code>
                           ); capabilities outside that list return no orchestrators. Discovery uses a new{' '}
-                          <code className="text-slate-300">gw_…</code> gateway key; the signer still uses your billing provider
-                          secret above.
+                          <code className="text-slate-300">gw_…</code> gateway key; the signer uses your billing provider
+                          <code className="text-slate-300"> pmth_*</code> key (the SDK exchanges it for a signer JWT at runtime).
                         </>
                       ) : (
                         <>
@@ -1962,12 +1971,12 @@ result = [...result].sort((a, b) => {
             <div className="text-center">
               <p className="text-text-primary font-medium">
                 {selectedBillingProvider?.slug === 'pymthouse'
-                  ? 'Creating your PymtHouse billing key...'
+                  ? 'Minting your PymtHouse API key...'
                   : 'Waiting for authentication...'}
               </p>
               <p className="text-sm text-text-secondary mt-1">
                 {selectedBillingProvider?.slug === 'pymthouse'
-                  ? 'Exchanging credentials with PymtHouse. This page updates when your key is ready.'
+                  ? 'Provisioning your account with PymtHouse. This page updates when your key is ready.'
                   : 'Complete sign-in in the new tab. This page updates automatically.'}
               </p>
             </div>
@@ -1989,23 +1998,20 @@ result = [...result].sort((a, b) => {
                 <p className="text-text-secondary mt-0.5">
                   {createdKeyWarning || 'This is the only time your API key will be shown. Copy it now and store it in a safe place.'}
                 </p>
-                {createdKeyExpiresAt && (
+                {createdKeyExpiresAt && !createdRawKey.startsWith('pmth_') && (
                   <p className="text-amber-200 mt-1">
-                    {createdRawKey.startsWith('pmth_')
-                      ? `Valid until ${new Date(createdKeyExpiresAt).toLocaleString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                          hour: 'numeric',
-                          minute: '2-digit',
-                        })} (about 90 days from when this key was created).`
-                      : `Expires at ${new Date(createdKeyExpiresAt).toLocaleString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                          hour: 'numeric',
-                          minute: '2-digit',
-                        })}.`}
+                    {`Expires at ${new Date(createdKeyExpiresAt).toLocaleString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                      hour: 'numeric',
+                      minute: '2-digit',
+                    })}.`}
+                  </p>
+                )}
+                {createdRawKey.startsWith('pmth_') && (
+                  <p className="text-text-secondary mt-1">
+                    Long-lived until revoked. The SDK exchanges this key for a short-lived signer session before streaming.
                   </p>
                 )}
               </div>
@@ -2014,8 +2020,9 @@ result = [...result].sort((a, b) => {
               <div className="space-y-2">
                 <label className="block text-xs font-medium text-text-primary">SDK Token (python-gateway)</label>
                 <p className="text-xs text-text-secondary">
-                  Base64 JSON for python-gateway <code className="text-slate-300">--token</code> flag, includes signer
-                  and discovery plan configuration
+                  Base64 JSON for python-gateway <code className="text-slate-300">--token</code> flag — signer, discovery,
+                  and header configuration. For PymtHouse, <code className="text-slate-300">signer_headers</code> carries
+                  your <code className="text-slate-300">pmth_*</code> key; the SDK exchanges it for a signer JWT before streaming.
                 </p>
                 <div className="flex items-start gap-2">
                   <code className="max-h-40 flex-1 overflow-y-auto break-all rounded-lg border border-white/10 bg-bg-tertiary px-3 py-2 font-mono text-xs text-accent-emerald select-all">


### PR DESCRIPTION
## Summary

- Upgrades `@pymthouse/builder-sdk` from `0.1.0` to **`0.4.3`** across web-next and the developer-api plugin packages.
- Adds PymtHouse API key exchange routes (`/api/pymthouse/keys/exchange`, `/api/signer/device/exchange`) and a billing config BFF endpoint, using the SDK's server-side exchange handlers.
- Refactors developer key management to mint long-lived `pmth_*` keys via the Builder Apps user-keys API, with shared utilities in `pymthouse-client.ts`, `pymthouse-keys-bff.ts`, and `pymthouse-signer-exchange-config.ts`.
- Simplifies the developer-api backend by delegating key creation to the web-next BFF layer and updates the DeveloperView UI accordingly.
- Documents the updated integration contract in `docs/pymthouse-integration.md`.

## Test plan

- [ ] `npm install` at repo root succeeds with the pinned `0.4.3` SDK
- [ ] Start NaaP locally with PymtHouse env vars configured (`PYMTHOUSE_M2M_CLIENT_ID`, `PYMTHOUSE_M2M_CLIENT_SECRET`, etc.)
- [ ] **Create API Key** flow in Developer API UI returns a long-lived `pmth_*` key on first-time PymtHouse link (`POST /api/v1/auth/providers/pymthouse/start`)
- [ ] `POST /api/pymthouse/keys/exchange` exchanges a `pmth_*` key for a short-lived signer JWT
- [ ] `POST /api/signer/device/exchange` exchanges a device token for a signer session
- [ ] `GET /api/v1/billing/pymthouse/config` returns signer URL for the Developer API UI
- [ ] `POST /api/v1/billing/pymthouse/token` still mints opaque signer sessions for authenticated users
- [ ] `GET /api/v1/billing/pymthouse/usage` continues to proxy usage data
- [ ] Existing developer key CRUD routes work with the refetch BFF layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PymtHouse create/start now provisions long-lived `pmth_*` API keys that persist until revoked.
  * Added/updated token exchange routes for `pmth_*` API keys and device tokens to signer sessions.
  * Added a public PymtHouse configuration endpoint for improved developer tooling.
  * Billing usage for `scope=me` now includes retail usage data.
* **Bug Fixes**
  * Developer API key expiry display/cleanup behavior was simplified: `pmth_*` keys no longer show computed expiry, and only `EXPIRED` keys are hidden/404’d.
* **Documentation**
  * Updated PymtHouse integration docs for the new token and exchange contracts.
* **Chores**
  * Upgraded `@pymthouse/builder-sdk` to version `0.4.3` across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->