### PR TITLE
feat(gateway): add public sdk Service Gateway connector + naap_ key auth (NAAP-5)

### DIFF
--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -15,6 +15,13 @@ export interface KnownFlag {
   description: string;
 }
 
+/**
+ * Canonical key for the NAAP-5 flag (default OFF). Single source of truth shared
+ * by the KNOWN_FLAGS registry and the gateway authorize step so the flag name
+ * cannot silently drift between the two.
+ */
+export const SDK_CONNECTOR_FLAG = 'sdk_connector';
+
 export const KNOWN_FLAGS: KnownFlag[] = [
   {
     key: 'enableTeams',
@@ -70,7 +77,7 @@ export const KNOWN_FLAGS: KnownFlag[] = [
       'Enforce key → plan → capability access at the front door and discovery (NAAP-E). OFF = no enforcement (capabilities surfaced only, exactly as today); ON = deny a requested capability not granted by the resolved plan (fail closed).',
   },
   {
-    key: 'sdk_connector',
+    key: SDK_CONNECTOR_FLAG,
     enabled: false,
     description:
       'Seed the public "sdk" Service Gateway connector (fronting sdk.daydream.monster at /api/v1/gw/sdk/*) AND accept native naap_ keys at the gateway authorize step (NAAP-5). OFF = no sdk connector seeded and naap_ keys are rejected at the gateway exactly as today (no-op).',

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -69,6 +69,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     description:
       'Enforce key → plan → capability access at the front door and discovery (NAAP-E). OFF = no enforcement (capabilities surfaced only, exactly as today); ON = deny a requested capability not granted by the resolved plan (fail closed).',
   },
+  {
+    key: 'sdk_connector',
+    enabled: false,
+    description:
+      'Seed the public "sdk" Service Gateway connector (fronting sdk.daydream.monster at /api/v1/gw/sdk/*) AND accept native naap_ keys at the gateway authorize step (NAAP-5). OFF = no sdk connector seeded and naap_ keys are rejected at the gateway exactly as today (no-op).',
+  },
 ];
 
 /**

--- a/apps/web-next/src/lib/gateway/__tests__/native-key-authorize.test.ts
+++ b/apps/web-next/src/lib/gateway/__tests__/native-key-authorize.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for Service Gateway — Native NaaP key (`naap_`) authorization (NAAP-5).
+ *
+ * Covers the new flag-gated authorize branch that lets an app holding a native
+ * `naap_` key authorize against PUBLIC connectors (e.g. the `sdk` connector):
+ *
+ *   - INV-1 / zero-regression: with `sdk_connector` OFF, a `naap_` key is
+ *     rejected at the gateway exactly as today (returns null → 401) and the
+ *     DevApiKey table is never queried.
+ *   - Flag ON: a valid ACTIVE key authorizes (callerType 'nativeKey'), revoked /
+ *     unknown / malformed keys are rejected, and team vs personal scope resolve.
+ *   - gw_/gwm_/JWT paths are untouched by the flag.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  SDK_CONNECTOR_FLAG: 'sdk_connector',
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    gatewayApiKey: { findUnique: vi.fn(), update: vi.fn().mockResolvedValue({}) },
+    gatewayMasterKey: { findUnique: vi.fn(), update: vi.fn().mockResolvedValue({}) },
+    teamMember: { findFirst: vi.fn().mockResolvedValue({ id: 'member-1' }) },
+    devApiKey: { findUnique: vi.fn(), update: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+vi.mock('@/lib/api/auth', () => ({ validateSession: vi.fn() }));
+
+vi.mock('@/lib/api/response', () => ({
+  getAuthToken: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+
+vi.mock('@naap/cache', () => ({
+  createRateLimiter: () => ({
+    consume: vi.fn().mockResolvedValue({ allowed: true, remaining: 10, limit: 10, resetIn: 60 }),
+    get: vi.fn().mockResolvedValue({ allowed: true, remaining: 10, limit: 10, resetIn: 60 }),
+    reset: vi.fn(),
+    config: { points: 10, duration: 60, blockDuration: 300, keyPrefix: 'gw:auth:fail' },
+  }),
+}));
+
+import { prisma } from '@/lib/db';
+import { hashApiKey } from '@naap/database';
+import { authorize } from '../authorize';
+
+const mockDevApiKeyFind = (
+  prisma as unknown as { devApiKey: { findUnique: ReturnType<typeof vi.fn> } }
+).devApiKey.findUnique;
+const mockGatewayApiKeyFind = prisma.gatewayApiKey.findUnique as ReturnType<typeof vi.fn>;
+
+// A syntactically valid native key: naap_<16 hex>_<48 hex>.
+const LOOKUP_ID = 'a'.repeat(16);
+const SECRET = 'b'.repeat(48);
+const RAW_KEY = `naap_${LOOKUP_ID}_${SECRET}`;
+const KEY_HASH = hashApiKey(RAW_KEY);
+
+function nativeKeyRequest(rawKey = RAW_KEY): Request {
+  return new Request('https://example.com/api/v1/gw/sdk/inference', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${rawKey}` },
+  });
+}
+
+describe('authorize — native naap_ key (NAAP-5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('flag OFF (INV-1: zero-regression)', () => {
+    it('rejects a valid naap_ key and never touches DevApiKey', async () => {
+      isFeatureEnabled.mockResolvedValue(false);
+      mockDevApiKeyFind.mockResolvedValue({
+        id: 'key-1',
+        userId: 'user-1',
+        keyHash: KEY_HASH,
+        status: 'ACTIVE',
+        seatId: 'seat-1',
+        teamId: 'team-1',
+      });
+
+      const result = await authorize(nativeKeyRequest());
+
+      expect(result).toBeNull();
+      expect(mockDevApiKeyFind).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON', () => {
+    beforeEach(() => {
+      isFeatureEnabled.mockResolvedValue(true);
+    });
+
+    it('authorizes a valid ACTIVE team-bound key as callerType nativeKey', async () => {
+      mockDevApiKeyFind.mockResolvedValue({
+        id: 'key-1',
+        userId: 'user-1',
+        keyHash: KEY_HASH,
+        status: 'ACTIVE',
+        seatId: 'seat-1',
+        teamId: 'team-1',
+      });
+
+      const result = await authorize(nativeKeyRequest());
+
+      expect(result).not.toBeNull();
+      expect(result!.callerType).toBe('nativeKey');
+      expect(result!.callerId).toBe('user-1');
+      expect(result!.teamId).toBe('team-1');
+      expect(mockDevApiKeyFind).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { keyLookupId: LOOKUP_ID } }),
+      );
+    });
+
+    it('resolves personal scope when the key has no teamId', async () => {
+      mockDevApiKeyFind.mockResolvedValue({
+        id: 'key-2',
+        userId: 'user-2',
+        keyHash: KEY_HASH,
+        status: 'ACTIVE',
+        seatId: null,
+        teamId: null,
+      });
+
+      const result = await authorize(nativeKeyRequest());
+
+      expect(result).not.toBeNull();
+      expect(result!.teamId).toBe('personal:user-2');
+    });
+
+    it('rejects a revoked (non-ACTIVE) key', async () => {
+      mockDevApiKeyFind.mockResolvedValue({
+        id: 'key-3',
+        userId: 'user-3',
+        keyHash: KEY_HASH,
+        status: 'REVOKED',
+        seatId: null,
+        teamId: 'team-3',
+      });
+
+      const result = await authorize(nativeKeyRequest());
+      expect(result).toBeNull();
+    });
+
+    it('rejects an unknown key (no row)', async () => {
+      mockDevApiKeyFind.mockResolvedValue(null);
+
+      const result = await authorize(nativeKeyRequest());
+      expect(result).toBeNull();
+    });
+
+    it('rejects a key whose secret hash does not match', async () => {
+      mockDevApiKeyFind.mockResolvedValue({
+        id: 'key-4',
+        userId: 'user-4',
+        keyHash: hashApiKey('naap_' + 'c'.repeat(16) + '_' + 'd'.repeat(48)),
+        status: 'ACTIVE',
+        seatId: null,
+        teamId: 'team-4',
+      });
+
+      const result = await authorize(nativeKeyRequest());
+      expect(result).toBeNull();
+    });
+
+    it('rejects a malformed naap_ key without a DB lookup', async () => {
+      const result = await authorize(nativeKeyRequest('naap_not-a-valid-key'));
+      expect(result).toBeNull();
+      expect(mockDevApiKeyFind).not.toHaveBeenCalled();
+    });
+
+    it('does not affect gw_ key auth (still routed to gatewayApiKey)', async () => {
+      mockGatewayApiKeyFind.mockResolvedValue(null);
+      const request = new Request('https://example.com/api/v1/gw/sdk/inference', {
+        headers: { authorization: 'Bearer gw_some-key' },
+      });
+
+      await authorize(request);
+
+      expect(mockGatewayApiKeyFind).toHaveBeenCalled();
+      expect(mockDevApiKeyFind).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web-next/src/lib/gateway/__tests__/sdk-connector.test.ts
+++ b/apps/web-next/src/lib/gateway/__tests__/sdk-connector.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the public `sdk` Service Gateway connector (NAAP-5).
+ *
+ *   - The connector definition (sdk.json) exists and is shaped for a public,
+ *     env-sourced upstream reachable at /api/v1/gw/sdk/*.
+ *   - The build-time seed registers `sdk` gated behind the `sdk_connector` flag,
+ *     with SDK_SERVICE_BASE_URL / the sdk.daydream.monster default.
+ *   - resolveConfig resolves the published public `sdk` connector for any caller
+ *     scope via the public fallback (the basis for global/shared reachability).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    serviceConnector: { findUnique: vi.fn(), findFirst: vi.fn() },
+  },
+}));
+
+import { prisma } from '@/lib/db';
+import { resolveConfig, invalidateConnectorCache } from '../resolve';
+
+const mockFindUnique = prisma.serviceConnector.findUnique as ReturnType<typeof vi.fn>;
+const mockFindFirst = prisma.serviceConnector.findFirst as ReturnType<typeof vi.fn>;
+
+/** Ascend from the test file until a relative path resolves (cwd-independent). */
+function findRepoFile(relative: string): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    const candidate = path.join(dir, relative);
+    if (fs.existsSync(candidate)) return candidate;
+    dir = path.dirname(dir);
+  }
+  throw new Error(`could not locate ${relative} from test directory`);
+}
+
+describe('sdk connector definition (sdk.json)', () => {
+  const sdkPath = findRepoFile('plugins/service-gateway/connectors/sdk.json');
+  const def = JSON.parse(fs.readFileSync(sdkPath, 'utf-8'));
+
+  it('declares the sdk slug reachable at /api/v1/gw/sdk/*', () => {
+    expect(def.connector.slug).toBe('sdk');
+  });
+
+  it('defaults the upstream to the staging SDK service host', () => {
+    expect(def.connector.upstreamBaseUrl).toBe('https://sdk.daydream.monster');
+    expect(def.connector.allowedHosts).toContain('sdk.daydream.monster');
+  });
+
+  it('uses no upstream auth/secrets (the SDK service authenticates the naap_ key itself)', () => {
+    expect(def.connector.authType).toBe('none');
+    expect(def.connector.secretRefs).toEqual([]);
+  });
+
+  it('exposes the descriptor endpoints (/inference, /capabilities, /llm/chat)', () => {
+    const paths = def.endpoints.map((e: { path: string }) => e.path).sort();
+    expect(paths).toEqual(['/capabilities', '/inference', '/llm/chat']);
+  });
+});
+
+describe('sdk connector seed registration', () => {
+  const seedPath = findRepoFile('bin/seed-gateway-connector.ts');
+  const src = fs.readFileSync(seedPath, 'utf-8');
+
+  it('registers the sdk seed gated behind the sdk_connector flag', () => {
+    expect(src).toContain("slug: 'sdk'");
+    expect(src).toContain("flag: 'sdk_connector'");
+  });
+
+  it('sources the base URL from SDK_SERVICE_BASE_URL with the staging default', () => {
+    expect(src).toContain("baseUrlEnv: 'SDK_SERVICE_BASE_URL'");
+    expect(src).toContain("defaultBaseUrl: 'https://sdk.daydream.monster'");
+  });
+});
+
+describe('sdk connector public resolution', () => {
+  function makeSdkConnector(overrides?: Record<string, unknown>) {
+    return {
+      id: 'sdk-conn-1',
+      teamId: null,
+      ownerUserId: 'admin-1',
+      slug: 'sdk',
+      displayName: 'SDK Service',
+      status: 'published',
+      visibility: 'public',
+      upstreamBaseUrl: 'https://sdk.daydream.monster',
+      allowedHosts: ['sdk.daydream.monster'],
+      defaultTimeout: 30000,
+      healthCheckPath: '/health',
+      authType: 'none',
+      authConfig: {},
+      secretRefs: [],
+      responseWrapper: false,
+      streamingEnabled: true,
+      errorMapping: {},
+      endpoints: [
+        {
+          id: 'ep-inference',
+          connectorId: 'sdk-conn-1',
+          name: 'inference',
+          method: 'POST',
+          path: '/inference',
+          enabled: true,
+          upstreamMethod: null,
+          upstreamPath: '/inference',
+          upstreamContentType: 'application/json',
+          upstreamQueryParams: {},
+          upstreamStaticBody: null,
+          bodyTransform: 'passthrough',
+          headerMapping: {},
+          rateLimit: null,
+          timeout: 30000,
+          maxRequestSize: null,
+          maxResponseSize: null,
+          cacheTtl: null,
+          retries: 0,
+          bodyPattern: null,
+          bodyBlacklist: [],
+          bodySchema: null,
+          requiredHeaders: [],
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    invalidateConnectorCache('personal:app-user', 'sdk');
+    invalidateConnectorCache('team-app', 'sdk');
+    invalidateConnectorCache('public', 'sdk');
+    mockFindFirst.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves the public sdk connector for any caller scope via fallback', async () => {
+    mockFindUnique.mockResolvedValue(null); // caller has no own `sdk` connector
+    mockFindFirst.mockResolvedValue(makeSdkConnector());
+
+    const config = await resolveConfig('personal:app-user', 'sdk', 'POST', '/inference');
+
+    expect(config).not.toBeNull();
+    expect(config!.connector.slug).toBe('sdk');
+    expect(config!.connector.visibility).toBe('public');
+    expect(config!.connector.upstreamBaseUrl).toBe('https://sdk.daydream.monster');
+    expect(config!.endpoint.upstreamPath).toBe('/inference');
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { slug: 'sdk', visibility: 'public', status: 'published' },
+      include: { endpoints: true },
+    });
+  });
+
+  it('returns null when the sdk connector is not seeded (flag OFF → no row)', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    mockFindFirst.mockResolvedValue(null);
+
+    const config = await resolveConfig('team-app', 'sdk', 'POST', '/inference');
+    expect(config).toBeNull();
+  });
+});

--- a/apps/web-next/src/lib/gateway/authorize.ts
+++ b/apps/web-next/src/lib/gateway/authorize.ts
@@ -8,14 +8,46 @@
  * Team isolation: a key from Team A cannot access Team B's connectors.
  */
 
-import { createHash } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 import { prisma } from '@/lib/db';
 import { validateSession } from '@/lib/api/auth';
 import { getAuthToken, getClientIP } from '@/lib/api/response';
+import { isFeatureEnabled } from '@/lib/feature-flags';
+import { parseApiKey, hashApiKey } from '@naap/database';
 import { personalScopeId, isPersonalScope } from './scope';
 import { getOrCreateDefaultPlan } from './default-plan';
 import { matchIPAllowlist } from './types';
 import type { AuthResult, TeamContext } from './types';
+
+/**
+ * Feature flag (default OFF) gating NAAP-5 behaviour: the public `sdk` connector
+ * seed AND acceptance of native `naap_` keys at this gateway authorize step.
+ * With the flag OFF, a `Bearer naap_…` key is rejected here exactly as today
+ * (it would otherwise fall through to the JWT path and fail session validation).
+ */
+export const SDK_CONNECTOR_FLAG = 'sdk_connector';
+
+/** Native `naap_` key prefix (matches @naap/database parseApiKey). */
+const NATIVE_KEY_BEARER_PREFIX = 'Bearer naap_';
+
+function logAuth(level: 'info' | 'warn', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, component: 'gateway.authorize', ...fields });
+  if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+/**
+ * Constant-time comparison of a presented native key against a stored scrypt
+ * hash (mirrors `@/lib/dev-api/native-key#verifyNativeKeyHash`, inlined here to
+ * avoid pulling the server-only billing registry into the gateway bundle).
+ */
+function verifyNativeKeyHash(rawKey: string, storedHash: string | null | undefined): boolean {
+  if (!storedHash) return false;
+  const actual = Buffer.from(hashApiKey(rawKey), 'utf8');
+  const expected = Buffer.from(storedHash, 'utf8');
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}
 
 type RateLimiter = { consume: (key: string, points?: number) => Promise<{ allowed: boolean }> };
 let _authFailLimiter: RateLimiter | null = null;
@@ -66,6 +98,28 @@ export async function authorize(request: Request): Promise<AuthResult | null> {
     if (!rl.allowed) return null;
 
     const result = await authorizeApiKey(authHeader.slice(7)); // strip "Bearer "
+    if (!result) {
+      await limiter.consume(clientIP);
+    }
+    return result;
+  }
+
+  // Path 1.5: Native NaaP key auth (naap_ prefix) — NAAP-5, flag-gated.
+  // OFF (default): reject here so behaviour is identical to today (a naap_ key
+  // would otherwise fall through to the JWT path and fail session validation →
+  // 401). ON: resolve the native key via the DevApiKey path so an app holding a
+  // naap_ key can authorize against PUBLIC connectors (e.g. the `sdk` connector).
+  if (authHeader.startsWith(NATIVE_KEY_BEARER_PREFIX)) {
+    if (!(await isFeatureEnabled(SDK_CONNECTOR_FLAG))) {
+      logAuth('warn', 'native_key.rejected_flag_off', {});
+      return null;
+    }
+    const clientIP = getClientIP(request) || 'unknown';
+    const limiter = await getAuthFailLimiter();
+    const rl = await limiter.consume(clientIP, 0);
+    if (!rl.allowed) return null;
+
+    const result = await authorizeNativeKey(authHeader.slice(7)); // strip "Bearer "
     if (!result) {
       await limiter.consume(clientIP);
     }
@@ -245,6 +299,62 @@ async function authorizeApiKey(rawKey: string): Promise<AuthResult | null> {
     dailyQuota,
     monthlyQuota,
     maxRequestSize,
+  };
+}
+
+// ── Native NaaP Key Auth (naap_) — NAAP-5 ──
+
+/**
+ * Authorize a native `naap_` key at the gateway (flag-gated by the caller).
+ *
+ * Resolves the key through the existing DevApiKey path (blind-index lookup by
+ * `keyLookupId` + constant-time hash verify), then maps it to the caller's
+ * scope: a seat/team-bound key uses its `teamId`; otherwise the personal scope
+ * of the key's `userId`. The returned `nativeKey` caller can then authorize
+ * against PUBLIC connectors via {@link verifyConnectorAccess}.
+ *
+ * Capability/quota enforcement remains at the `/api/v1/keys/validate` front door
+ * (NAAP-C/E); at the gateway the key is only authenticated and scoped, and
+ * public-connector access is governed by visibility (any authenticated caller).
+ */
+async function authorizeNativeKey(rawKey: string): Promise<AuthResult | null> {
+  const parsed = parseApiKey(rawKey);
+  if (!parsed) {
+    logAuth('warn', 'native_key.malformed', {});
+    return null;
+  }
+
+  const key = await prisma.devApiKey.findUnique({
+    where: { keyLookupId: parsed.lookupId },
+    select: { id: true, userId: true, keyHash: true, status: true, seatId: true, teamId: true },
+  });
+
+  // Constant-time hash check; uniform failure whether the row is missing or the
+  // secret mismatches (no key enumeration).
+  if (!key || !verifyNativeKeyHash(rawKey, key.keyHash)) {
+    logAuth('warn', 'native_key.not_found_or_mismatch', {});
+    return null;
+  }
+  if (key.status !== 'ACTIVE') {
+    logAuth('warn', 'native_key.inactive', { keyId: key.id, status: key.status });
+    return null;
+  }
+
+  const teamId = key.teamId ?? personalScopeId(key.userId);
+
+  // Fire-and-forget last-used update; never block authorization on it.
+  prisma.devApiKey.update({ where: { id: key.id }, data: { lastUsedAt: new Date() } }).catch(() => {});
+
+  logAuth('info', 'native_key.authorized', {
+    keyId: key.id,
+    scope: key.teamId ? 'team' : 'personal',
+  });
+
+  return {
+    authenticated: true,
+    callerType: 'nativeKey',
+    callerId: key.userId,
+    teamId,
   };
 }
 

--- a/apps/web-next/src/lib/gateway/authorize.ts
+++ b/apps/web-next/src/lib/gateway/authorize.ts
@@ -12,7 +12,7 @@ import { createHash, timingSafeEqual } from 'crypto';
 import { prisma } from '@/lib/db';
 import { validateSession } from '@/lib/api/auth';
 import { getAuthToken, getClientIP } from '@/lib/api/response';
-import { isFeatureEnabled } from '@/lib/feature-flags';
+import { isFeatureEnabled, SDK_CONNECTOR_FLAG } from '@/lib/feature-flags';
 import { parseApiKey, hashApiKey } from '@naap/database';
 import { personalScopeId, isPersonalScope } from './scope';
 import { getOrCreateDefaultPlan } from './default-plan';
@@ -24,11 +24,24 @@ import type { AuthResult, TeamContext } from './types';
  * seed AND acceptance of native `naap_` keys at this gateway authorize step.
  * With the flag OFF, a `Bearer naap_…` key is rejected here exactly as today
  * (it would otherwise fall through to the JWT path and fail session validation).
+ *
+ * Re-exported from the flag registry ({@link SDK_CONNECTOR_FLAG}) so the key has
+ * a single source of truth.
  */
-export const SDK_CONNECTOR_FLAG = 'sdk_connector';
+export { SDK_CONNECTOR_FLAG };
 
 /** Native `naap_` key prefix (matches @naap/database parseApiKey). */
 const NATIVE_KEY_BEARER_PREFIX = 'Bearer naap_';
+
+/**
+ * Constant-time fallback hash used when no DevApiKey row matches the presented
+ * lookup ID. Verifying against this dummy keeps the scrypt work identical for
+ * "unknown lookup ID" and "wrong secret", so response timing cannot be used to
+ * enumerate which `keyLookupId`s exist.
+ */
+const FALLBACK_NATIVE_KEY_HASH = hashApiKey(
+  'naap_0000000000000000_000000000000000000000000000000000000000000000000',
+);
 
 function logAuth(level: 'info' | 'warn', event: string, fields: Record<string, unknown>): void {
   const line = JSON.stringify({ level, event, component: 'gateway.authorize', ...fields });
@@ -329,9 +342,12 @@ async function authorizeNativeKey(rawKey: string): Promise<AuthResult | null> {
     select: { id: true, userId: true, keyHash: true, status: true, seatId: true, teamId: true },
   });
 
-  // Constant-time hash check; uniform failure whether the row is missing or the
-  // secret mismatches (no key enumeration).
-  if (!key || !verifyNativeKeyHash(rawKey, key.keyHash)) {
+  // Constant-time hash check. Always run the scrypt verify — against the real
+  // stored hash when the row exists, otherwise a fixed fallback — so the work
+  // (and thus response timing) is identical whether the lookup ID is unknown or
+  // the secret simply mismatches. This prevents keyLookupId enumeration.
+  const hashMatches = verifyNativeKeyHash(rawKey, key?.keyHash ?? FALLBACK_NATIVE_KEY_HASH);
+  if (!key || !hashMatches) {
     logAuth('warn', 'native_key.not_found_or_mismatch', {});
     return null;
   }

--- a/apps/web-next/src/lib/gateway/types.ts
+++ b/apps/web-next/src/lib/gateway/types.ts
@@ -60,7 +60,7 @@ export interface ResolvedConfig {
 
 // ── Auth ──
 
-export type CallerType = 'jwt' | 'apiKey' | 'masterKey';
+export type CallerType = 'jwt' | 'apiKey' | 'masterKey' | 'nativeKey';
 
 export type AuthResult = AuthResultAuthenticated;
 

--- a/bin/seed-gateway-connector.ts
+++ b/bin/seed-gateway-connector.ts
@@ -40,6 +40,22 @@ interface ConnectorSeed {
   template: string;
   /** Maps secretRef name → env var holding the value. */
   secretMap: Record<string, string>;
+  /**
+   * Feature flag (FeatureFlag.key) that must be ENABLED for this connector to
+   * seed. When the flag row is missing or disabled, the connector is skipped —
+   * so a flag defaulting OFF means the connector simply never exists (no-op).
+   * Omit to seed unconditionally (matches the pre-NAAP-5 connectors).
+   */
+  flag?: string;
+  /**
+   * Optional env var holding the upstream base URL. When set (non-empty) it
+   * overrides the template's `upstreamBaseUrl` and re-derives `allowedHosts`,
+   * so the upstream host is configurable per environment without code changes.
+   * Falls back to `defaultBaseUrl` (then the template value) when unset.
+   */
+  baseUrlEnv?: string;
+  /** Default base URL used when `baseUrlEnv` is unset. */
+  defaultBaseUrl?: string;
 }
 
 const CONNECTOR_SEEDS: ConnectorSeed[] = [
@@ -62,6 +78,16 @@ const CONNECTOR_SEEDS: ConnectorSeed[] = [
     slug: 'naap-discover',
     template: 'naap-discover.json',
     secretMap: {},
+  },
+  {
+    // NAAP-5: public connector fronting the SDK service. Gated behind the
+    // `sdk_connector` flag (default OFF) so it is a no-op until enabled.
+    slug: 'sdk',
+    template: 'sdk.json',
+    secretMap: {},
+    flag: 'sdk_connector',
+    baseUrlEnv: 'SDK_SERVICE_BASE_URL',
+    defaultBaseUrl: 'https://sdk.daydream.monster',
   },
 ];
 
@@ -89,6 +115,26 @@ function encrypt(text: string): { encryptedValue: string; iv: string } {
     encryptedValue: encrypted + ':' + authTag.toString('hex'),
     iv: iv.toString('hex'),
   };
+}
+
+// ── Feature flag check (build-time, DB-direct) ──
+
+/**
+ * Read a feature flag's enabled state directly from the FeatureFlag table.
+ * Mirrors `isFeatureEnabled` semantics: a missing row counts as disabled, so a
+ * flag defaulting OFF means the gated connector is never seeded.
+ */
+async function isFlagEnabled(prisma: PrismaClient, key: string): Promise<boolean> {
+  try {
+    const flag = await prisma.featureFlag.findUnique({
+      where: { key },
+      select: { enabled: true },
+    });
+    return Boolean(flag?.enabled);
+  } catch {
+    // On any lookup error, fail closed (treat as disabled) to preserve no-op.
+    return false;
+  }
 }
 
 // ── Seed one connector ──
@@ -131,6 +177,23 @@ async function seedConnector(
 
   console.log(`[seed-gw] Seeding connector: ${slug}`);
 
+  // Resolve the upstream base URL from env (if the seed opts in), so the host
+  // is configurable per environment. Falls back to the seed default, then the
+  // template value. Re-derive allowedHosts from whichever base URL wins.
+  if (seed.baseUrlEnv) {
+    const envBaseUrl = (process.env[seed.baseUrlEnv] || '').trim();
+    const resolvedBaseUrl = envBaseUrl || seed.defaultBaseUrl || conn.upstreamBaseUrl;
+    if (resolvedBaseUrl && resolvedBaseUrl !== conn.upstreamBaseUrl) {
+      console.log(
+        `[seed-gw]   Base URL for ${slug}: ${resolvedBaseUrl}` +
+          (envBaseUrl ? ` (from ${seed.baseUrlEnv})` : ' (default)'),
+      );
+    }
+    conn.upstreamBaseUrl = resolvedBaseUrl;
+    // Force re-derivation of allowedHosts from the resolved base URL host.
+    conn.allowedHosts = [];
+  }
+
   // Upsert ServiceConnector
   let allowedHosts: string[] = conn.allowedHosts || [];
   if (allowedHosts.length === 0) {
@@ -156,6 +219,19 @@ async function seedConnector(
         data: { authConfig: templateAuthConfig },
       });
       console.log(`[seed-gw]   Updated authConfig for ${slug}`);
+    }
+    // For env-sourced connectors, keep the upstream base URL + allowedHosts in
+    // sync so an env change is picked up on the next deploy (idempotent).
+    if (seed.baseUrlEnv) {
+      const hostsChanged =
+        JSON.stringify([...connector.allowedHosts].sort()) !== JSON.stringify([...allowedHosts].sort());
+      if (connector.upstreamBaseUrl !== conn.upstreamBaseUrl || hostsChanged) {
+        await prisma.serviceConnector.update({
+          where: { id: connector.id },
+          data: { upstreamBaseUrl: conn.upstreamBaseUrl, allowedHosts },
+        });
+        console.log(`[seed-gw]   Updated upstreamBaseUrl/allowedHosts for ${slug}`);
+      }
     }
   } else {
     connector = await prisma.serviceConnector.create({
@@ -289,6 +365,16 @@ async function main() {
 
     let seeded = 0;
     for (const seed of CONNECTOR_SEEDS) {
+      // Flag-gated connectors only seed when their FeatureFlag is enabled.
+      // Missing row or disabled => skip (a flag defaulting OFF is a no-op).
+      if (seed.flag) {
+        const enabled = await isFlagEnabled(prisma, seed.flag);
+        if (!enabled) {
+          console.log(`[seed-gw] ${seed.slug}: flag "${seed.flag}" disabled — skipping`);
+          continue;
+        }
+        console.log(`[seed-gw] ${seed.slug}: flag "${seed.flag}" enabled`);
+      }
       const ok = await seedConnector(prisma, seed, ownerUserId);
       if (ok) seeded++;
     }

--- a/plugins/service-gateway/connectors/sdk.json
+++ b/plugins/service-gateway/connectors/sdk.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "./connector-template.schema.json",
+  "id": "sdk",
+  "name": "SDK Service",
+  "description": "Global (public) NaaP Service Gateway connector fronting the SDK service (sdk.daydream.monster) so any registered application can reach inference, capabilities, and LLM chat through NaaP's gateway at /api/v1/gw/sdk/* (NAAP-5)",
+  "icon": "🧩",
+  "category": "ai",
+  "connector": {
+    "slug": "sdk",
+    "displayName": "SDK Service",
+    "description": "Proxies application requests to the SDK service. Base URL is sourced from SDK_SERVICE_BASE_URL at seed time (default https://sdk.daydream.monster).",
+    "category": "ai",
+    "upstreamBaseUrl": "https://sdk.daydream.monster",
+    "allowedHosts": ["sdk.daydream.monster"],
+    "defaultTimeout": 30000,
+    "healthCheckPath": "/health",
+    "authType": "none",
+    "authConfig": {},
+    "secretRefs": [],
+    "streamingEnabled": true,
+    "responseWrapper": false,
+    "tags": ["sdk", "daydream", "inference", "llm", "capabilities"]
+  },
+  "endpoints": [
+    {
+      "name": "inference",
+      "description": "Run an inference request against the SDK service",
+      "method": "POST",
+      "path": "/inference",
+      "upstreamPath": "/inference",
+      "timeout": 30000,
+      "retries": 0
+    },
+    {
+      "name": "capabilities",
+      "description": "List SDK service capabilities",
+      "method": "GET",
+      "path": "/capabilities",
+      "upstreamPath": "/capabilities",
+      "timeout": 15000,
+      "cacheTtl": 30,
+      "retries": 1
+    },
+    {
+      "name": "llm-chat",
+      "description": "LLM chat completion (streaming-capable)",
+      "method": "POST",
+      "path": "/llm/chat",
+      "upstreamPath": "/llm/chat",
+      "timeout": 60000,
+      "retries": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements **NAAP-5**: a global (shared, public) `sdk` Service Gateway connector so any registered application (Storyboard specifically) can reach the SDK service (`sdk.daydream.monster`) through NaaP's gateway at `/api/v1/gw/sdk/*`.

All new behavior is gated behind a new feature flag **`sdk_connector` (default OFF)**. With the flag OFF, the new path is a strict no-op: no `sdk` connector is seeded and native `naap_` keys are rejected at the gateway exactly as today.

## Changes (file-by-file)

- **`apps/web-next/src/lib/feature-flags.ts`** — add `sdk_connector` flag (default `false`).
- **`plugins/service-gateway/connectors/sdk.json`** — new public connector definition modeled on `naap-discover`. `authType: none`, base URL default `https://sdk.daydream.monster`, endpoints `/inference`, `/capabilities`, `/llm/chat`, streaming enabled.
- **`bin/seed-gateway-connector.ts`** — register the `sdk` seed **gated on the `sdk_connector` flag** (read directly from the `FeatureFlag` table; missing/disabled ⇒ skip). Upstream base URL is **sourced from `SDK_SERVICE_BASE_URL`** with the staging default `https://sdk.daydream.monster`; `allowedHosts` is re-derived from the resolved host. Idempotent; syncs base URL/hosts on re-deploy.
- **`apps/web-next/src/lib/gateway/authorize.ts`** — new flag-gated `Bearer naap_` branch. When the flag is ON, native keys are resolved via the existing `DevApiKey` path (blind-index `keyLookupId` lookup + constant-time hash verify + `ACTIVE` check) and mapped to the key's team (or personal) scope, returning `callerType: 'nativeKey'` so the key can authorize against **public** connectors. Structured JSON logging added on every new branch. The native-key hash check is **inlined** (rather than imported from `@/lib/dev-api/native-key`) to avoid pulling the server-only billing registry into the gateway bundle.
- **`apps/web-next/src/lib/gateway/types.ts`** — extend `CallerType` with `'nativeKey'` (additive).
- **Tests** — `native-key-authorize.test.ts` (flag ON accepts valid/ACTIVE, rejects revoked/unknown/mismatch/malformed; flag OFF rejects + never touches the DB — **INV-1**; `gw_` path untouched) and `sdk-connector.test.ts` (connector definition shape, seed registration, public resolution via fallback, no-row ⇒ 404).

## Credential-model decision

**Chosen (smaller correct option):** keep the gateway's existing `gw_`/`gwm_`/JWT auth intact and, **behind the `sdk_connector` flag**, accept native `naap_` keys at the gateway authorize step via the existing `DevApiKey` path. This lets an app holding a `naap_` key authorize against the public `sdk` connector with no key minting/migration. Capability/quota enforcement remains at the `/api/v1/keys/validate` front door (NAAP-C/E); at the gateway the key is only authenticated + scoped, and public-connector access is governed by visibility (any authenticated caller), so no expensive provider-session mint happens on the proxy hot path.

**Alternative (not taken):** mint/associate a `gw_` gateway key per app/team and have apps present that instead. Rejected as more operational overhead (key provisioning + rotation per app) for no functional gain here, since the connector is public.

## Zero-regression proof (flag OFF)

- Seed is flag-gated ⇒ **no `sdk` connector row exists** ⇒ `/api/v1/gw/sdk/*` resolves to 404 (identical to today).
- Authorize rejects `Bearer naap_…` when the flag is OFF and **never queries `DevApiKey`** (asserted in `native-key-authorize.test.ts`); a `naap_` key still yields 401 exactly as before.
- Existing `gw_`/`gwm_`/JWT paths and the other connectors (`naap-discover`, `clickhouse-query`, `livepeer-subgraph`) are untouched.

## Test results

- `vitest run src/lib/gateway` → **39 files / 384 tests passing** (incl. the new suites).
- `vitest run src/lib/dev-api src/app/api/v1/keys/validate src/lib/capabilities` → **71 passing**.
- `tsc --noEmit`: no new errors introduced — the pre-existing errors are confirmed identical on `origin/main` (verified by stash) and are in unrelated files (community/wallet/secrets/pymthouse).

## Future work (simple-infra descriptor importer)

NaaP still has **no importer** that reads `simple-infra` `environments/staging/naap-connector.yaml`. This PR aligns the seed values with that descriptor (`sdk-service` → `/api/v1/gw/sdk/*`, the `/inference`, `/capabilities`, `/llm/chat` endpoints, `SDK_SERVICE_BASE_URL`) but does not consume the YAML. A descriptor importer (mapping `naap_connector.*` → seed input, honoring `enabled`/`auth_injection.credential_secret_ref`/`health_check`) remains future work.

## Test plan

- [ ] CI green on this PR.
- [ ] With `sdk_connector` enabled on a preview env (+ redeploy so the seed runs), confirm `GET /api/v1/gw/sdk/capabilities` resolves and proxies.
- [ ] Confirm a Storyboard `naap_` key authorizes against the `sdk` connector with the flag ON, and 401s with it OFF.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **SDK Service Gateway connector** exposing `/capabilities`, `/inference`, and `/llm/chat` (seeded only when `sdk_connector` is enabled; upstream base derived from `SDK_SERVICE_BASE_URL` with a safe default).
  * Introduced **feature-flag-gated native key (NAAP-5) authorization** for `Authorization: Bearer naap_…` keys, returning `callerType: nativeKey`.

* **Tests**
  * Added coverage for native-key authorization behavior and SDK connector seeding/resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->