### PR TITLE
feat(billing): live pymthouse capability resolution at validate front door (NAAP-A)

### DIFF
--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -4,16 +4,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const fetchUsageForExternalUser = vi.fn();
 const getUsage = vi.fn();
+const getUserSubscription = vi.fn();
+const listBillingProducts = vi.fn();
 
 vi.mock('@/lib/pymthouse-client', () => ({
-  getPmtHouseServerClient: () => ({ fetchUsageForExternalUser, getUsage }),
+  getPmtHouseServerClient: () => ({
+    fetchUsageForExternalUser,
+    getUsage,
+    getUserSubscription,
+    listBillingProducts,
+  }),
 }));
 
 vi.mock('@pymthouse/builder-sdk/config', () => ({
   isPymthouseConfigured: () => true,
 }));
 
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  PYMTHOUSE_BPP_VALIDATE_FLAG: 'pymthouse_bpp_validate',
+}));
+
 import { PymthouseAdapter } from './pymthouse-adapter';
+import { AdapterNotImplementedError } from './adapter';
+import { resetPymthouseCapabilityCacheForTests } from './pymthouse-capabilities';
 
 const WINDOW = { startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-31T23:59:59.999Z' };
 
@@ -21,11 +36,63 @@ let adapter: PymthouseAdapter;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetPymthouseCapabilityCacheForTests();
+  isFeatureEnabled.mockResolvedValue(false);
   adapter = new PymthouseAdapter();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  resetPymthouseCapabilityCacheForTests();
+});
+
+describe('PymthouseAdapter.validate (BPP ② live capabilities, flag-gated)', () => {
+  it('flag OFF → throws AdapterNotImplementedError (zero regression, no provider call)', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    await expect(adapter.validate('acct_om_1')).rejects.toBeInstanceOf(AdapterNotImplementedError);
+    expect(getUserSubscription).not.toHaveBeenCalled();
+  });
+
+  it('flag ON + delegated account (no subscription) → wildcard capabilities', async () => {
+    isFeatureEnabled.mockResolvedValue(true);
+    getUserSubscription.mockResolvedValue({ externalUserId: 'acct_om_1', subscription: null });
+
+    const res = await adapter.validate('acct_om_1');
+    expect(getUserSubscription).toHaveBeenCalledWith('acct_om_1');
+    expect(res.valid).toBe(true);
+    expect(res.capabilities).toEqual(['*']);
+    expect(res.quota).toBeNull();
+  });
+
+  it('flag ON + plan-backed account → mapped, taxonomy-normalized capabilities', async () => {
+    isFeatureEnabled.mockResolvedValue(true);
+    getUserSubscription.mockResolvedValue({
+      externalUserId: 'acct_om_1',
+      subscription: { id: 'sub_1', status: 'active', planId: 'plan_pro', createdAt: 'x' },
+    });
+    listBillingProducts.mockResolvedValue({
+      apiVersion: 1,
+      products: [
+        {
+          id: 'plan_pro',
+          capabilities: [
+            { pipeline: 'text-to-image', modelId: 'flux-dev' },
+            { pipeline: 'live-video-to-video', modelId: 'scope' },
+          ],
+        },
+      ],
+    });
+
+    const res = await adapter.validate('acct_om_1');
+    expect(res.capabilities).toEqual(['text-to-image:flux-dev', 'live-video-to-video:scope']);
+    expect(res.subscriptionRef).toBe('sub_1');
+  });
+
+  it('flag ON + provider error → propagates (front door fails closed)', async () => {
+    isFeatureEnabled.mockResolvedValue(true);
+    getUserSubscription.mockRejectedValue(new Error('provider down'));
+    await expect(adapter.validate('acct_om_1')).rejects.toThrow('provider down');
+  });
 });
 
 describe('PymthouseAdapter.getSpend', () => {

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -15,6 +15,8 @@ import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
 import type { MeScopeUsagePayload, UsageApiResponse } from '@pymthouse/builder-sdk';
 
 import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import { isFeatureEnabled, PYMTHOUSE_BPP_VALIDATE_FLAG } from '@/lib/feature-flags';
+import { resolvePymthouseCapabilities } from './pymthouse-capabilities';
 import {
   AdapterNotImplementedError,
   type AppUsageInput,
@@ -40,10 +42,27 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     return isPymthouseConfigured();
   }
 
-  async validate(_key: string): Promise<ValidateResult> {
-    // BPP ② validate is provider-side (PYMT-3) and not yet C0-shaped on the NaaP
-    // side; do not fabricate identity/capabilities here.
-    throw new AdapterNotImplementedError(this.slug, 'validate');
+  /**
+   * BPP ② — resolve a validated account's capabilities live from pymthouse.
+   *
+   * The front door passes `billingAccountRef.accountId` here (the provider
+   * `externalUserId`); see `pymthouse-capabilities.ts` for the O1 subject-identity
+   * rationale. Gated behind `PYMTHOUSE_BPP_VALIDATE_FLAG` (default OFF): when OFF
+   * this throws `AdapterNotImplementedError` exactly as before, so the front door
+   * falls back to an empty capability set (zero regression). Provider errors
+   * propagate so the front door fails CLOSED.
+   */
+  async validate(externalUserId: string): Promise<ValidateResult> {
+    if (!(await isFeatureEnabled(PYMTHOUSE_BPP_VALIDATE_FLAG))) {
+      throw new AdapterNotImplementedError(this.slug, 'validate');
+    }
+    const resolved = await resolvePymthouseCapabilities(externalUserId);
+    return {
+      valid: true,
+      capabilities: resolved.capabilities,
+      quota: resolved.quota,
+      ...(resolved.subscriptionRef ? { subscriptionRef: resolved.subscriptionRef } : {}),
+    };
   }
 
   async getPlans(): Promise<Plan[]> {

--- a/apps/web-next/src/lib/billing/pymthouse-capabilities.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-capabilities.test.ts
@@ -159,4 +159,23 @@ describe('resolvePymthouseCapabilities — short-TTL cache (per-account, tenant-
 
     expect(getUserSubscription).toHaveBeenCalledTimes(2);
   });
+
+  it('expired entries are swept (no unbounded growth) and re-resolve after TTL', async () => {
+    process.env.PYMTHOUSE_CAPABILITY_CACHE_TTL_MS = '1000';
+    getUserSubscription.mockResolvedValue(subscription(null));
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      await resolvePymthouseCapabilities('acct_evict');
+      expect(getUserSubscription).toHaveBeenCalledTimes(1);
+
+      // Past TTL: the next resolution sweeps the stale entry and re-hits.
+      vi.setSystemTime(2000);
+      await resolvePymthouseCapabilities('acct_evict');
+      expect(getUserSubscription).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/web-next/src/lib/billing/pymthouse-capabilities.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-capabilities.test.ts
@@ -1,0 +1,162 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getUserSubscription = vi.fn();
+const listBillingProducts = vi.fn();
+
+vi.mock('@/lib/pymthouse-client', () => ({
+  getPmtHouseServerClient: () => ({ getUserSubscription, listBillingProducts }),
+}));
+
+import {
+  resolvePymthouseCapabilities,
+  resetPymthouseCapabilityCacheForTests,
+} from './pymthouse-capabilities';
+
+const ACCOUNT = 'acct_om_1';
+
+function subscription(planId: string | null) {
+  return {
+    externalUserId: ACCOUNT,
+    subscription:
+      planId === null
+        ? null
+        : {
+            id: 'sub_local_1',
+            status: 'active',
+            planId,
+            planName: 'Pro',
+            planType: 'paid',
+            currentPeriodStart: null,
+            currentPeriodEnd: null,
+            openmeterSubscriptionId: null,
+            stripeCheckoutSessionId: null,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            cancelledAt: null,
+          },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetPymthouseCapabilityCacheForTests();
+  delete process.env.PYMTHOUSE_CAPABILITY_CACHE_TTL_MS;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetPymthouseCapabilityCacheForTests();
+});
+
+describe('resolvePymthouseCapabilities — live mapping (O1: keyed on externalUserId)', () => {
+  it('delegated MVP (no subscription) → wildcard, no product lookup', async () => {
+    getUserSubscription.mockResolvedValue(subscription(null));
+
+    const res = await resolvePymthouseCapabilities(ACCOUNT);
+
+    expect(getUserSubscription).toHaveBeenCalledWith(ACCOUNT);
+    expect(listBillingProducts).not.toHaveBeenCalled();
+    expect(res.capabilities).toEqual(['*']);
+    expect(res.quota).toBeNull();
+    expect(res.source).toBe('delegated');
+  });
+
+  it('subscription without a planId → wildcard (delegated MVP), surfaces subscriptionRef', async () => {
+    getUserSubscription.mockResolvedValue({
+      externalUserId: ACCOUNT,
+      subscription: { id: 'sub_local_1', status: 'active', planId: null, createdAt: 'x' },
+    });
+
+    const res = await resolvePymthouseCapabilities(ACCOUNT);
+    expect(res.capabilities).toEqual(['*']);
+    expect(res.subscriptionRef).toBe('sub_local_1');
+  });
+
+  it('subscription bound to a plan → maps plan capability bundles to <pipeline>:<model>', async () => {
+    getUserSubscription.mockResolvedValue(subscription('plan_pro'));
+    listBillingProducts.mockResolvedValue({
+      apiVersion: 1,
+      products: [
+        {
+          id: 'plan_free',
+          capabilities: [{ pipeline: 'text-to-image', modelId: 'sdxl' }],
+        },
+        {
+          id: 'plan_pro',
+          capabilities: [
+            { pipeline: 'text-to-image', modelId: 'flux-dev' },
+            { pipeline: 'live-video-to-video', modelId: 'scope' },
+            // malformed rows are dropped by normalization
+            { pipeline: '', modelId: 'x' },
+            { pipeline: 'text-to-image', modelId: 'flux-dev' }, // duplicate
+          ],
+        },
+      ],
+    });
+
+    const res = await resolvePymthouseCapabilities(ACCOUNT);
+
+    expect(res.source).toBe('plan');
+    expect(res.capabilities).toEqual([
+      'text-to-image:flux-dev',
+      'live-video-to-video:scope',
+    ]);
+    expect(res.subscriptionRef).toBe('sub_local_1');
+  });
+
+  it('subscription whose plan cannot be resolved → fail closed ([]), key still valid', async () => {
+    getUserSubscription.mockResolvedValue(subscription('plan_ghost'));
+    listBillingProducts.mockResolvedValue({ apiVersion: 1, products: [{ id: 'plan_other', capabilities: [] }] });
+
+    const res = await resolvePymthouseCapabilities(ACCOUNT);
+    expect(res.capabilities).toEqual([]);
+    expect(res.source).toBe('plan_unresolved');
+  });
+
+  it('provider error PROPAGATES (front door fails closed) — never treated as all-caps', async () => {
+    getUserSubscription.mockRejectedValue(new Error('provider down'));
+    await expect(resolvePymthouseCapabilities(ACCOUNT)).rejects.toThrow('provider down');
+  });
+});
+
+describe('resolvePymthouseCapabilities — short-TTL cache (per-account, tenant-scoped)', () => {
+  it('cache hit: a second call within TTL does not re-hit the provider', async () => {
+    getUserSubscription.mockResolvedValue(subscription(null));
+
+    await resolvePymthouseCapabilities(ACCOUNT);
+    await resolvePymthouseCapabilities(ACCOUNT);
+
+    expect(getUserSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache miss: a different account is resolved independently (no cross-tenant leak)', async () => {
+    getUserSubscription.mockResolvedValue(subscription(null));
+
+    await resolvePymthouseCapabilities('acct_a');
+    await resolvePymthouseCapabilities('acct_b');
+
+    expect(getUserSubscription).toHaveBeenCalledTimes(2);
+    expect(getUserSubscription).toHaveBeenNthCalledWith(1, 'acct_a');
+    expect(getUserSubscription).toHaveBeenNthCalledWith(2, 'acct_b');
+  });
+
+  it('skipCache forces a fresh provider call', async () => {
+    getUserSubscription.mockResolvedValue(subscription(null));
+
+    await resolvePymthouseCapabilities(ACCOUNT);
+    await resolvePymthouseCapabilities(ACCOUNT, { skipCache: true });
+
+    expect(getUserSubscription).toHaveBeenCalledTimes(2);
+  });
+
+  it('TTL=0 disables caching (every call re-hits the provider)', async () => {
+    process.env.PYMTHOUSE_CAPABILITY_CACHE_TTL_MS = '0';
+    getUserSubscription.mockResolvedValue(subscription(null));
+
+    await resolvePymthouseCapabilities(ACCOUNT);
+    await resolvePymthouseCapabilities(ACCOUNT);
+
+    expect(getUserSubscription).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web-next/src/lib/billing/pymthouse-capabilities.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-capabilities.ts
@@ -55,10 +55,25 @@ interface CacheEntry {
 }
 
 let cache = new Map<string, CacheEntry>();
+let lastSweepAt = 0;
 
 /** Vitest / isolated tests: clear the per-account capability cache. */
 export function resetPymthouseCapabilityCacheForTests(): void {
   cache = new Map<string, CacheEntry>();
+  lastSweepAt = 0;
+}
+
+/**
+ * Purge expired entries so unique-account traffic cannot grow the process-wide
+ * cache without bound. Bounded overhead: sweeps at most once per TTL window.
+ */
+function sweepExpiredCache(now: number, ttl: number): void {
+  if (ttl <= 0 || cache.size === 0) return;
+  if (now - lastSweepAt < ttl) return;
+  for (const [key, entry] of cache) {
+    if (now - entry.at >= ttl) cache.delete(key);
+  }
+  lastSweepAt = now;
 }
 
 /** Effective cache TTL (configurable via env, like the usage-pull cache). */
@@ -112,6 +127,7 @@ export async function resolvePymthouseCapabilities(
 ): Promise<PymthouseCapabilityResolution> {
   const now = Date.now();
   const ttl = cacheTtlMs();
+  sweepExpiredCache(now, ttl);
 
   if (!opts?.skipCache && ttl > 0) {
     const hit = cache.get(externalUserId);
@@ -122,6 +138,7 @@ export async function resolvePymthouseCapabilities(
       });
       return hit.data;
     }
+    if (hit) cache.delete(externalUserId);
   }
 
   const client = getPmtHouseServerClient();

--- a/apps/web-next/src/lib/billing/pymthouse-capabilities.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-capabilities.ts
@@ -1,0 +1,182 @@
+/**
+ * Pymthouse capability resolution (BPP ② — live, NAAP follow-up #1).
+ *
+ * Resolves the capability grant set for a validated key LIVE from the pymthouse
+ * provider, keyed on the account's `externalUserId` (the NaaP
+ * `billingAccountRef.accountId`). This reproduces the resolution that the merged
+ * pymthouse `POST /api/v1/auth/validate` (BPP ②) performs server-side:
+ *
+ *   - no subscription, or a subscription without a resolvable plan → delegated
+ *     MVP → the wildcard `["*"]` (grants everything the app offers);
+ *   - a subscription bound to a plan → that plan's capability bundles, mapped to
+ *     canonical `"<pipeline>:<model>"` ids.
+ *
+ * O1 (subject identity): the merged `POST /api/v1/auth/validate` is keyed on a
+ * pymthouse-issued provider API key (`pmth_*`, hashed → `apiKeys` lookup), which
+ * NaaP's seat → team → account binding does NOT hold — NaaP holds the provider
+ * `externalUserId` (= `accountId`) plus M2M client credentials. Rather than mint
+ * and persist a per-account provider API key (a new secret-management surface),
+ * we resolve capabilities live through the already-wired M2M client keyed on the
+ * externalUserId, reproducing the validate endpoint's own logic. The provider
+ * stays the single source of truth (O3: live-only, no local grant table).
+ *
+ * SECURITY: all provider I/O goes through the env-configured M2M client (never a
+ * request-derived URL — preserves the front door's no-SSRF property). The cache
+ * is keyed per externalUserId so it never crosses a tenant boundary. Structured
+ * logs carry only counts / booleans — never the raw account id or any secret.
+ */
+
+import 'server-only';
+
+import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import { normalizeProviderCapabilities } from '@/lib/capabilities/taxonomy';
+
+/** Canonical wildcard grant returned for delegated (no-plan) accounts. */
+const CAPABILITY_WILDCARD = '*';
+
+/** Default short cache TTL (mirrors the 45 s discovery-plans cache pattern). */
+const DEFAULT_CACHE_TTL_MS = 45_000;
+
+/** Where the resolved capabilities came from (informational logging only). */
+export type CapabilityResolutionSource = 'delegated' | 'plan' | 'plan_unresolved';
+
+/** Live capability resolution result for one account (provider-neutral). */
+export interface PymthouseCapabilityResolution {
+  capabilities: string[];
+  quota: { remaining: number; resetAt?: string } | null;
+  /** Neutral, opaque subscription pointer when the account has a subscription. */
+  subscriptionRef?: string;
+  source: CapabilityResolutionSource;
+}
+
+interface CacheEntry {
+  at: number;
+  data: PymthouseCapabilityResolution;
+}
+
+let cache = new Map<string, CacheEntry>();
+
+/** Vitest / isolated tests: clear the per-account capability cache. */
+export function resetPymthouseCapabilityCacheForTests(): void {
+  cache = new Map<string, CacheEntry>();
+}
+
+/** Effective cache TTL (configurable via env, like the usage-pull cache). */
+function cacheTtlMs(): number {
+  const raw = process.env.PYMTHOUSE_CAPABILITY_CACHE_TTL_MS?.trim();
+  if (!raw) return DEFAULT_CACHE_TTL_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_CACHE_TTL_MS;
+}
+
+function log(level: 'info' | 'warn', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+/**
+ * Map a plan's capability bundles to canonical `"<pipeline>:<model>"` ids.
+ * Rows missing either part are dropped; the result is taxonomy-normalized so
+ * malformed ids never reach the gate as grants.
+ */
+function mapPlanCapabilities(
+  capabilities: ReadonlyArray<{ pipeline?: string | null; modelId?: string | null }>,
+): string[] {
+  const raw: string[] = [];
+  for (const cap of capabilities) {
+    const pipeline = cap.pipeline?.trim();
+    const modelId = cap.modelId?.trim();
+    if (pipeline && modelId) raw.push(`${pipeline}:${modelId}`);
+  }
+  return normalizeProviderCapabilities(raw);
+}
+
+/**
+ * Resolve the capability grant set for one account live from pymthouse.
+ *
+ * Fail-closed contract:
+ *   - a provider/transport error PROPAGATES (the front door catches it and
+ *     falls back to an empty capability set — deny everything when the gate is
+ *     ON); callers must NOT treat a thrown error as "all capabilities";
+ *   - a well-formed response with no resolvable plan yields `["*"]` (delegated
+ *     MVP, matching the provider's own validate semantics);
+ *   - a subscription whose plan cannot be resolved yields `[]` (the key is still
+ *     valid, but grants nothing until the plan resolves).
+ *
+ * @param externalUserId the provider account id (NaaP `billingAccountRef.accountId`)
+ */
+export async function resolvePymthouseCapabilities(
+  externalUserId: string,
+  opts?: { skipCache?: boolean },
+): Promise<PymthouseCapabilityResolution> {
+  const now = Date.now();
+  const ttl = cacheTtlMs();
+
+  if (!opts?.skipCache && ttl > 0) {
+    const hit = cache.get(externalUserId);
+    if (hit && now - hit.at < ttl) {
+      log('info', 'pymthouse.capabilities.cache_hit', {
+        capabilityCount: hit.data.capabilities.length,
+        source: hit.data.source,
+      });
+      return hit.data;
+    }
+  }
+
+  const client = getPmtHouseServerClient();
+
+  // Provider errors propagate (fail closed at the front door); do NOT swallow.
+  const subscriptionResponse = await client.getUserSubscription(externalUserId);
+  const subscription = subscriptionResponse?.subscription ?? null;
+  const subscriptionRef = subscription?.id ? subscription.id : undefined;
+
+  let resolution: PymthouseCapabilityResolution;
+
+  if (!subscription || !subscription.planId) {
+    // Delegated MVP: capabilities = all (wildcard), quota unmetered.
+    resolution = {
+      capabilities: [CAPABILITY_WILDCARD],
+      quota: null,
+      source: 'delegated',
+      ...(subscriptionRef ? { subscriptionRef } : {}),
+    };
+  } else {
+    const { products } = await client.listBillingProducts();
+    const product = Array.isArray(products)
+      ? products.find((p) => p.id === subscription.planId)
+      : undefined;
+
+    if (!product) {
+      // Subscription bound to a plan we cannot resolve → grant nothing (fail
+      // closed) rather than over-grant. Key stays valid.
+      log('warn', 'pymthouse.capabilities.plan_unresolved', { hasSubscription: true });
+      resolution = {
+        capabilities: [],
+        quota: null,
+        source: 'plan_unresolved',
+        ...(subscriptionRef ? { subscriptionRef } : {}),
+      };
+    } else {
+      resolution = {
+        capabilities: mapPlanCapabilities(product.capabilities ?? []),
+        // O4: quota.remaining enforcement is OUT OF SCOPE for this follow-up; the
+        // gate enforces capability membership only, so quota stays null here.
+        quota: null,
+        source: 'plan',
+        ...(subscriptionRef ? { subscriptionRef } : {}),
+      };
+    }
+  }
+
+  if (ttl > 0) {
+    cache.set(externalUserId, { at: now, data: resolution });
+  }
+
+  log('info', 'pymthouse.capabilities.resolved', {
+    capabilityCount: resolution.capabilities.length,
+    source: resolution.source,
+    cacheHit: false,
+  });
+  return resolution;
+}

--- a/apps/web-next/src/lib/capabilities/taxonomy.test.ts
+++ b/apps/web-next/src/lib/capabilities/taxonomy.test.ts
@@ -8,6 +8,7 @@ import {
   categoryOfCapability,
   isWellFormedCapabilityId,
   normalizeCapabilities,
+  normalizeProviderCapabilities,
   parseCapabilityId,
 } from './taxonomy';
 
@@ -66,5 +67,42 @@ describe('NAAP-E taxonomy — categories + normalize', () => {
   it('normalizes a non-array to []', () => {
     expect(normalizeCapabilities(null)).toEqual([]);
     expect(normalizeCapabilities(undefined)).toEqual([]);
+  });
+});
+
+describe('NAAP-E taxonomy — normalizeProviderCapabilities (O2: canonical `:` format)', () => {
+  it('coerces the legacy `<pipeline>/<scope>` slash form to the canonical `:` form', () => {
+    expect(normalizeProviderCapabilities(['live-video-to-video/scope'])).toEqual([
+      'live-video-to-video:scope',
+    ]);
+  });
+
+  it('leaves already-canonical colon ids and the wildcard unchanged', () => {
+    expect(normalizeProviderCapabilities(['text-to-image:sdxl', '*'])).toEqual([
+      'text-to-image:sdxl',
+      '*',
+    ]);
+  });
+
+  it('coerces, de-duplicates across separator variants, and drops malformed ids', () => {
+    expect(
+      normalizeProviderCapabilities([
+        'live-video-to-video/scope',
+        'live-video-to-video:scope', // same as the slash form after coercion
+        'tool:ffmpeg-concat',
+        'garbage',
+        '',
+      ]),
+    ).toEqual(['live-video-to-video:scope', 'tool:ffmpeg-concat']);
+  });
+
+  it('only the FIRST separator is coerced (a colon already present wins)', () => {
+    // `a:b/c` already has a colon → not coerced → `a:b/c` is malformed → dropped.
+    expect(normalizeProviderCapabilities(['a:b/c'])).toEqual([]);
+  });
+
+  it('normalizes a non-array to []', () => {
+    expect(normalizeProviderCapabilities(null)).toEqual([]);
+    expect(normalizeProviderCapabilities(undefined)).toEqual([]);
   });
 });

--- a/apps/web-next/src/lib/capabilities/taxonomy.ts
+++ b/apps/web-next/src/lib/capabilities/taxonomy.ts
@@ -95,3 +95,40 @@ export function normalizeCapabilities(raw: readonly string[] | null | undefined)
   }
   return out;
 }
+
+/**
+ * Coerce a single provider/legacy capability id to the canonical `:` separator.
+ *
+ * O2 decision — the canonical capability-id format is `<pipeline>:<model>` (the
+ * taxonomy grammar above and the form pymthouse BPP returns via `toCapabilityIds`).
+ * Some NaaP-side defaults (e.g. `storyboard-default-plan.ts`) historically used a
+ * `<pipeline>/<scope>` slash form; this coerces that single legacy `/` separator
+ * to the canonical `:` so both inputs normalize to the same id. The wildcard `*`
+ * and already-colon ids pass through unchanged.
+ */
+function coerceCanonicalSeparator(entry: string): string {
+  const trimmed = entry.trim();
+  if (trimmed === CAPABILITY_WILDCARD) return trimmed;
+  if (!trimmed.includes(':') && trimmed.includes('/')) {
+    return trimmed.replace('/', ':');
+  }
+  return trimmed;
+}
+
+/**
+ * Normalize capability ids received from a provider/external source to the
+ * canonical taxonomy form: coerce the legacy `/` separator to `:` (O2), then
+ * validate + de-duplicate through {@link normalizeCapabilities}. Malformed ids
+ * are dropped (fail closed — they never reach the gate as grants).
+ */
+export function normalizeProviderCapabilities(
+  raw: readonly string[] | null | undefined,
+): string[] {
+  if (!Array.isArray(raw)) return [];
+  const coerced: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'string') continue;
+    coerced.push(coerceCanonicalSeparator(entry));
+  }
+  return normalizeCapabilities(coerced);
+}

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -22,6 +22,15 @@ export interface KnownFlag {
  */
 export const SDK_CONNECTOR_FLAG = 'sdk_connector';
 
+/**
+ * Canonical key for the pymthouse BPP ② live capability-resolution flag (default
+ * OFF). When OFF, `PymthouseAdapter.validate()` throws `AdapterNotImplementedError`
+ * exactly as before, so the front door falls back to an empty capability set
+ * (today's behavior). Shared by KNOWN_FLAGS and the adapter so the name cannot
+ * drift. Requires the provider's `BPP_VALIDATE_V2` posture in the same env.
+ */
+export const PYMTHOUSE_BPP_VALIDATE_FLAG = 'pymthouse_bpp_validate';
+
 export const KNOWN_FLAGS: KnownFlag[] = [
   {
     key: 'enableTeams',
@@ -87,6 +96,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: false,
     description:
       'Seed the public "sdk" Service Gateway connector (fronting sdk.daydream.monster at /api/v1/gw/sdk/*) AND accept native naap_ keys at the gateway authorize step (NAAP-5). OFF = no sdk connector seeded and naap_ keys are rejected at the gateway exactly as today (no-op).',
+  },
+  {
+    key: PYMTHOUSE_BPP_VALIDATE_FLAG,
+    enabled: false,
+    description:
+      'Resolve a validated key\'s capabilities LIVE from the pymthouse provider (BPP ②) via the M2M client, keyed on the account\'s externalUserId, and surface them at the validation front door. OFF = PymthouseAdapter.validate() is unimplemented (front door falls back to an empty capability set, exactly as today). Requires the provider\'s BPP_VALIDATE_V2 posture in the same environment; pairs with capability_gate (also default OFF).',
   },
 ];
 


### PR DESCRIPTION
## Summary

Closes the NaaP **capability-provisioning gap** (follow-up #1). The capability gate (`enforcement.ts`) enforces correctly, but `PymthouseAdapter.validate()` threw `AdapterNotImplementedError`, so the front door (`/api/v1/keys/validate`) fell back to `capabilities = []`. With the gate ON, a real pymthouse plan therefore granted **nothing** (the prior e2e only passed because the *stub* adapter returns canned capabilities).

This PR wires `PymthouseAdapter.validate()` to resolve a validated account's capabilities **live from the provider** via the already-wired M2M client, behind a new flag defaulting **OFF**.

**All additive. Flag OFF = exact current behavior (zero regression).**

## What changed (file-by-file)

- **`apps/web-next/src/lib/billing/pymthouse-capabilities.ts`** *(new)* — live resolution keyed on the account `externalUserId` + short-TTL per-account cache + structured logging. Reproduces the merged BPP ② validate logic: no subscription / no plan → wildcard `["*"]` (delegated MVP); subscription→plan → mapped `"<pipeline>:<model>"` ids; plan unresolvable → `[]` (fail closed).
- **`apps/web-next/src/lib/billing/pymthouse-adapter.ts`** — `validate()` now flag-gates on `pymthouse_bpp_validate`: **OFF → throws `AdapterNotImplementedError` exactly as before**; ON → returns the live resolution. Provider errors propagate (front door fails CLOSED).
- **`apps/web-next/src/lib/capabilities/taxonomy.ts`** — adds `normalizeProviderCapabilities()`: coerces the legacy `<pipeline>/<scope>` slash form to the canonical `<pipeline>:<model>` colon form, then validates/de-dups through the taxonomy.
- **`apps/web-next/src/lib/feature-flags.ts`** — new `pymthouse_bpp_validate` flag (**default OFF**) + exported constant.
- **Tests** — `pymthouse-capabilities.test.ts` (new), plus additions to `pymthouse-adapter.test.ts` and `taxonomy.test.ts`.

## Open decisions resolved (documented)

- **O1 — validate subject identity:** The merged `POST /api/v1/auth/validate` is keyed on a pymthouse-issued provider API key (`pmth_*`, hashed → `apiKeys` lookup), which NaaP's seat→team→account binding does **not** hold — NaaP holds the provider `externalUserId` (= `billingAccountRef.accountId`) + M2M credentials. Rather than mint/persist a per-account provider API key (a new secret-management surface), we resolve capabilities **live via the M2M client keyed on the externalUserId**, reproducing the validate endpoint's own resolution. Adapter signature stays `validate(externalUserId)`.
- **O2 — canonical capability-id format:** chose `"<pipeline>:<model>"` (colon — the taxonomy grammar and the form pymthouse BPP returns). Legacy `<pipeline>/<scope>` slash variants are coerced to colon before validation.
- **O3 — local SoT vs live-only:** **live-only.** No `AccountCapabilityGrant` table added — the provider is the single source of truth (no drift); the short-TTL cache covers latency. Live resolution is sufficient, so the additive table from the plan was intentionally not built.
- **O4 — quota enforcement:** **out of scope.** The gate enforces capability membership only; `quota` is surfaced as `null` (delegated MVP is unmetered), not enforced.

## Flag confirmation

- `pymthouse_bpp_validate` defaults **OFF** in `KNOWN_FLAGS`.
- Flag-OFF no-op: `validate()` throws `AdapterNotImplementedError`, the front door catches it and leaves `capabilities = []` — byte-for-byte today's path. Paired with `capability_gate` (also default OFF) the end-to-end response is unchanged.

## Fail-closed preserved

- Provider/transport errors **propagate** out of resolution → the front door's existing catch leaves `capabilities = []` (gate ON denies everything). Never treated as "all capabilities".
- A subscription whose plan can't be resolved → `[]` (not over-granted), key still valid.
- Cache is keyed per `externalUserId` (tenant-scoped); logs carry only counts/booleans — never the account id or any secret.

## Test plan

- [x] `vitest run` for billing/capabilities/validate suites — **73 passed** (live mapping, taxonomy normalization incl. `/`→`:`, cache hit/miss + TTL=0, flag-OFF no-op, fail-closed on provider error, gate allow/deny).
- [x] `tsc --noEmit` — 15 errors, **identical to `origin/main` baseline**, none in touched files.
- [ ] Preview: enable `pymthouse_bpp_validate` with provider `BPP_VALIDATE_V2` ON; verify a real subscribed plan grants expected caps with `capability_gate` still OFF (log-only `capabilityCount`), then enable the gate.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability resolution from billing provider with configurable feature flag support.
  * Introduced capability normalization for external provider data.

* **Tests**
  * Added comprehensive test coverage for capability resolution, including caching behavior and error handling.
  * Added validation tests for capability normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->