### PR TITLE
feat(metrics): pull pymthouse usage for spend dashboard (NAAP-2)

### DIFF
--- a/apps/web-next/src/app/api/v1/metrics/usage/route.test.ts
+++ b/apps/web-next/src/app/api/v1/metrics/usage/route.test.ts
@@ -24,6 +24,20 @@ vi.mock('@/lib/db', () => ({
   },
 }));
 
+// Isolate the route from the pull lib internals: the lib is unit-tested
+// separately. `spendScopeKey` keeps its real (trivial) shape so the route's DB
+// exclusion logic is exercised faithfully.
+const pullSpend = vi.fn();
+const listPullCapableProviderSlugs = vi.fn();
+vi.mock('@/lib/metrics/usage-pull', () => ({
+  pullSpend: (...a: unknown[]) => pullSpend(...a),
+  listPullCapableProviderSlugs: () => listPullCapableProviderSlugs(),
+  spendScopeKey: (s: { providerSlug: string; accountId?: string }) =>
+    `${s.providerSlug}\u0000${s.accountId ?? '*app*'}`,
+}));
+
+const FLAGS = { usage_ingest: true, usage_pull: false };
+
 function req(query = ''): NextRequest {
   return new NextRequest(`https://naap.test/api/v1/metrics/usage${query}`, {
     method: 'GET',
@@ -46,14 +60,21 @@ function usageRow(accountId: string, providerSlug = 'pymthouse') {
   };
 }
 
+function scopeKey(providerSlug: string, accountId?: string) {
+  return `${providerSlug}\u0000${accountId ?? '*app*'}`;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  isFeatureEnabled.mockResolvedValue(true);
+  FLAGS.usage_ingest = true;
+  FLAGS.usage_pull = false;
+  isFeatureEnabled.mockImplementation(async (key: string) => FLAGS[key as keyof typeof FLAGS]);
+  listPullCapableProviderSlugs.mockReturnValue(['pymthouse']);
 });
 
 describe('usage_ingest flag OFF → no-op', () => {
   it('returns 404 and never authenticates or queries', async () => {
-    isFeatureEnabled.mockResolvedValue(false);
+    FLAGS.usage_ingest = false;
     const res = await GET(req());
     expect(res.status).toBe(404);
     expect(validateSession).not.toHaveBeenCalled();
@@ -61,7 +82,20 @@ describe('usage_ingest flag OFF → no-op', () => {
   });
 });
 
-describe('cross-tenant spend scoping', () => {
+describe('cross-tenant spend scoping (usage_pull OFF → reads ProviderUsageRecord)', () => {
+  it('never pulls when usage_pull is OFF', async () => {
+    validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
+    teamFindMany.mockResolvedValue([
+      { billingAccountProviderSlug: 'pymthouse', billingAccountId: SELF_ACCOUNT },
+    ]);
+    usageFindMany.mockResolvedValue([usageRow(SELF_ACCOUNT)]);
+
+    await GET(req());
+
+    expect(pullSpend).not.toHaveBeenCalled();
+    expect(usageFindMany).toHaveBeenCalledTimes(1);
+  });
+
   it('forbids a non-member from reading another account', async () => {
     validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
     // Caller belongs to a team bound only to their own account.
@@ -75,7 +109,7 @@ describe('cross-tenant spend scoping', () => {
     expect(usageFindMany).not.toHaveBeenCalled();
   });
 
-  it('returns only the caller\'s accounts when no accountId is given', async () => {
+  it("returns only the caller's accounts when no accountId is given", async () => {
     validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
     teamFindMany.mockResolvedValue([
       { billingAccountProviderSlug: 'pymthouse', billingAccountId: SELF_ACCOUNT },
@@ -139,5 +173,124 @@ describe('cross-tenant spend scoping', () => {
     const res = await GET(req());
     expect(res.status).toBe(401);
     expect(usageFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('usage_pull flag ON → pull-first with fallback', () => {
+  beforeEach(() => {
+    FLAGS.usage_pull = true;
+  });
+
+  it("pulls the caller's ref live and does NOT read the DB for pulled scopes", async () => {
+    validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
+    teamFindMany.mockResolvedValue([
+      { billingAccountProviderSlug: 'pymthouse', billingAccountId: SELF_ACCOUNT },
+    ]);
+    pullSpend.mockResolvedValue({
+      records: [
+        {
+          providerSlug: 'pymthouse',
+          accountId: SELF_ACCOUNT,
+          sessions: 0,
+          tickets: 42,
+          feeWei: null,
+          networkFeeUsdMicros: '9000',
+          byCapability: { 'text-to-image:sdxl': { tickets: 42, networkFeeUsdMicros: '9000' } },
+        },
+      ],
+      pulled: new Set([scopeKey('pymthouse', SELF_ACCOUNT)]),
+    });
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    // Scoped to the caller's authorized ref only (tenant boundary preserved).
+    expect(pullSpend).toHaveBeenCalledTimes(1);
+    expect(pullSpend.mock.calls[0][0]).toEqual([
+      { providerSlug: 'pymthouse', accountId: SELF_ACCOUNT },
+    ]);
+    // Pulled ⇒ no DB backfill for that ref.
+    expect(usageFindMany).not.toHaveBeenCalled();
+    const json = await res.json();
+    expect(json.data.providers).toHaveLength(1);
+    expect(json.data.providers[0].tickets).toBe(42);
+    expect(json.data.providers[0].byCapability).toEqual({
+      'text-to-image:sdxl': { tickets: 42, networkFeeUsdMicros: '9000' },
+    });
+  });
+
+  it('falls back to ProviderUsageRecord when the live pull yields nothing', async () => {
+    validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
+    teamFindMany.mockResolvedValue([
+      { billingAccountProviderSlug: 'pymthouse', billingAccountId: SELF_ACCOUNT },
+    ]);
+    // Simulate a failed/empty pull (graceful degradation contract).
+    pullSpend.mockResolvedValue({ records: [], pulled: new Set<string>() });
+    usageFindMany.mockResolvedValue([usageRow(SELF_ACCOUNT)]);
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    expect(usageFindMany).toHaveBeenCalledTimes(1);
+    const where = usageFindMany.mock.calls[0][0].where as {
+      OR: Array<{ providerSlug: string; accountId: string }>;
+    };
+    expect(where.OR).toEqual([{ providerSlug: 'pymthouse', accountId: SELF_ACCOUNT }]);
+    const json = await res.json();
+    expect(json.data.providers[0].tickets).toBe(10); // from the DB row
+  });
+
+  it('never 500s: a thrown pull orchestration degrades to the full DB read', async () => {
+    validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
+    teamFindMany.mockResolvedValue([
+      { billingAccountProviderSlug: 'pymthouse', billingAccountId: SELF_ACCOUNT },
+    ]);
+    pullSpend.mockRejectedValue(new Error('boom'));
+    usageFindMany.mockResolvedValue([usageRow(SELF_ACCOUNT)]);
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    expect(usageFindMany).toHaveBeenCalledTimes(1);
+    const json = await res.json();
+    expect(json.data.providers[0].tickets).toBe(10);
+  });
+
+  it('does not pull and does not 403-bypass: a forbidden account never reaches the pull', async () => {
+    validateSession.mockResolvedValue({ id: 'user-1', roles: ['user'] });
+    teamFindMany.mockResolvedValue([
+      { billingAccountProviderSlug: 'pymthouse', billingAccountId: SELF_ACCOUNT },
+    ]);
+
+    const res = await GET(req(`?accountId=${OTHER_ACCOUNT}`));
+
+    expect(res.status).toBe(403);
+    expect(pullSpend).not.toHaveBeenCalled();
+    expect(usageFindMany).not.toHaveBeenCalled();
+  });
+
+  it('admin app-wide: pulls pull-capable providers and excludes them from the DB read', async () => {
+    validateSession.mockResolvedValue({ id: 'admin-1', roles: ['system:admin'] });
+    pullSpend.mockResolvedValue({
+      records: [
+        { providerSlug: 'pymthouse', accountId: 'u1', sessions: 0, tickets: 7, networkFeeUsdMicros: '700' },
+      ],
+      pulled: new Set([scopeKey('pymthouse')]),
+    });
+    // A push-only provider (stub) is still served from the DB.
+    usageFindMany.mockResolvedValue([usageRow('acct_x', 'stub')]);
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    // Admin app-wide ⇒ pull each capable provider with no accountId (app-wide).
+    expect(pullSpend.mock.calls[0][0]).toEqual([{ providerSlug: 'pymthouse' }]);
+    const where = usageFindMany.mock.calls[0][0].where as {
+      providerSlug?: { notIn: string[] };
+    };
+    expect(where.providerSlug).toEqual({ notIn: ['pymthouse'] });
+    const json = await res.json();
+    const slugs = json.data.providers.map((p: { providerSlug: string }) => p.providerSlug).sort();
+    expect(slugs).toEqual(['pymthouse', 'stub']);
   });
 });

--- a/apps/web-next/src/app/api/v1/metrics/usage/route.ts
+++ b/apps/web-next/src/app/api/v1/metrics/usage/route.ts
@@ -3,31 +3,57 @@
  *
  *   GET /api/v1/metrics/usage?from=ISO&to=ISO[&accountId=…]
  *
- * Aggregates ingested BPP ⑥ usage into a spend view keyed by provider (the
- * "provider column"), so the dashboard can compare spend across ANY number of
- * billing providers. Read-only.
+ * Aggregates BPP ⑥ usage into a spend view keyed by provider (the "provider
+ * column"), so the dashboard can compare spend across ANY number of billing
+ * providers. Read-only.
+ *
+ * Data source is flag-controlled (zero regression):
+ *  - `usage_pull` OFF (default): reads pushed `ProviderUsageRecord` rows exactly
+ *    as before.
+ *  - `usage_pull` ON: PULLS usage live from each pull-capable provider adapter
+ *    (e.g. pymthouse via the M2M client) for the caller's authorized scopes, and
+ *    falls back to `ProviderUsageRecord` for any scope whose live pull fails or
+ *    whose provider cannot be pulled. A pull failure NEVER 500s the dashboard.
  *
  * Auth: a signed-in user (session). Results are scoped to the billing accounts
  * the caller can reach through their team bindings (the NAAP-1 team →
  * `billingAccountRef` linkage). A non-admin caller can NEVER read another
  * account's spend: an `accountId` they cannot reach is rejected, and omitting
  * `accountId` returns only their own accounts. `system:admin` may query any
- * account (matching the app-wide usage precedent in billing/[provider]).
+ * account (matching the app-wide usage precedent in billing/[provider]). This
+ * tenant boundary is identical on the pull and DB paths.
  * Gated behind the `usage_ingest` flag (default OFF) → 404 when OFF.
  */
 
 export const runtime = 'nodejs';
 
 import { NextRequest } from 'next/server';
+import { randomUUID } from 'node:crypto';
 
 import { prisma } from '@/lib/db';
 import { success, errors, getAuthToken } from '@/lib/api/response';
 import { validateSession } from '@/lib/api/auth';
 import { isFeatureEnabled } from '@/lib/feature-flags';
-import { USAGE_INGEST_FLAG } from '@/lib/metrics/flags';
-import { aggregateSpendByProvider } from '@/lib/metrics/aggregate';
+import { USAGE_INGEST_FLAG, USAGE_PULL_FLAG } from '@/lib/metrics/flags';
+import { aggregateSpendByProvider, type UsageRecordLike } from '@/lib/metrics/aggregate';
+import {
+  listPullCapableProviderSlugs,
+  pullSpend,
+  spendScopeKey,
+  type SpendScopeRef,
+} from '@/lib/metrics/usage-pull';
 
 const MAX_RECORDS = 50_000;
+
+const DB_RECORD_SELECT = {
+  providerSlug: true,
+  accountId: true,
+  appId: true,
+  sessions: true,
+  tickets: true,
+  feeWei: true,
+  networkFeeUsdMicros: true,
+} as const;
 
 function parseDate(raw: string | null): Date | null {
   if (!raw) return null;
@@ -37,6 +63,10 @@ function parseDate(raw: string | null): Date | null {
 
 function isSystemAdmin(roles: string[] | undefined): boolean {
   return Boolean(roles?.includes('system:admin'));
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
 }
 
 /** A provider-agnostic billing-account reference (BPP `billingAccountRef`). */
@@ -74,6 +104,20 @@ async function accessibleBillingAccountRefs(userId: string): Promise<BillingAcco
   return refs;
 }
 
+/** Read aggregated usage records from the stored `ProviderUsageRecord` rows. */
+async function readDbRecords(
+  where: Record<string, unknown>,
+): Promise<{ records: UsageRecordLike[]; overflow: boolean }> {
+  const records = await prisma.providerUsageRecord.findMany({
+    where,
+    select: DB_RECORD_SELECT,
+    // Fetch one past the cap so we can detect (rather than silently truncate)
+    // an oversized window that would under-count usage/spend.
+    take: MAX_RECORDS + 1,
+  });
+  return { records, overflow: records.length > MAX_RECORDS };
+}
+
 export async function GET(request: NextRequest) {
   if (!(await isFeatureEnabled(USAGE_INGEST_FLAG))) return errors.notFound('Resource');
 
@@ -100,15 +144,11 @@ export async function GET(request: NextRequest) {
   // Authorization: scope the query to accounts the caller may read. A trusted
   // query-string `accountId` (the previous behavior) would let any signed-in
   // user read any account's spend — instead we derive the allowed set here.
-  let where: Record<string, unknown>;
-  if (isSystemAdmin(user.roles)) {
-    where = {
-      ...(requestedAccountId ? { accountId: requestedAccountId } : {}),
-      ...dateFilter,
-    };
-  } else {
+  const admin = isSystemAdmin(user.roles);
+  let scoped: BillingAccountRef[] = [];
+  if (!admin) {
     const refs = await accessibleBillingAccountRefs(user.id);
-    let scoped = refs;
+    scoped = refs;
     if (requestedAccountId) {
       scoped = refs.filter((r) => r.accountId === requestedAccountId);
       if (scoped.length === 0) {
@@ -119,34 +159,112 @@ export async function GET(request: NextRequest) {
       // Caller reaches no billing accounts → nothing to show (never leak others').
       return success({ providers: aggregateSpendByProvider([]) });
     }
-    where = {
-      OR: scoped.map((r) => ({ providerSlug: r.providerSlug, accountId: r.accountId })),
-      ...dateFilter,
+  }
+
+  const pullEnabled = await isFeatureEnabled(USAGE_PULL_FLAG);
+  const correlationId = correlationIdOf(request);
+
+  // Pulled records (flag ON) accumulate here; the DB backfill is appended after.
+  let pulledRecords: UsageRecordLike[] = [];
+  let pulledKeys = new Set<string>();
+
+  if (pullEnabled) {
+    try {
+      const scopes = buildPullScopes({ admin, requestedAccountId, scoped });
+      const result = await pullSpend(scopes, { from, to }, { correlationId });
+      pulledRecords = result.records;
+      pulledKeys = result.pulled;
+    } catch (err) {
+      // Defensive: pullSpend degrades per scope and should not throw, but if the
+      // orchestration itself fails we must still render from the DB (never 500).
+      console.warn(
+        JSON.stringify({
+          level: 'warn',
+          event: 'metrics.usage.pull.orchestration_failed',
+          correlationId,
+          error: err instanceof Error ? err.name : typeof err,
+        }),
+      );
+      pulledRecords = [];
+      pulledKeys = new Set<string>();
+    }
+  }
+
+  // Build the DB where for the remainder NOT served by a successful pull. With
+  // the pull flag OFF this reproduces the legacy query exactly.
+  const where = buildDbWhere({
+    admin,
+    requestedAccountId,
+    scoped,
+    dateFilter,
+    pulledKeys,
+  });
+
+  let dbRecords: UsageRecordLike[] = [];
+  if (where) {
+    const { records, overflow } = await readDbRecords(where);
+    if (overflow) {
+      return errors.badRequest(
+        'Too many usage records for this window; narrow the from/to range and retry',
+      );
+    }
+    dbRecords = records;
+  }
+
+  const providers = aggregateSpendByProvider([...pulledRecords, ...dbRecords]);
+  return success({ providers });
+}
+
+/** The scopes to attempt a live pull for, given the caller's authorization. */
+function buildPullScopes(ctx: {
+  admin: boolean;
+  requestedAccountId?: string;
+  scoped: BillingAccountRef[];
+}): SpendScopeRef[] {
+  if (!ctx.admin) {
+    // Non-admin: pull exactly the caller's authorized refs (tenant boundary).
+    return ctx.scoped.map((r) => ({ providerSlug: r.providerSlug, accountId: r.accountId }));
+  }
+  // Admin: pull every pull-capable provider, scoped to the requested account
+  // when one was given, else app-wide.
+  return listPullCapableProviderSlugs().map((providerSlug) => ({
+    providerSlug,
+    ...(ctx.requestedAccountId ? { accountId: ctx.requestedAccountId } : {}),
+  }));
+}
+
+/**
+ * The DB query (or `null` for "no DB read needed") covering everything NOT served
+ * by a successful pull. Successfully-pulled scopes are excluded so pulled and
+ * stored rows never double-count.
+ */
+function buildDbWhere(ctx: {
+  admin: boolean;
+  requestedAccountId?: string;
+  scoped: BillingAccountRef[];
+  dateFilter: Record<string, unknown>;
+  pulledKeys: Set<string>;
+}): Record<string, unknown> | null {
+  if (!ctx.admin) {
+    // Backfill only the refs we did NOT pull successfully.
+    const remaining = ctx.scoped.filter(
+      (r) => !ctx.pulledKeys.has(spendScopeKey({ providerSlug: r.providerSlug, accountId: r.accountId })),
+    );
+    if (remaining.length === 0) return null;
+    return {
+      OR: remaining.map((r) => ({ providerSlug: r.providerSlug, accountId: r.accountId })),
+      ...ctx.dateFilter,
     };
   }
 
-  const records = await prisma.providerUsageRecord.findMany({
-    where,
-    select: {
-      providerSlug: true,
-      accountId: true,
-      appId: true,
-      sessions: true,
-      tickets: true,
-      feeWei: true,
-      networkFeeUsdMicros: true,
-    },
-    // Fetch one past the cap so we can detect (rather than silently truncate)
-    // an oversized window that would under-count usage/spend.
-    take: MAX_RECORDS + 1,
-  });
-
-  if (records.length > MAX_RECORDS) {
-    return errors.badRequest(
-      'Too many usage records for this window; narrow the from/to range and retry',
-    );
+  // Admin: exclude any provider slug fully served by the pull for this scope.
+  const pulledSlugs = new Set<string>();
+  for (const key of ctx.pulledKeys) {
+    pulledSlugs.add(key.split('\u0000')[0]);
   }
-
-  const providers = aggregateSpendByProvider(records);
-  return success({ providers });
+  return {
+    ...(ctx.requestedAccountId ? { accountId: ctx.requestedAccountId } : {}),
+    ...(pulledSlugs.size > 0 ? { providerSlug: { notIn: [...pulledSlugs] } } : {}),
+    ...ctx.dateFilter,
+  };
 }

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -91,6 +91,51 @@ export interface AppUsageInput {
   userId?: string;
 }
 
+/**
+ * Scope for a spend pull (BPP usage, dashboard direction). Either ONE tenant
+ * account (`accountId` present — the provider's external-user/account id from the
+ * NaaP `billingAccountRef` binding) or app-wide (`accountId` omitted, caller must
+ * be authorized for app-wide reads). The window is required so the provider can
+ * bound its query.
+ */
+export interface ProviderSpendScope {
+  /**
+   * Provider external-user/account id to scope to (the NaaP binding's
+   * `accountId`). When omitted the pull is app-wide. A scoped pull MUST only
+   * ever return that one account's usage (the provider enforces the boundary).
+   */
+  accountId?: string;
+  startDate: string;
+  endDate: string;
+}
+
+/**
+ * Neutral spend-pull result. `records` are already mapped into the dashboard's
+ * provider-agnostic `UsageRecordLike` shape — a provider's internal metering
+ * shape (BPP ⑨) never crosses this seam. `source` is purely informational
+ * (e.g. "openmeter" | "postgres").
+ */
+export interface ProviderSpendResult {
+  source?: string;
+  records: ProviderSpendRecord[];
+}
+
+/**
+ * One neutral usage row (structurally compatible with the dashboard's
+ * `UsageRecordLike`). Monetary fields are decimal strings; `byCapability` is an
+ * optional per-pipeline/model rollup keyed `"<pipeline>:<modelId>"`.
+ */
+export interface ProviderSpendRecord {
+  providerSlug: string;
+  accountId: string;
+  appId?: string | null;
+  sessions?: number | null;
+  tickets?: number | null;
+  feeWei?: string | null;
+  networkFeeUsdMicros?: string | null;
+  byCapability?: Record<string, { tickets?: number; networkFeeUsdMicros?: string }>;
+}
+
 export interface MintSignerSessionInput {
   externalUserId: string;
   email?: string;
@@ -117,6 +162,15 @@ export interface BillingProviderAdapter {
 
   /** BPP usage/telemetry — app-wide usage (admin scope). */
   getAppUsage(input: AppUsageInput): Promise<unknown>;
+
+  /**
+   * BPP usage/telemetry (dashboard PULL) — fetch spend live and map it into the
+   * neutral `ProviderSpendRecord` shape for the cross-provider spend dashboard.
+   * Optional: providers that cannot be pulled (only pushed) omit it, and the
+   * dashboard falls back to stored `ProviderUsageRecord` rows. Implementations
+   * MUST honor `scope.accountId` as a hard tenant boundary.
+   */
+  getSpend?(scope: ProviderSpendScope): Promise<ProviderSpendResult>;
 
   /**
    * BPP mintSignerSession — provider-issued, opaque to apps. Always the

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -1,0 +1,134 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchUsageForExternalUser = vi.fn();
+const getUsage = vi.fn();
+
+vi.mock('@/lib/pymthouse-client', () => ({
+  getPmtHouseServerClient: () => ({ fetchUsageForExternalUser, getUsage }),
+}));
+
+vi.mock('@pymthouse/builder-sdk/config', () => ({
+  isPymthouseConfigured: () => true,
+}));
+
+import { PymthouseAdapter } from './pymthouse-adapter';
+
+const WINDOW = { startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-31T23:59:59.999Z' };
+
+let adapter: PymthouseAdapter;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adapter = new PymthouseAdapter();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PymthouseAdapter.getSpend', () => {
+  it('scoped pull: asks the provider for ONE external user and maps to a neutral record', async () => {
+    fetchUsageForExternalUser.mockResolvedValue({
+      clientId: 'app_1',
+      period: { start: WINDOW.startDate, end: WINDOW.endDate },
+      currentUser: {
+        externalUserId: 'acct_self',
+        requestCount: 42,
+        currency: 'USD',
+        networkFeeUsdMicros: '9000',
+        ownerChargeUsdMicros: '12000',
+        endUserBillableUsdMicros: '15000',
+        pipelineModels: [
+          {
+            pipeline: 'text-to-image',
+            modelId: 'sdxl',
+            requestCount: 30,
+            currency: 'USD',
+            networkFeeUsdMicros: '6000',
+            ownerChargeUsdMicros: '8000',
+            endUserBillableUsdMicros: '10000',
+          },
+          {
+            pipeline: 'live-video',
+            modelId: 'lvx',
+            requestCount: 12,
+            currency: 'USD',
+            networkFeeUsdMicros: '3000',
+            ownerChargeUsdMicros: '4000',
+            endUserBillableUsdMicros: '5000',
+          },
+        ],
+      },
+    });
+
+    const result = await adapter.getSpend({ accountId: 'acct_self', ...WINDOW });
+
+    // Tenant boundary: the provider was asked for this one external user only.
+    expect(fetchUsageForExternalUser).toHaveBeenCalledWith({
+      externalUserId: 'acct_self',
+      startDate: WINDOW.startDate,
+      endDate: WINDOW.endDate,
+    });
+    expect(getUsage).not.toHaveBeenCalled();
+    expect(result.records).toEqual([
+      {
+        providerSlug: 'pymthouse',
+        accountId: 'acct_self',
+        appId: null,
+        sessions: 0,
+        tickets: 42,
+        feeWei: null,
+        networkFeeUsdMicros: '9000',
+        byCapability: {
+          'text-to-image:sdxl': { tickets: 30, networkFeeUsdMicros: '6000' },
+          'live-video:lvx': { tickets: 12, networkFeeUsdMicros: '3000' },
+        },
+      },
+    ]);
+  });
+
+  it('scoped pull with no pipeline rows omits byCapability', async () => {
+    fetchUsageForExternalUser.mockResolvedValue({
+      clientId: 'app_1',
+      period: { start: WINDOW.startDate, end: WINDOW.endDate },
+      currentUser: {
+        externalUserId: 'acct_self',
+        requestCount: 3,
+        currency: 'USD',
+        networkFeeUsdMicros: '300',
+        ownerChargeUsdMicros: '0',
+        endUserBillableUsdMicros: '0',
+        pipelineModels: [],
+      },
+    });
+
+    const result = await adapter.getSpend({ accountId: 'acct_self', ...WINDOW });
+    expect('byCapability' in result.records[0]).toBe(false);
+  });
+
+  it('app-wide pull: maps one neutral record per app user and surfaces source', async () => {
+    getUsage.mockResolvedValue({
+      clientId: 'app_1',
+      source: 'openmeter',
+      period: { start: WINDOW.startDate, end: WINDOW.endDate },
+      totals: { requestCount: 50 },
+      byUser: [
+        { endUserId: 'eu1', externalUserId: 'acct_a', requestCount: 30, feeWei: '1000', networkFeeUsdMicros: '6000' },
+        // Unattributed row: Usage API returns endUserId "unknown" + externalUserId null.
+        { endUserId: 'unknown', externalUserId: null, requestCount: 20, feeWei: '500', networkFeeUsdMicros: '4000' },
+      ],
+    });
+
+    const result = await adapter.getSpend({ ...WINDOW });
+
+    expect(getUsage).toHaveBeenCalledWith({ startDate: WINDOW.startDate, endDate: WINDOW.endDate, groupBy: 'user' });
+    expect(fetchUsageForExternalUser).not.toHaveBeenCalled();
+    expect(result.source).toBe('openmeter');
+    expect(result.records).toEqual([
+      { providerSlug: 'pymthouse', accountId: 'acct_a', appId: null, sessions: 0, tickets: 30, feeWei: '1000', networkFeeUsdMicros: '6000' },
+      { providerSlug: 'pymthouse', accountId: 'unknown', appId: null, sessions: 0, tickets: 20, feeWei: '500', networkFeeUsdMicros: '4000' },
+    ]);
+  });
+});

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -12,6 +12,8 @@ import 'server-only';
 
 import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
 
+import type { MeScopeUsagePayload, UsageApiResponse } from '@pymthouse/builder-sdk';
+
 import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
 import {
   AdapterNotImplementedError,
@@ -21,6 +23,9 @@ import {
   type CuratedOrchestrator,
   type MintSignerSessionInput,
   type Plan,
+  type ProviderSpendRecord,
+  type ProviderSpendResult,
+  type ProviderSpendScope,
   type SignerSessionToken,
   type UsageForExternalUserInput,
   type ValidateResult,
@@ -61,6 +66,85 @@ export class PymthouseAdapter implements BillingProviderAdapter {
       ...(input.groupBy ? { groupBy: input.groupBy } : {}),
       ...(input.userId ? { userId: input.userId } : {}),
     });
+  }
+
+  /**
+   * Dashboard PULL: fetch pymthouse spend live via the M2M client and map the
+   * SDK response into neutral `ProviderSpendRecord`s. Provider-internal wire
+   * shapes never escape this method.
+   *
+   *  - Scoped (`accountId` present): `fetchUsageForExternalUser` is bound to that
+   *    one external user, so pymthouse itself enforces the tenant boundary — we
+   *    never even receive another tenant's usage. Yields one record with a
+   *    per-pipeline/model `byCapability` rollup.
+   *  - App-wide (`accountId` omitted): `getUsage(groupBy=user)` returns one row
+   *    per app user, mapped to one record each (route layer restricts app-wide
+   *    pulls to system:admin).
+   */
+  async getSpend(scope: ProviderSpendScope): Promise<ProviderSpendResult> {
+    const client = getPmtHouseServerClient();
+
+    if (scope.accountId) {
+      const payload: MeScopeUsagePayload = await client.fetchUsageForExternalUser({
+        externalUserId: scope.accountId,
+        startDate: scope.startDate,
+        endDate: scope.endDate,
+      });
+      return { records: [this.mapMeScopePayload(scope.accountId, payload)] };
+    }
+
+    const usage: UsageApiResponse = await client.getUsage({
+      startDate: scope.startDate,
+      endDate: scope.endDate,
+      groupBy: 'user',
+    });
+    return {
+      source: usage.source,
+      records: this.mapAppUsage(usage),
+    };
+  }
+
+  /** Map a per-external-user payload → one neutral record (with capability rollup). */
+  private mapMeScopePayload(
+    accountId: string,
+    payload: MeScopeUsagePayload,
+  ): ProviderSpendRecord {
+    const u = payload.currentUser;
+    const byCapability: Record<string, { tickets?: number; networkFeeUsdMicros?: string }> = {};
+    for (const row of u.pipelineModels ?? []) {
+      // Key by pipeline:model so the dashboard can break spend down by capability.
+      byCapability[`${row.pipeline}:${row.modelId}`] = {
+        tickets: row.requestCount,
+        networkFeeUsdMicros: row.networkFeeUsdMicros,
+      };
+    }
+    return {
+      providerSlug: this.slug,
+      accountId,
+      appId: null,
+      // pymthouse meters signed tickets per request; there is no separate session
+      // count on this seam, so sessions stays 0 and tickets carries requestCount.
+      sessions: 0,
+      tickets: u.requestCount,
+      // The fiat (USD-micros) usage path does not return wei; leave it null.
+      feeWei: null,
+      networkFeeUsdMicros: u.networkFeeUsdMicros,
+      ...(Object.keys(byCapability).length > 0 ? { byCapability } : {}),
+    };
+  }
+
+  /** Map an app-wide usage response → one neutral record per app user. */
+  private mapAppUsage(usage: UsageApiResponse): ProviderSpendRecord[] {
+    return (usage.byUser ?? []).map((row) => ({
+      providerSlug: this.slug,
+      // Unattributed rows roll up under "unknown" (matches the Usage API).
+      accountId: row.externalUserId ?? row.endUserId ?? 'unknown',
+      appId: null,
+      sessions: 0,
+      tickets: row.requestCount,
+      feeWei: row.feeWei ?? null,
+      networkFeeUsdMicros: row.networkFeeUsdMicros ?? null,
+    }));
   }
 
   async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken> {

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -47,6 +47,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
       'Enable cross-provider usage telemetry: the BPP ⑥ ingest endpoint (/api/v1/metrics/ingest) and the spend dashboard BFF (/api/v1/metrics/usage). OFF = both return 404 (no-op).',
   },
   {
+    key: 'usage_pull',
+    enabled: false,
+    description:
+      'Spend dashboard PULLS provider usage live via the provider adapter (e.g. pymthouse M2M client) instead of reading pushed ProviderUsageRecord rows. OFF = reads ProviderUsageRecord exactly as today. ON = pull-first with graceful fallback to ProviderUsageRecord on any pull failure (never 500). Tenant scoping is preserved either way (NAAP-2).',
+  },
+  {
     key: 'app_registry',
     enabled: false,
     description:

--- a/apps/web-next/src/lib/metrics/aggregate.test.ts
+++ b/apps/web-next/src/lib/metrics/aggregate.test.ts
@@ -83,4 +83,41 @@ describe('aggregateSpendByProvider', () => {
       ]),
     ).toThrow(/non-decimal/);
   });
+
+  it('omits byCapability for legacy/push records that carry none', () => {
+    const rows = aggregateSpendByProvider(records);
+    for (const row of rows) {
+      expect('byCapability' in row).toBe(false);
+    }
+  });
+
+  it('rolls up byCapability per provider when records carry it (pull path)', () => {
+    const rows = aggregateSpendByProvider([
+      {
+        providerSlug: 'pymthouse',
+        accountId: 'acct_a',
+        tickets: 30,
+        networkFeeUsdMicros: '3000',
+        byCapability: {
+          'text-to-image:sdxl': { tickets: 20, networkFeeUsdMicros: '2000' },
+          'live-video:lvx': { tickets: 10, networkFeeUsdMicros: '1000' },
+        },
+      },
+      {
+        providerSlug: 'pymthouse',
+        accountId: 'acct_b',
+        tickets: 5,
+        networkFeeUsdMicros: '500',
+        byCapability: {
+          'text-to-image:sdxl': { tickets: 5, networkFeeUsdMicros: '500' },
+        },
+      },
+    ]);
+    expect(rows).toHaveLength(1);
+    const pymt = rows[0];
+    expect(pymt.byCapability).toEqual({
+      'text-to-image:sdxl': { tickets: 25, networkFeeUsdMicros: '2500' },
+      'live-video:lvx': { tickets: 10, networkFeeUsdMicros: '1000' },
+    });
+  });
 });

--- a/apps/web-next/src/lib/metrics/aggregate.ts
+++ b/apps/web-next/src/lib/metrics/aggregate.ts
@@ -9,6 +9,12 @@
  * unbounded magnitude; sums use BigInt to avoid float precision loss.
  */
 
+/** Per-pipeline/model usage, keyed `"<pipeline>:<modelId>"`. */
+export type CapabilityUsageMap = Record<
+  string,
+  { tickets?: number; networkFeeUsdMicros?: string }
+>;
+
 /** Minimal shape of a stored/ingested usage record needed for aggregation. */
 export interface UsageRecordLike {
   providerSlug: string;
@@ -18,6 +24,18 @@ export interface UsageRecordLike {
   tickets?: number | null;
   feeWei?: string | null;
   networkFeeUsdMicros?: string | null;
+  /**
+   * Optional per-capability rollup (pipeline/model). Present on live-pulled
+   * records; stored push records leave it unset, so the aggregated row omits
+   * `byCapability` entirely and stays byte-identical to the legacy output.
+   */
+  byCapability?: CapabilityUsageMap | null;
+}
+
+/** One aggregated capability bucket on a provider spend row. */
+export interface CapabilitySpend {
+  tickets: number;
+  networkFeeUsdMicros: string;
 }
 
 /** One row of the cross-provider spend view. */
@@ -33,6 +51,12 @@ export interface ProviderSpendRow {
   accounts: number;
   /** Distinct apps seen for this provider (excludes records with no appId). */
   apps: number;
+  /**
+   * Per-capability spend, keyed `"<pipeline>:<modelId>"`. Only present when at
+   * least one contributing record carried `byCapability` (i.e. the live-pull
+   * path); omitted otherwise so legacy/push output is unchanged.
+   */
+  byCapability?: Record<string, CapabilitySpend>;
 }
 
 function addDecimal(acc: bigint, value: string | null | undefined): bigint {
@@ -43,6 +67,11 @@ function addDecimal(acc: bigint, value: string | null | undefined): bigint {
   return acc + BigInt(value);
 }
 
+interface CapabilityAccumulator {
+  tickets: number;
+  networkFeeUsdMicros: bigint;
+}
+
 interface Accumulator {
   sessions: number;
   tickets: number;
@@ -50,6 +79,7 @@ interface Accumulator {
   networkFeeUsdMicros: bigint;
   accounts: Set<string>;
   apps: Set<string>;
+  byCapability: Map<string, CapabilityAccumulator>;
 }
 
 /**
@@ -69,6 +99,7 @@ export function aggregateSpendByProvider(records: UsageRecordLike[]): ProviderSp
         networkFeeUsdMicros: 0n,
         accounts: new Set(),
         apps: new Set(),
+        byCapability: new Map(),
       };
       byProvider.set(r.providerSlug, acc);
     }
@@ -78,17 +109,41 @@ export function aggregateSpendByProvider(records: UsageRecordLike[]): ProviderSp
     acc.networkFeeUsdMicros = addDecimal(acc.networkFeeUsdMicros, r.networkFeeUsdMicros);
     acc.accounts.add(r.accountId);
     if (r.appId) acc.apps.add(r.appId);
+    if (r.byCapability) {
+      for (const [cap, usage] of Object.entries(r.byCapability)) {
+        let capAcc = acc.byCapability.get(cap);
+        if (!capAcc) {
+          capAcc = { tickets: 0, networkFeeUsdMicros: 0n };
+          acc.byCapability.set(cap, capAcc);
+        }
+        capAcc.tickets += usage.tickets ?? 0;
+        capAcc.networkFeeUsdMicros = addDecimal(capAcc.networkFeeUsdMicros, usage.networkFeeUsdMicros);
+      }
+    }
   }
 
   return [...byProvider.entries()]
-    .map(([providerSlug, acc]) => ({
-      providerSlug,
-      sessions: acc.sessions,
-      tickets: acc.tickets,
-      feeWei: acc.feeWei.toString(),
-      networkFeeUsdMicros: acc.networkFeeUsdMicros.toString(),
-      accounts: acc.accounts.size,
-      apps: acc.apps.size,
-    }))
+    .map(([providerSlug, acc]) => {
+      const row: ProviderSpendRow = {
+        providerSlug,
+        sessions: acc.sessions,
+        tickets: acc.tickets,
+        feeWei: acc.feeWei.toString(),
+        networkFeeUsdMicros: acc.networkFeeUsdMicros.toString(),
+        accounts: acc.accounts.size,
+        apps: acc.apps.size,
+      };
+      // Only surface byCapability when a record actually carried it, so the
+      // legacy push/DB path output is unchanged (no empty object emitted).
+      if (acc.byCapability.size > 0) {
+        row.byCapability = Object.fromEntries(
+          [...acc.byCapability.entries()].map(([cap, c]) => [
+            cap,
+            { tickets: c.tickets, networkFeeUsdMicros: c.networkFeeUsdMicros.toString() },
+          ]),
+        );
+      }
+      return row;
+    })
     .sort((a, b) => a.providerSlug.localeCompare(b.providerSlug));
 }

--- a/apps/web-next/src/lib/metrics/flags.ts
+++ b/apps/web-next/src/lib/metrics/flags.ts
@@ -28,3 +28,19 @@ export function usagePullCacheTtlMs(): number {
   // Ceiling guards against an accidental huge TTL serving very stale spend.
   return Math.min(parsed, 3_600_000);
 }
+
+/**
+ * Per-scope timeout (ms) for a live provider spend pull. Configurable via
+ * `USAGE_PULL_TIMEOUT_MS`; defaults to 10s. A non-positive value disables the
+ * timeout (await indefinitely — not recommended). A hung provider call hits this
+ * deadline, throws, and is caught so the scope degrades to the stored DB rows
+ * instead of stalling the dashboard request. Clamped to a sane ceiling.
+ */
+export function usagePullTimeoutMs(): number {
+  const raw = process.env.USAGE_PULL_TIMEOUT_MS;
+  if (raw == null || raw.trim() === '') return 10_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return 10_000;
+  if (parsed <= 0) return 0;
+  return Math.min(parsed, 60_000);
+}

--- a/apps/web-next/src/lib/metrics/flags.ts
+++ b/apps/web-next/src/lib/metrics/flags.ts
@@ -4,3 +4,27 @@
 
 /** Gates the usage ingest endpoint + cross-provider dashboard BFF (default OFF). */
 export const USAGE_INGEST_FLAG = 'usage_ingest';
+
+/**
+ * Gates the spend-dashboard live PULL path (default OFF). When OFF the dashboard
+ * BFF reads `ProviderUsageRecord` rows exactly as today (push-fed). When ON the
+ * BFF pulls usage live from a pull-capable provider adapter (e.g. pymthouse via
+ * the M2M client) and falls back to `ProviderUsageRecord` on any pull failure.
+ * Independent of `usage_ingest`, which still gates whether the endpoint exists.
+ */
+export const USAGE_PULL_FLAG = 'usage_pull';
+
+/**
+ * TTL (ms) for the in-memory spend-pull cache. Configurable via
+ * `USAGE_PULL_CACHE_TTL_MS`; defaults to 60s. A non-positive value disables
+ * caching (every request pulls live). Clamped to a sane ceiling.
+ */
+export function usagePullCacheTtlMs(): number {
+  const raw = process.env.USAGE_PULL_CACHE_TTL_MS;
+  if (raw == null || raw.trim() === '') return 60_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return 60_000;
+  if (parsed <= 0) return 0;
+  // Ceiling guards against an accidental huge TTL serving very stale spend.
+  return Math.min(parsed, 3_600_000);
+}

--- a/apps/web-next/src/lib/metrics/usage-pull.test.ts
+++ b/apps/web-next/src/lib/metrics/usage-pull.test.ts
@@ -173,6 +173,58 @@ describe('pullSpend', () => {
     expect(out.pulled.size).toBe(0); // caller will backfill from the DB
   });
 
+  it('degrades gracefully when the provider pull hangs past the timeout', async () => {
+    vi.useFakeTimers();
+    process.env.USAGE_PULL_TIMEOUT_MS = '5000';
+    // A provider call that never resolves on its own.
+    adapter.getSpend.mockImplementation(() => new Promise<ProviderSpendResult>(() => {}));
+
+    const promise = pullSpend([{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }], WINDOW, OPTS);
+    await vi.advanceTimersByTimeAsync(6000); // past the 5s deadline
+    const out = await promise;
+
+    expect(out.records).toEqual([]);
+    expect(out.pulled.size).toBe(0); // not pulled ⇒ caller backfills from the DB
+  });
+
+  it('enforces the tenant boundary: drops adapter rows outside the requested account', async () => {
+    // A misbehaving adapter leaks another tenant's row alongside the requested one.
+    adapter.getSpend.mockResolvedValue({
+      records: [rec('acct_1', 5), rec('acct_OTHER', 99)],
+    });
+
+    const out = await pullSpend([{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }], WINDOW, OPTS);
+
+    // Only the requested account's row survives — the foreign row never escapes.
+    expect(out.records).toEqual([rec('acct_1', 5)]);
+    expect(out.pulled.has(spendScopeKey({ providerSlug: FAKE_SLUG, accountId: 'acct_1' }))).toBe(
+      true,
+    );
+  });
+
+  it('caches only the in-scope rows after a scope-boundary filter', async () => {
+    adapter.getSpend.mockResolvedValue({
+      records: [rec('acct_1', 5), rec('acct_OTHER', 99)],
+    });
+    const scope = [{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }];
+
+    await pullSpend(scope, WINDOW, OPTS);
+    const second = await pullSpend(scope, WINDOW, OPTS);
+
+    expect(adapter.getSpend).toHaveBeenCalledTimes(1); // served from cache
+    expect(second.records).toEqual([rec('acct_1', 5)]); // foreign row not cached
+  });
+
+  it('keeps all rows for an app-wide pull (no per-account boundary to enforce)', async () => {
+    adapter.getSpend.mockResolvedValue({
+      records: [rec('acct_a', 1), rec('acct_b', 2)],
+    });
+
+    const out = await pullSpend([{ providerSlug: FAKE_SLUG }], WINDOW, OPTS);
+
+    expect(out.records).toEqual([rec('acct_a', 1), rec('acct_b', 2)]);
+  });
+
   it('skips a provider with no pull-capable adapter (push-only)', async () => {
     const out = await pullSpend([{ providerSlug: 'stub', accountId: 'acct_1' }], WINDOW, OPTS);
     expect(out.records).toEqual([]);

--- a/apps/web-next/src/lib/metrics/usage-pull.test.ts
+++ b/apps/web-next/src/lib/metrics/usage-pull.test.ts
@@ -1,0 +1,206 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  listPullCapableProviderSlugs,
+  pullSpend,
+  resetUsagePullCacheForTests,
+  resolveSpendWindow,
+  spendScopeKey,
+} from './usage-pull';
+import type {
+  AppUsageInput,
+  BillingProviderAdapter,
+  Capability,
+  CuratedOrchestrator,
+  MintSignerSessionInput,
+  Plan,
+  ProviderSpendRecord,
+  ProviderSpendResult,
+  ProviderSpendScope,
+  SignerSessionToken,
+  UsageForExternalUserInput,
+  ValidateResult,
+} from '@/lib/billing/adapter';
+import {
+  registerBillingProviderAdapter,
+  resetBillingProviderRegistryForTests,
+} from '@/lib/billing/registry';
+
+const FAKE_SLUG = 'fakeprov';
+
+/** A minimal pull-capable provider adapter for exercising usage-pull in isolation. */
+class FakePullAdapter implements BillingProviderAdapter {
+  readonly slug = FAKE_SLUG;
+  configured = true;
+  getSpend = vi.fn(async (_scope: ProviderSpendScope): Promise<ProviderSpendResult> => ({
+    records: [],
+  }));
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+  async validate(_key: string): Promise<ValidateResult> {
+    return { valid: false };
+  }
+  async getPlans(): Promise<Plan[]> {
+    return [];
+  }
+  async getUsageForExternalUser(_input: UsageForExternalUserInput): Promise<unknown> {
+    return {};
+  }
+  async getAppUsage(_input: AppUsageInput): Promise<unknown> {
+    return {};
+  }
+  async mintSignerSession(_input: MintSignerSessionInput): Promise<SignerSessionToken> {
+    return { accessToken: 'x' };
+  }
+  async receiveCuratedOrchestrators(_plan: string, _list: CuratedOrchestrator[]): Promise<void> {}
+  async getCapabilityManifest(): Promise<Capability[]> {
+    return [];
+  }
+}
+
+function rec(accountId: string, tickets: number): ProviderSpendRecord {
+  return { providerSlug: FAKE_SLUG, accountId, tickets, networkFeeUsdMicros: String(tickets * 100) };
+}
+
+const WINDOW = { from: new Date('2026-01-01T00:00:00Z'), to: new Date('2026-01-31T23:59:59Z') };
+const OPTS = { correlationId: 'test-cid' };
+
+let adapter: FakePullAdapter;
+
+beforeEach(() => {
+  resetBillingProviderRegistryForTests();
+  resetUsagePullCacheForTests();
+  delete process.env.USAGE_PULL_CACHE_TTL_MS;
+  adapter = new FakePullAdapter();
+  registerBillingProviderAdapter(adapter);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetBillingProviderRegistryForTests();
+  resetUsagePullCacheForTests();
+  delete process.env.USAGE_PULL_CACHE_TTL_MS;
+});
+
+describe('resolveSpendWindow', () => {
+  it('uses explicit bounds when provided', () => {
+    const w = resolveSpendWindow(WINDOW.from, WINDOW.to);
+    expect(w.startDate).toBe(WINDOW.from.toISOString());
+    expect(w.endDate).toBe(WINDOW.to.toISOString());
+  });
+
+  it('defaults to the current UTC month-to-now when omitted', () => {
+    const w = resolveSpendWindow(null, new Date('2026-03-15T12:00:00Z'));
+    expect(w.startDate).toBe('2026-03-01T00:00:00.000Z');
+    expect(w.endDate).toBe('2026-03-15T12:00:00.000Z');
+  });
+});
+
+describe('listPullCapableProviderSlugs', () => {
+  it('includes a configured adapter that implements getSpend', () => {
+    expect(listPullCapableProviderSlugs()).toContain(FAKE_SLUG);
+  });
+
+  it('excludes an adapter that is not configured', () => {
+    adapter.configured = false;
+    expect(listPullCapableProviderSlugs()).not.toContain(FAKE_SLUG);
+  });
+});
+
+describe('pullSpend', () => {
+  it('pulls a scoped account and marks it pulled', async () => {
+    adapter.getSpend.mockResolvedValue({ records: [rec('acct_1', 5)], source: 'openmeter' });
+
+    const out = await pullSpend([{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }], WINDOW, OPTS);
+
+    expect(adapter.getSpend).toHaveBeenCalledTimes(1);
+    expect(adapter.getSpend).toHaveBeenCalledWith({
+      accountId: 'acct_1',
+      startDate: WINDOW.from.toISOString(),
+      endDate: WINDOW.to.toISOString(),
+    });
+    expect(out.records).toEqual([rec('acct_1', 5)]);
+    expect(out.pulled.has(spendScopeKey({ providerSlug: FAKE_SLUG, accountId: 'acct_1' }))).toBe(true);
+  });
+
+  it('serves a cache hit on the second call (no second provider call)', async () => {
+    adapter.getSpend.mockResolvedValue({ records: [rec('acct_1', 5)] });
+    const scope = [{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }];
+
+    await pullSpend(scope, WINDOW, OPTS);
+    const second = await pullSpend(scope, WINDOW, OPTS);
+
+    expect(adapter.getSpend).toHaveBeenCalledTimes(1); // cached
+    expect(second.records).toEqual([rec('acct_1', 5)]);
+    expect(second.pulled.size).toBe(1);
+  });
+
+  it('re-pulls after the TTL expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-01T00:00:00Z'));
+    process.env.USAGE_PULL_CACHE_TTL_MS = '1000';
+    adapter.getSpend.mockResolvedValue({ records: [rec('acct_1', 5)] });
+    const scope = [{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }];
+
+    await pullSpend(scope, WINDOW, OPTS);
+    vi.advanceTimersByTime(1500); // past TTL
+    await pullSpend(scope, WINDOW, OPTS);
+
+    expect(adapter.getSpend).toHaveBeenCalledTimes(2);
+  });
+
+  it('bypasses the cache entirely when TTL <= 0', async () => {
+    process.env.USAGE_PULL_CACHE_TTL_MS = '0';
+    adapter.getSpend.mockResolvedValue({ records: [rec('acct_1', 5)] });
+    const scope = [{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }];
+
+    await pullSpend(scope, WINDOW, OPTS);
+    await pullSpend(scope, WINDOW, OPTS);
+
+    expect(adapter.getSpend).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades gracefully when the provider pull throws (no throw, not pulled)', async () => {
+    adapter.getSpend.mockRejectedValue(new Error('provider 503'));
+
+    const out = await pullSpend([{ providerSlug: FAKE_SLUG, accountId: 'acct_1' }], WINDOW, OPTS);
+
+    expect(out.records).toEqual([]);
+    expect(out.pulled.size).toBe(0); // caller will backfill from the DB
+  });
+
+  it('skips a provider with no pull-capable adapter (push-only)', async () => {
+    const out = await pullSpend([{ providerSlug: 'stub', accountId: 'acct_1' }], WINDOW, OPTS);
+    expect(out.records).toEqual([]);
+    expect(out.pulled.size).toBe(0);
+  });
+
+  it('isolates tenants: only the requested account is pulled and cached per-account', async () => {
+    adapter.getSpend.mockImplementation(async (scope: ProviderSpendScope) => ({
+      records: [rec(scope.accountId ?? '*app*', 1)],
+    }));
+
+    await pullSpend(
+      [
+        { providerSlug: FAKE_SLUG, accountId: 'acct_1' },
+        { providerSlug: FAKE_SLUG, accountId: 'acct_2' },
+      ],
+      WINDOW,
+      OPTS,
+    );
+
+    // Each account asked the provider for ITS OWN id only — never another's.
+    const askedAccounts = adapter.getSpend.mock.calls.map((c) => c[0].accountId);
+    expect(askedAccounts.sort()).toEqual(['acct_1', 'acct_2']);
+
+    // A different account is a different cache key → its own provider call.
+    adapter.getSpend.mockClear();
+    await pullSpend([{ providerSlug: FAKE_SLUG, accountId: 'acct_3' }], WINDOW, OPTS);
+    expect(adapter.getSpend).toHaveBeenCalledTimes(1);
+    expect(adapter.getSpend.mock.calls[0][0].accountId).toBe('acct_3');
+  });
+});

--- a/apps/web-next/src/lib/metrics/usage-pull.ts
+++ b/apps/web-next/src/lib/metrics/usage-pull.ts
@@ -1,0 +1,166 @@
+/**
+ * Spend dashboard live PULL (NAAP-2, `usage_pull` flag).
+ *
+ * Pulls provider usage live through the provider-agnostic `BillingProviderAdapter`
+ * (`adapter.getSpend`) instead of reading pushed `ProviderUsageRecord` rows. Adds
+ * a short-TTL in-memory cache (so a dashboard load does not hammer the provider
+ * usage API) and degrades gracefully: a pull failure for a scope is logged and
+ * left for the caller to backfill from `ProviderUsageRecord` (never throws per
+ * scope, never 500s the dashboard).
+ *
+ * This module stays provider-agnostic: it never imports a provider client. The
+ * provider-internal → neutral mapping lives behind each adapter's `getSpend`.
+ * Tenant scoping is the caller's responsibility — `pullSpend` only pulls the
+ * exact scopes it is handed (each carrying the authorized `accountId`), and a
+ * scoped pull asks the provider for that one account only.
+ */
+
+import 'server-only';
+
+import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import type { ProviderSpendScope } from '@/lib/billing/adapter';
+import { listBillingProviderSlugs } from '@/lib/billing/registry';
+import type { UsageRecordLike } from './aggregate';
+import { usagePullCacheTtlMs } from './flags';
+
+/** A provider account to pull. `accountId` omitted ⇒ app-wide (admin only). */
+export interface SpendScopeRef {
+  providerSlug: string;
+  accountId?: string;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  records: UsageRecordLike[];
+  source?: string;
+}
+
+// Module-level cache. Keyed by provider + account scope + window, so a scoped
+// pull can never serve another tenant's cached rows.
+const cache = new Map<string, CacheEntry>();
+
+/** Stable key for a scope (account-level or app-wide). */
+export function spendScopeKey(scope: SpendScopeRef): string {
+  return `${scope.providerSlug}\u0000${scope.accountId ?? '*app*'}`;
+}
+
+function cacheKey(scope: SpendScopeRef, startDate: string, endDate: string): string {
+  return `${spendScopeKey(scope)}\u0000${startDate}\u0000${endDate}`;
+}
+
+function log(level: 'info' | 'warn', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+/** Short, secret-free description of a thrown value for structured logs. */
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.name || 'Error';
+  return typeof err;
+}
+
+/**
+ * Resolve the pull window to ISO bounds. Defaults to the current UTC calendar
+ * month-to-now when the caller did not supply explicit `from`/`to`, matching the
+ * existing per-user usage endpoint's default windowing.
+ */
+export function resolveSpendWindow(
+  from: Date | null,
+  to: Date | null,
+): { startDate: string; endDate: string } {
+  const end = to ?? new Date();
+  const start = from ?? new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+  return { startDate: start.toISOString(), endDate: end.toISOString() };
+}
+
+/** Provider slugs whose adapter can be pulled right now (implements + configured). */
+export function listPullCapableProviderSlugs(): string[] {
+  return listBillingProviderSlugs().filter((slug) => {
+    const adapter = getBillingProviderAdapter(slug);
+    return Boolean(adapter && typeof adapter.getSpend === 'function' && adapter.isConfigured());
+  });
+}
+
+export interface PullSpendResult {
+  /** Neutral usage rows pulled live (ready for `aggregateSpendByProvider`). */
+  records: UsageRecordLike[];
+  /** `spendScopeKey`s that were successfully pulled (caller excludes from DB). */
+  pulled: Set<string>;
+}
+
+/**
+ * Pull spend for the given scopes through their provider adapters, with caching
+ * and graceful per-scope degradation. Never throws: a scope that has no
+ * pull-capable adapter, or whose pull fails, is simply absent from `pulled`, so
+ * the caller backfills it from `ProviderUsageRecord`.
+ */
+export async function pullSpend(
+  scopes: SpendScopeRef[],
+  window: { from: Date | null; to: Date | null },
+  opts: { correlationId: string },
+): Promise<PullSpendResult> {
+  const { startDate, endDate } = resolveSpendWindow(window.from, window.to);
+  const ttl = usagePullCacheTtlMs();
+  const now = Date.now();
+  const records: UsageRecordLike[] = [];
+  const pulled = new Set<string>();
+
+  for (const scope of scopes) {
+    const adapter = getBillingProviderAdapter(scope.providerSlug);
+    if (!adapter || typeof adapter.getSpend !== 'function' || !adapter.isConfigured()) {
+      // Not pull-capable → leave for the DB backfill (push-only provider).
+      continue;
+    }
+
+    const key = spendScopeKey(scope);
+    const ck = cacheKey(scope, startDate, endDate);
+    const cached = ttl > 0 ? cache.get(ck) : undefined;
+    if (cached && cached.expiresAt > now) {
+      records.push(...cached.records);
+      pulled.add(key);
+      log('info', 'metrics.usage.pull.cache_hit', {
+        correlationId: opts.correlationId,
+        providerSlug: scope.providerSlug,
+        appWide: !scope.accountId,
+      });
+      continue;
+    }
+
+    try {
+      const result = await adapter.getSpend({
+        ...(scope.accountId ? { accountId: scope.accountId } : {}),
+        startDate,
+        endDate,
+      } as ProviderSpendScope);
+      records.push(...result.records);
+      pulled.add(key);
+      if (ttl > 0) {
+        cache.set(ck, { expiresAt: now + ttl, records: result.records, source: result.source });
+      }
+      log('info', 'metrics.usage.pull.ok', {
+        correlationId: opts.correlationId,
+        providerSlug: scope.providerSlug,
+        appWide: !scope.accountId,
+        source: result.source,
+        rows: result.records.length,
+      });
+    } catch (err) {
+      // Graceful degradation: this scope falls back to ProviderUsageRecord.
+      // Never log the opaque accountId — slug + appWide only.
+      log('warn', 'metrics.usage.pull.failed', {
+        correlationId: opts.correlationId,
+        providerSlug: scope.providerSlug,
+        appWide: !scope.accountId,
+        error: describeError(err),
+      });
+    }
+  }
+
+  return { records, pulled };
+}
+
+/** Test isolation: clear the module-level cache. */
+export function resetUsagePullCacheForTests(): void {
+  cache.clear();
+}

--- a/apps/web-next/src/lib/metrics/usage-pull.ts
+++ b/apps/web-next/src/lib/metrics/usage-pull.ts
@@ -21,7 +21,7 @@ import { getBillingProviderAdapter } from '@/lib/billing/registry';
 import type { ProviderSpendScope } from '@/lib/billing/adapter';
 import { listBillingProviderSlugs } from '@/lib/billing/registry';
 import type { UsageRecordLike } from './aggregate';
-import { usagePullCacheTtlMs } from './flags';
+import { usagePullCacheTtlMs, usagePullTimeoutMs } from './flags';
 
 /** A provider account to pull. `accountId` omitted ⇒ app-wide (admin only). */
 export interface SpendScopeRef {
@@ -58,6 +58,53 @@ function log(level: 'info' | 'warn', event: string, fields: Record<string, unkno
 function describeError(err: unknown): string {
   if (err instanceof Error) return err.name || 'Error';
   return typeof err;
+}
+
+/** Thrown when a provider pull exceeds its deadline (caught → DB fallback). */
+class PullTimeoutError extends Error {
+  constructor() {
+    super('provider spend pull timed out');
+    this.name = 'PullTimeoutError';
+  }
+}
+
+/**
+ * Race a provider pull against a deadline so a hung/slow provider call degrades
+ * to the stored DB rows instead of stalling the dashboard request. `ms <= 0`
+ * disables the deadline. The timer is always cleared so we never leak a handle.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  if (ms <= 0) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new PullTimeoutError()), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Defense-in-depth tenant boundary: for a scoped pull (a single `accountId`),
+ * drop any record the adapter returned that is NOT for that exact account. The
+ * provider is the primary enforcer (a scoped pull asks for one external user),
+ * but a buggy/compromised adapter must never be able to surface another tenant's
+ * rows through the dashboard. App-wide pulls (admin, no `accountId`) keep all
+ * rows. Returns the in-scope records and how many were dropped.
+ */
+function enforceScopeBoundary(
+  scope: SpendScopeRef,
+  records: UsageRecordLike[],
+): { records: UsageRecordLike[]; dropped: number } {
+  if (!scope.accountId) return { records, dropped: 0 };
+  const inScope = records.filter((r) => r.accountId === scope.accountId);
+  return { records: inScope, dropped: records.length - inScope.length };
 }
 
 /**
@@ -102,6 +149,7 @@ export async function pullSpend(
 ): Promise<PullSpendResult> {
   const { startDate, endDate } = resolveSpendWindow(window.from, window.to);
   const ttl = usagePullCacheTtlMs();
+  const timeoutMs = usagePullTimeoutMs();
   const now = Date.now();
   const records: UsageRecordLike[] = [];
   const pulled = new Set<string>();
@@ -128,22 +176,34 @@ export async function pullSpend(
     }
 
     try {
-      const result = await adapter.getSpend({
-        ...(scope.accountId ? { accountId: scope.accountId } : {}),
-        startDate,
-        endDate,
-      } as ProviderSpendScope);
-      records.push(...result.records);
+      const result = await withTimeout(
+        adapter.getSpend({
+          ...(scope.accountId ? { accountId: scope.accountId } : {}),
+          startDate,
+          endDate,
+        } as ProviderSpendScope),
+        timeoutMs,
+      );
+      // Enforce the tenant boundary on the adapter's output before trusting it.
+      const { records: safeRecords, dropped } = enforceScopeBoundary(scope, result.records);
+      if (dropped > 0) {
+        log('warn', 'metrics.usage.pull.scope_violation', {
+          correlationId: opts.correlationId,
+          providerSlug: scope.providerSlug,
+          dropped,
+        });
+      }
+      records.push(...safeRecords);
       pulled.add(key);
       if (ttl > 0) {
-        cache.set(ck, { expiresAt: now + ttl, records: result.records, source: result.source });
+        cache.set(ck, { expiresAt: now + ttl, records: safeRecords, source: result.source });
       }
       log('info', 'metrics.usage.pull.ok', {
         correlationId: opts.correlationId,
         providerSlug: scope.providerSlug,
         appWide: !scope.accountId,
         source: result.source,
-        rows: result.records.length,
+        rows: safeRecords.length,
       });
     } catch (err) {
       // Graceful degradation: this scope falls back to ProviderUsageRecord.


### PR DESCRIPTION
## Summary

Implements the NaaP side of the push→pull usage migration: the spend dashboard can now **PULL** pymthouse usage live via the M2M client (the `@pymthouse/builder-sdk` usage helpers) instead of depending on usage pushed to `/metrics/ingest`. **Additive, flag-gated, default OFF, zero-regression.**

- The pull is routed through a new **provider-agnostic** adapter method (`BillingProviderAdapter.getSpend`), so it stays generalized across providers. Provider-internal → neutral mapping lives behind the adapter seam (NaaP never learns OpenMeter-internal field names).
- New `usage_pull` feature flag (**default OFF**). OFF = reads `ProviderUsageRecord` exactly as today. ON = **pull-first with graceful fallback** to `ProviderUsageRecord` on any pull failure/timeout — **never 500s** the dashboard.
- Short-TTL in-memory cache (60s default, `USAGE_PULL_CACHE_TTL_MS` configurable; keyed per provider+account+window) to avoid hammering the usage API on every dashboard load.
- **H1 tenant scoping preserved** identically on both paths.
- The generic `POST /api/v1/metrics/ingest` endpoint and the `usage_ingest` flag are **left intact but dormant** so push remains available for billing providers that can't be pulled.

## Usage endpoint / shape implemented against (per `builder-api.md`)

- Endpoint: `GET /api/v1/apps/{clientId}/usage` (M2M HTTP-Basic / client-credentials), accessed via the SDK helpers:
  - **scoped (per tenant):** `client.fetchUsageForExternalUser({ externalUserId, startDate, endDate })` → `MeScopeUsagePayload` (tenant boundary enforced by the provider — we never even receive another tenant's rows). Mapped to one neutral record incl. a `byCapability` (pipeline/model) rollup from `currentUser.pipelineModels`.
  - **admin app-wide:** `client.getUsage({ startDate, endDate, groupBy: 'user' })` → `UsageApiResponse` (`byUser[]`), mapped to one neutral record per app user; `source` (`"openmeter"|"postgres"`) surfaced.
- Typed against the owner's canonical `builder-sdk` `types.ts#L149-161` (`UsageQueryInput`, `UsageTotals`, `UsageByPipelineModelRow`, `UsageApiResponse`, etc.).

## SDK-version decision (reconciliation)

**Used the published SDK helper directly — no bespoke HTTP contract, no version bump in this PR.** The usage methods/types we need (`getUsage`, `fetchUsageForExternalUser`, `UsageApiResponse`, `MeScopeUsagePayload`, `summarizeUsageForExternalUser`, `listUsageByPipelineModel`) are present across published versions **0.1.0 → 0.4.4**. The installed **0.4.3** matches the owner's `feat/balance-gate` `types.ts#L149-161` exactly (including the `source` field, which 0.1.0 lacks). The `feat/balance-gate` branch is **not** required.

> Note: `apps/web-next/package.json` currently pins `@pymthouse/builder-sdk@0.1.0`, but `main`'s existing usage route + adapter already depend on `getUsage`/`fetchUsageForExternalUser` (de-facto ≥0.4.x; the integration/preview branch bumps to 0.4.3). The `source` field needs **≥0.4.3**. To avoid pulling unrelated signer-mint changes into this additive PR, the SDK bump is intentionally left to that branch. This PR builds/tests/typechecks green against the installed 0.4.3.

## Tenant scoping (H1) — how it's preserved

- Authorization boundary is computed exactly as before (`accessibleBillingAccountRefs`): teams the caller owns/belongs to that are bound to a `billingAccountRef`. A non-admin requesting an `accountId` they can't reach still gets **403** *before any pull*; no accounts → empty result.
- Non-admin pulls are scoped **per authorized ref** (`getSpend({ accountId })`), so the provider only ever returns that one account's usage. Caching is keyed per account, so no cross-tenant cache bleed.
- Admin keeps the existing precedent (any account / app-wide). Successfully-pulled scopes are excluded from the DB backfill so pulled + stored rows never double-count.

## File-by-file

- `lib/metrics/flags.ts` — add `USAGE_PULL_FLAG = 'usage_pull'` + `usagePullCacheTtlMs()` (env-configurable, clamped).
- `lib/feature-flags.ts` — register `usage_pull` in `KNOWN_FLAGS` (**default OFF**).
- `lib/billing/adapter.ts` — add neutral `ProviderSpendScope` / `ProviderSpendResult` / `ProviderSpendRecord` types + optional `getSpend()` on the SPI.
- `lib/billing/pymthouse-adapter.ts` — implement `getSpend()` (scoped + app-wide), mapping SDK responses → neutral records behind the seam.
- `lib/metrics/aggregate.ts` — additive `byCapability` rollup (omitted entirely when no record carries it → legacy/push output byte-identical).
- `lib/metrics/usage-pull.ts` *(new)* — TTL cache, provider-agnostic pull orchestration, structured logging, graceful per-scope degradation (never throws).
- `app/api/v1/metrics/usage/route.ts` — pull-first + DB fallback wiring; flag-OFF path unchanged; tenant scoping preserved; `usage_ingest` gate unchanged.
- Tests: `usage-pull.test.ts`, `pymthouse-adapter.test.ts` *(new)*, plus extended `aggregate.test.ts` and `metrics/usage/route.test.ts`.

## Test plan

- [x] `vitest run` on metrics + billing dirs — **94 passed**.
- [x] New coverage: pull mapping, cache hit/miss/TTL/disabled, graceful fallback, flag-OFF no-op, tenant isolation, admin app-wide DB exclusion.
- [x] `tsc --noEmit` — identical 15 pre-existing errors as `origin/main` (none in changed files).
- [ ] Vercel preview renders the dashboard with `usage_pull` OFF (parity) and ON (live pull + fallback).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live provider usage data retrieval with automatic fallback to existing stored records
  * Introduced capability-level usage breakdown for detailed consumption insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->