### PR TITLE
feat(billing): ProviderInstance foundation + per-config adapter construction (P0)

### DIFF
--- a/apps/web-next/src/lib/billing/provider-instance.test.ts
+++ b/apps/web-next/src/lib/billing/provider-instance.test.ts
@@ -1,0 +1,174 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    secretVault: { findUnique: vi.fn() },
+  },
+}));
+
+const decryptV1 = vi.fn();
+vi.mock('@naap/crypto', () => ({
+  decryptV1: (...a: unknown[]) => decryptV1(...a),
+}));
+
+const createPmtHouseClient = vi.fn();
+vi.mock('@/lib/pymthouse-client', () => ({
+  createPmtHouseClient: (...a: unknown[]) => createPmtHouseClient(...a),
+  getPmtHouseServerClient: vi.fn(),
+}));
+
+vi.mock('@pymthouse/builder-sdk/config', () => ({
+  isPymthouseConfigured: () => true,
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  buildAdapterForProviderInstance,
+  getProviderInstanceSecret,
+  parsePymthouseInstanceConfig,
+  type ProviderInstanceRecord,
+} from './provider-instance';
+
+const secretFindUnique = prisma.secretVault.findUnique as ReturnType<typeof vi.fn>;
+
+const GOOD_CONFIG = {
+  issuerUrl: 'https://acme.pymthouse.com',
+  publicClientId: 'app_acme',
+  m2mClientId: 'm2m_acme',
+};
+
+function instance(overrides: Partial<ProviderInstanceRecord> = {}): ProviderInstanceRecord {
+  return {
+    id: 'pi_acme',
+    adapterType: 'pymthouse',
+    slug: 'pymthouse-acme',
+    config: { ...GOOD_CONFIG },
+    secretRef: 'pmt:acme:m2m-secret',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('parsePymthouseInstanceConfig', () => {
+  it('parses + trims the non-secret connection params', () => {
+    const cfg = parsePymthouseInstanceConfig({
+      issuerUrl: '  https://acme.pymthouse.com  ',
+      publicClientId: ' app_acme ',
+      m2mClientId: ' m2m_acme ',
+    });
+    expect(cfg).toEqual({
+      issuerUrl: 'https://acme.pymthouse.com',
+      publicClientId: 'app_acme',
+      m2mClientId: 'm2m_acme',
+    });
+  });
+
+  it('passes through allowInsecureHttp only when it is a boolean', () => {
+    expect(parsePymthouseInstanceConfig({ ...GOOD_CONFIG, allowInsecureHttp: true })?.allowInsecureHttp).toBe(true);
+    expect('allowInsecureHttp' in (parsePymthouseInstanceConfig({ ...GOOD_CONFIG, allowInsecureHttp: 'yes' }) ?? {})).toBe(false);
+  });
+
+  it('returns null when a required field is missing or blank', () => {
+    expect(parsePymthouseInstanceConfig({ publicClientId: 'x', m2mClientId: 'y' })).toBeNull();
+    expect(parsePymthouseInstanceConfig({ ...GOOD_CONFIG, issuerUrl: '   ' })).toBeNull();
+  });
+
+  it('returns null for non-object config', () => {
+    expect(parsePymthouseInstanceConfig(null)).toBeNull();
+    expect(parsePymthouseInstanceConfig('str')).toBeNull();
+    expect(parsePymthouseInstanceConfig(['a'])).toBeNull();
+  });
+
+  it('INV-secret-isolation: never surfaces a secret value even if present in config', () => {
+    const cfg = parsePymthouseInstanceConfig({
+      ...GOOD_CONFIG,
+      m2mClientSecret: 'leaked-secret',
+    });
+    expect(cfg).not.toBeNull();
+    expect(Object.keys(cfg ?? {})).not.toContain('m2mClientSecret');
+    expect(JSON.stringify(cfg)).not.toContain('leaked-secret');
+  });
+});
+
+describe('getProviderInstanceSecret', () => {
+  it('resolves + decrypts the vault value', async () => {
+    secretFindUnique.mockResolvedValue({ encryptedValue: 'v1:gcm:scrypt:...' });
+    decryptV1.mockReturnValue('super-secret');
+    await expect(getProviderInstanceSecret('pmt:acme:m2m-secret')).resolves.toBe('super-secret');
+    expect(secretFindUnique).toHaveBeenCalledWith({
+      where: { key: 'pmt:acme:m2m-secret' },
+      select: { encryptedValue: true },
+    });
+  });
+
+  it('returns null for a blank ref without touching the DB', async () => {
+    await expect(getProviderInstanceSecret('   ')).resolves.toBeNull();
+    expect(secretFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the vault row is missing', async () => {
+    secretFindUnique.mockResolvedValue(null);
+    await expect(getProviderInstanceSecret('missing')).resolves.toBeNull();
+  });
+
+  it('returns null (never throws) when decryption fails', async () => {
+    secretFindUnique.mockResolvedValue({ encryptedValue: 'corrupt' });
+    decryptV1.mockImplementation(() => {
+      throw new Error('bad envelope');
+    });
+    await expect(getProviderInstanceSecret('pmt:acme:m2m-secret')).resolves.toBeNull();
+  });
+});
+
+describe('buildAdapterForProviderInstance', () => {
+  it('builds a pymthouse adapter bound to a per-instance client', async () => {
+    secretFindUnique.mockResolvedValue({ encryptedValue: 'v1' });
+    decryptV1.mockReturnValue('super-secret');
+    const fakeClient = { id: 'client-acme' };
+    createPmtHouseClient.mockReturnValue(fakeClient);
+
+    const adapter = await buildAdapterForProviderInstance(instance());
+    expect(adapter?.slug).toBe('pymthouse');
+    expect(adapter?.isConfigured()).toBe(true);
+    expect(createPmtHouseClient).toHaveBeenCalledWith({
+      issuerUrl: GOOD_CONFIG.issuerUrl,
+      publicClientId: GOOD_CONFIG.publicClientId,
+      m2mClientId: GOOD_CONFIG.m2mClientId,
+      m2mClientSecret: 'super-secret',
+    });
+  });
+
+  it('returns undefined for incomplete config (no client built)', async () => {
+    const adapter = await buildAdapterForProviderInstance(instance({ config: { issuerUrl: 'x' } }));
+    expect(adapter).toBeUndefined();
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when no secretRef is set', async () => {
+    const adapter = await buildAdapterForProviderInstance(instance({ secretRef: null }));
+    expect(adapter).toBeUndefined();
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the secret cannot be resolved', async () => {
+    secretFindUnique.mockResolvedValue(null);
+    const adapter = await buildAdapterForProviderInstance(instance());
+    expect(adapter).toBeUndefined();
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a non-pymthouse adapterType (config-free in P0)', async () => {
+    const adapter = await buildAdapterForProviderInstance(instance({ adapterType: 'stub' }));
+    expect(adapter).toBeUndefined();
+  });
+});

--- a/apps/web-next/src/lib/billing/provider-instance.ts
+++ b/apps/web-next/src/lib/billing/provider-instance.ts
@@ -1,0 +1,124 @@
+/**
+ * Per-`ProviderInstance` adapter construction helpers (NAAP P0, multi-app).
+ *
+ * Building blocks used by the DB adapter registry (`registry-db.ts`) to turn a
+ * `ProviderInstance` row into a configured `BillingProviderAdapter`:
+ *   - parse the row's NON-SECRET `config` into typed connection params,
+ *   - resolve the M2M secret from `SecretVault` by `secretRef` (never inline),
+ *   - build a pymthouse adapter bound to a per-instance client.
+ *
+ * Secrets discipline: the secret VALUE never appears in `config`, is read only
+ * via `SecretVault`, and is never logged. All new behavior is reachable only
+ * when the `provider_instances` flag is ON (gated by the registry); these
+ * helpers perform no flag check themselves.
+ */
+
+import 'server-only';
+
+import { decryptV1 } from '@naap/crypto';
+
+import { prisma } from '@/lib/db';
+import { createPmtHouseClient } from '@/lib/pymthouse-client';
+
+import type { BillingProviderAdapter } from './adapter';
+import { PymthouseAdapter, PYMTHOUSE_ADAPTER_SLUG } from './pymthouse-adapter';
+
+/** Minimal `ProviderInstance` shape the registry needs to build an adapter. */
+export interface ProviderInstanceRecord {
+  id: string;
+  adapterType: string;
+  slug: string;
+  config: unknown;
+  secretRef: string | null;
+  enabled: boolean;
+}
+
+/** Non-secret pymthouse connection params parsed from `ProviderInstance.config`. */
+export interface PymthouseInstanceConfig {
+  issuerUrl: string;
+  publicClientId: string;
+  m2mClientId: string;
+  allowInsecureHttp?: boolean;
+}
+
+/**
+ * Parse a `ProviderInstance.config` JSON blob into typed pymthouse connection
+ * params. Returns null when any required NON-SECRET field is missing/blank so
+ * the caller can fall back rather than build a half-configured client. The M2M
+ * secret is intentionally NOT part of config (it lives in `SecretVault`).
+ */
+export function parsePymthouseInstanceConfig(
+  config: unknown,
+): PymthouseInstanceConfig | null {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return null;
+  }
+  const c = config as Record<string, unknown>;
+  const issuerUrl = typeof c.issuerUrl === 'string' ? c.issuerUrl.trim() : '';
+  const publicClientId = typeof c.publicClientId === 'string' ? c.publicClientId.trim() : '';
+  const m2mClientId = typeof c.m2mClientId === 'string' ? c.m2mClientId.trim() : '';
+  if (!issuerUrl || !publicClientId || !m2mClientId) {
+    return null;
+  }
+  const allowInsecureHttp =
+    typeof c.allowInsecureHttp === 'boolean' ? c.allowInsecureHttp : undefined;
+  return {
+    issuerUrl,
+    publicClientId,
+    m2mClientId,
+    ...(allowInsecureHttp !== undefined ? { allowInsecureHttp } : {}),
+  };
+}
+
+/**
+ * Resolve an instance's M2M secret from `SecretVault` by its `secretRef` (the
+ * vault `key`). Returns null when the ref is blank, the row is missing, or
+ * decryption fails — callers fall back rather than throw. Never logs the value.
+ */
+export async function getProviderInstanceSecret(secretRef: string): Promise<string | null> {
+  const key = secretRef.trim();
+  if (!key) {
+    return null;
+  }
+  try {
+    const row = await prisma.secretVault.findUnique({
+      where: { key },
+      select: { encryptedValue: true },
+    });
+    if (!row?.encryptedValue) {
+      return null;
+    }
+    const value = decryptV1(row.encryptedValue);
+    return value.trim() ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a `BillingProviderAdapter` for a `ProviderInstance` row.
+ *
+ * - `pymthouse`: parse config + resolve the M2M secret, then bind a
+ *   per-instance `PmtHouseClient` (so multiple pymthouse apps coexist).
+ *   Returns undefined when config is incomplete or the secret cannot resolve,
+ *   so the registry can fall back to the global-env default adapter.
+ * - other adapterTypes: config-free in P0; the registry uses its default
+ *   factory for those, so this returns undefined here.
+ */
+export async function buildAdapterForProviderInstance(
+  instance: ProviderInstanceRecord,
+): Promise<BillingProviderAdapter | undefined> {
+  if (instance.adapterType === PYMTHOUSE_ADAPTER_SLUG) {
+    const config = parsePymthouseInstanceConfig(instance.config);
+    if (!config || !instance.secretRef) {
+      return undefined;
+    }
+    const m2mClientSecret = await getProviderInstanceSecret(instance.secretRef);
+    if (!m2mClientSecret) {
+      return undefined;
+    }
+    const client = createPmtHouseClient({ ...config, m2mClientSecret });
+    return new PymthouseAdapter({ client, isConfigured: () => true });
+  }
+  return undefined;
+}

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -95,6 +95,32 @@ describe('PymthouseAdapter.validate (BPP ② live capabilities, flag-gated)', ()
   });
 });
 
+describe('PymthouseAdapter per-instance client (P0, zero regression)', () => {
+  it('default constructor → talks to the global-env client singleton (today\'s behavior)', async () => {
+    getUsage.mockResolvedValue({ byUser: [] });
+    const a = new PymthouseAdapter();
+    await a.getAppUsage(WINDOW);
+    // `getUsage` is the env client mock from getPmtHouseServerClient().
+    expect(getUsage).toHaveBeenCalled();
+  });
+
+  it('injected client → uses that client instead of the env singleton', async () => {
+    const instanceGetUsage = vi.fn().mockResolvedValue({ byUser: [] });
+    const a = new PymthouseAdapter({
+      client: { getUsage: instanceGetUsage } as never,
+      isConfigured: () => true,
+    });
+    await a.getAppUsage(WINDOW);
+    expect(instanceGetUsage).toHaveBeenCalled();
+    expect(getUsage).not.toHaveBeenCalled();
+  });
+
+  it('isConfigured honors the injected override, else delegates to the env check', () => {
+    expect(new PymthouseAdapter({ isConfigured: () => false }).isConfigured()).toBe(false);
+    expect(new PymthouseAdapter().isConfigured()).toBe(true);
+  });
+});
+
 describe('PymthouseAdapter.getSpend', () => {
   it('scoped pull: asks the provider for ONE external user and maps to a neutral record', async () => {
     fetchUsageForExternalUser.mockResolvedValue({

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -12,7 +12,7 @@ import 'server-only';
 
 import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
 
-import type { MeScopeUsagePayload, UsageApiResponse } from '@pymthouse/builder-sdk';
+import type { MeScopeUsagePayload, PmtHouseClient, UsageApiResponse } from '@pymthouse/builder-sdk';
 
 import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
 import { isFeatureEnabled, PYMTHOUSE_BPP_VALIDATE_FLAG } from '@/lib/feature-flags';
@@ -35,11 +35,42 @@ import {
 
 export const PYMTHOUSE_ADAPTER_SLUG = 'pymthouse';
 
+/**
+ * Optional per-instance overrides (P0, `provider_instances`). When omitted the
+ * adapter behaves EXACTLY as before — it talks to the global `PYMTHOUSE_*` env
+ * singleton (`getPmtHouseServerClient()`) and reports configuration via
+ * `isPymthouseConfigured()`. When the registry builds a per-`ProviderInstance`
+ * adapter it injects a `client` constructed from that instance's config/secret
+ * (so multiple pymthouse apps coexist) and an `isConfigured` that reflects the
+ * instance.
+ */
+export interface PymthouseAdapterOptions {
+  client?: PmtHouseClient;
+  isConfigured?: () => boolean;
+}
+
 export class PymthouseAdapter implements BillingProviderAdapter {
   readonly slug = PYMTHOUSE_ADAPTER_SLUG;
 
+  private readonly clientOverride?: PmtHouseClient;
+  private readonly isConfiguredOverride?: () => boolean;
+
+  constructor(options: PymthouseAdapterOptions = {}) {
+    this.clientOverride = options.client;
+    this.isConfiguredOverride = options.isConfigured;
+  }
+
+  /**
+   * The pymthouse client backing this adapter. Defaults to the global-env
+   * process singleton (today's behavior) unless a per-instance client was
+   * injected at construction.
+   */
+  private client(): PmtHouseClient {
+    return this.clientOverride ?? getPmtHouseServerClient();
+  }
+
   isConfigured(): boolean {
-    return isPymthouseConfigured();
+    return this.isConfiguredOverride ? this.isConfiguredOverride() : isPymthouseConfigured();
   }
 
   /**
@@ -70,7 +101,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
   }
 
   async getUsageForExternalUser(input: UsageForExternalUserInput): Promise<unknown> {
-    return getPmtHouseServerClient().fetchUsageForExternalUser({
+    return this.client().fetchUsageForExternalUser({
       externalUserId: input.externalUserId,
       startDate: input.startDate,
       endDate: input.endDate,
@@ -79,7 +110,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
   }
 
   async getAppUsage(input: AppUsageInput): Promise<unknown> {
-    return getPmtHouseServerClient().getUsage({
+    return this.client().getUsage({
       startDate: input.startDate,
       endDate: input.endDate,
       ...(input.groupBy ? { groupBy: input.groupBy } : {}),
@@ -101,7 +132,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
    *    pulls to system:admin).
    */
   async getSpend(scope: ProviderSpendScope): Promise<ProviderSpendResult> {
-    const client = getPmtHouseServerClient();
+    const client = this.client();
 
     if (scope.accountId) {
       const payload: MeScopeUsagePayload = await client.fetchUsageForExternalUser({
@@ -167,7 +198,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
   }
 
   async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken> {
-    const session = await getPmtHouseServerClient().mintSignerSessionForExternalUser({
+    const session = await this.client().mintSignerSessionForExternalUser({
       externalUserId: input.externalUserId,
       ...(input.email != null ? { email: input.email } : {}),
     });

--- a/apps/web-next/src/lib/billing/registry-db-instance.test.ts
+++ b/apps/web-next/src/lib/billing/registry-db-instance.test.ts
@@ -1,0 +1,226 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    billingProvider: { findUnique: vi.fn() },
+    providerInstance: { findUnique: vi.fn() },
+    secretVault: { findUnique: vi.fn() },
+  },
+}));
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  PROVIDER_INSTANCES_FLAG: 'provider_instances',
+  PYMTHOUSE_BPP_VALIDATE_FLAG: 'pymthouse_bpp_validate',
+}));
+
+const createPmtHouseClient = vi.fn();
+const getPmtHouseServerClient = vi.fn();
+vi.mock('@/lib/pymthouse-client', () => ({
+  createPmtHouseClient: (...a: unknown[]) => createPmtHouseClient(...a),
+  getPmtHouseServerClient: (...a: unknown[]) => getPmtHouseServerClient(...a),
+}));
+
+const decryptV1 = vi.fn();
+vi.mock('@naap/crypto', () => ({
+  decryptV1: (...a: unknown[]) => decryptV1(...a),
+}));
+
+vi.mock('@pymthouse/builder-sdk/config', () => ({
+  isPymthouseConfigured: () => true,
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  PROVIDER_INSTANCES_FLAG,
+  resolveAdapterForProviderInstance,
+  resetAdapterFactoriesForTests,
+  resetProviderInstanceAdapterCacheForTests,
+} from './registry-db';
+
+const providerInstanceFindUnique = prisma.providerInstance.findUnique as ReturnType<typeof vi.fn>;
+const secretFindUnique = prisma.secretVault.findUnique as ReturnType<typeof vi.fn>;
+
+const CONFIG_ACME = {
+  issuerUrl: 'https://acme.pymthouse.com',
+  publicClientId: 'app_acme',
+  m2mClientId: 'm2m_acme',
+};
+
+const WINDOW = { startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-31T23:59:59.999Z' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetAdapterFactoriesForTests();
+  resetProviderInstanceAdapterCacheForTests();
+});
+
+afterEach(() => {
+  resetAdapterFactoriesForTests();
+  resetProviderInstanceAdapterCacheForTests();
+});
+
+describe('resolveAdapterForProviderInstance — flag exposure', () => {
+  it('exposes the canonical flag key', () => {
+    expect(PROVIDER_INSTANCES_FLAG).toBe('provider_instances');
+  });
+});
+
+describe('INV-availability: provider_instances OFF → global-env single-app path unchanged', () => {
+  beforeEach(() => isFeatureEnabled.mockResolvedValue(false));
+
+  it('returns the default env-backed pymthouse adapter and reads NEITHER ProviderInstance NOR SecretVault', async () => {
+    const res = await resolveAdapterForProviderInstance('pymthouse-acme');
+
+    expect(res.source).toBe('flag-off-default-env');
+    expect(res.providerInstanceId).toBeNull();
+    expect(res.adapter?.slug).toBe('pymthouse');
+    expect(providerInstanceFindUnique).not.toHaveBeenCalled();
+    expect(secretFindUnique).not.toHaveBeenCalled();
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+
+  it('the flag-OFF adapter talks to the global-env client singleton (today\'s behavior)', async () => {
+    const envClient = { getUsage: vi.fn().mockResolvedValue({ byUser: [] }) };
+    getPmtHouseServerClient.mockReturnValue(envClient);
+
+    const res = await resolveAdapterForProviderInstance('pymthouse-acme');
+    await res.adapter!.getAppUsage(WINDOW);
+
+    expect(getPmtHouseServerClient).toHaveBeenCalled();
+    expect(envClient.getUsage).toHaveBeenCalled();
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('flag ON → per-ProviderInstance adapter construction', () => {
+  beforeEach(() => isFeatureEnabled.mockResolvedValue(true));
+
+  it('builds a per-config adapter from the instance config + vault secret', async () => {
+    providerInstanceFindUnique.mockResolvedValue({
+      id: 'pi_acme',
+      adapterType: 'pymthouse',
+      slug: 'pymthouse-acme',
+      config: { ...CONFIG_ACME },
+      secretRef: 'pmt:acme:m2m',
+      enabled: true,
+    });
+    secretFindUnique.mockResolvedValue({ encryptedValue: 'v1' });
+    decryptV1.mockReturnValue('acme-secret');
+    const acmeClient = { getUsage: vi.fn().mockResolvedValue({ byUser: [] }) };
+    createPmtHouseClient.mockReturnValue(acmeClient);
+
+    const res = await resolveAdapterForProviderInstance('pymthouse-acme');
+
+    expect(res.source).toBe('instance');
+    expect(res.providerInstanceId).toBe('pi_acme');
+    expect(res.adapterType).toBe('pymthouse');
+    expect(createPmtHouseClient).toHaveBeenCalledWith({ ...CONFIG_ACME, m2mClientSecret: 'acme-secret' });
+
+    // The adapter uses the INSTANCE client, not the global-env singleton.
+    await res.adapter!.getAppUsage(WINDOW);
+    expect(acmeClient.getUsage).toHaveBeenCalled();
+    expect(getPmtHouseServerClient).not.toHaveBeenCalled();
+  });
+
+  it('caches the adapter by ProviderInstance id (one client build per instance)', async () => {
+    providerInstanceFindUnique.mockResolvedValue({
+      id: 'pi_acme',
+      adapterType: 'pymthouse',
+      slug: 'pymthouse-acme',
+      config: { ...CONFIG_ACME },
+      secretRef: 'pmt:acme:m2m',
+      enabled: true,
+    });
+    secretFindUnique.mockResolvedValue({ encryptedValue: 'v1' });
+    decryptV1.mockReturnValue('acme-secret');
+    createPmtHouseClient.mockReturnValue({ getUsage: vi.fn() });
+
+    const first = await resolveAdapterForProviderInstance('pymthouse-acme');
+    const second = await resolveAdapterForProviderInstance('pymthouse-acme');
+
+    expect(first.adapter).toBe(second.adapter);
+    expect(createPmtHouseClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('multiple pymthouse instances coexist as distinct adapters/clients', async () => {
+    const clientA = { tag: 'A' };
+    const clientB = { tag: 'B' };
+    createPmtHouseClient.mockReturnValueOnce(clientA).mockReturnValueOnce(clientB);
+    secretFindUnique.mockResolvedValue({ encryptedValue: 'v1' });
+    decryptV1.mockReturnValue('secret');
+
+    providerInstanceFindUnique.mockResolvedValueOnce({
+      id: 'pi_a',
+      adapterType: 'pymthouse',
+      slug: 'pymthouse-a',
+      config: { ...CONFIG_ACME, publicClientId: 'app_a' },
+      secretRef: 'pmt:a',
+      enabled: true,
+    });
+    providerInstanceFindUnique.mockResolvedValueOnce({
+      id: 'pi_b',
+      adapterType: 'pymthouse',
+      slug: 'pymthouse-b',
+      config: { ...CONFIG_ACME, publicClientId: 'app_b' },
+      secretRef: 'pmt:b',
+      enabled: true,
+    });
+
+    const a = await resolveAdapterForProviderInstance('pymthouse-a');
+    const b = await resolveAdapterForProviderInstance('pymthouse-b');
+
+    expect(a.providerInstanceId).toBe('pi_a');
+    expect(b.providerInstanceId).toBe('pi_b');
+    expect(a.adapter).not.toBe(b.adapter);
+    expect(createPmtHouseClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the default env adapter when the instance row is missing', async () => {
+    providerInstanceFindUnique.mockResolvedValue(null);
+    const res = await resolveAdapterForProviderInstance('does-not-exist');
+    expect(res.source).toBe('instance-missing-default-env');
+    expect(res.adapter?.slug).toBe('pymthouse');
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default env adapter when the instance is disabled', async () => {
+    providerInstanceFindUnique.mockResolvedValue({
+      id: 'pi_off',
+      adapterType: 'pymthouse',
+      slug: 'pymthouse-off',
+      config: { ...CONFIG_ACME },
+      secretRef: 'pmt:off',
+      enabled: false,
+    });
+    const res = await resolveAdapterForProviderInstance('pymthouse-off');
+    expect(res.source).toBe('instance-missing-default-env');
+    expect(res.adapter?.slug).toBe('pymthouse');
+  });
+
+  it('falls back to the default env adapter when the secret cannot be resolved', async () => {
+    providerInstanceFindUnique.mockResolvedValue({
+      id: 'pi_acme',
+      adapterType: 'pymthouse',
+      slug: 'pymthouse-acme',
+      config: { ...CONFIG_ACME },
+      secretRef: 'pmt:acme:m2m',
+      enabled: true,
+    });
+    secretFindUnique.mockResolvedValue(null);
+    const res = await resolveAdapterForProviderInstance('pymthouse-acme');
+    expect(res.source).toBe('instance-error-default-env');
+    expect(res.adapter?.slug).toBe('pymthouse');
+    expect(createPmtHouseClient).not.toHaveBeenCalled();
+  });
+
+  it('never hard-fails when the DB lookup throws (keeps global-env behavior)', async () => {
+    providerInstanceFindUnique.mockRejectedValue(new Error('connection refused'));
+    const res = await resolveAdapterForProviderInstance('pymthouse-acme');
+    expect(res.source).toBe('instance-error-default-env');
+    expect(res.adapter?.slug).toBe('pymthouse');
+  });
+});

--- a/apps/web-next/src/lib/billing/registry-db.ts
+++ b/apps/web-next/src/lib/billing/registry-db.ts
@@ -20,14 +20,17 @@
 import 'server-only';
 
 import { prisma } from '@/lib/db';
-import { isFeatureEnabled } from '@/lib/feature-flags';
+import { isFeatureEnabled, PROVIDER_INSTANCES_FLAG } from '@/lib/feature-flags';
 
 import type { BillingProviderAdapter } from './adapter';
-import { PymthouseAdapter } from './pymthouse-adapter';
+import { PymthouseAdapter, PYMTHOUSE_ADAPTER_SLUG } from './pymthouse-adapter';
 import { StubAdapter } from './stub-adapter';
 import { getBillingProviderAdapter } from './registry';
+import { buildAdapterForProviderInstance } from './provider-instance';
 
 export const DB_ADAPTER_REGISTRY_FLAG = 'db_adapter_registry';
+
+export { PROVIDER_INSTANCES_FLAG } from '@/lib/feature-flags';
 
 /** How a provider's adapter was resolved (for structured logging/telemetry). */
 export type AdapterResolutionSource =
@@ -126,6 +129,122 @@ export async function resolveBillingProviderAdapter(
   return (await resolveBillingProviderAdapterDetailed(slug)).adapter;
 }
 
+// ── Per-ProviderInstance resolution (NAAP P0, `provider_instances`) ──
+
+/** How a per-instance adapter was resolved (for structured logging/telemetry). */
+export type InstanceResolutionSource =
+  | 'flag-off-default-env' // flag OFF → today's global PYMTHOUSE_* env path (no DB read)
+  | 'instance' // built per-config from the ProviderInstance row
+  | 'instance-missing-default-env' // flag ON but row missing/disabled → default env
+  | 'instance-error-default-env'; // flag ON but config/secret/DB unusable → default env
+
+export interface InstanceAdapterResolution {
+  adapter: BillingProviderAdapter | undefined;
+  source: InstanceResolutionSource;
+  providerInstanceId: string | null;
+  adapterType: string;
+}
+
+/**
+ * Memoized per-instance adapters, keyed by `ProviderInstance.id` (NOT
+ * adapterType) so multiple pymthouse apps each get their own client/creds.
+ */
+let instanceAdapterCache: Map<string, BillingProviderAdapter> = new Map();
+
+/**
+ * Resolve a `BillingProviderAdapter` for a `ProviderInstance` slug.
+ *
+ * Flag-gated by `provider_instances` (default OFF):
+ *  - OFF → returns the DEFAULT env-backed adapter for `fallbackAdapterType`
+ *    (today's single-app global-env path) with NO `ProviderInstance`/`SecretVault`
+ *    read — byte-for-byte today's behavior (zero regression).
+ *  - ON  → look up the instance by slug; build a per-config adapter from its
+ *    `config` + `secretRef` (cached by instance id). On a missing/disabled row,
+ *    incomplete config, unresolved secret, or any DB error it FALLS BACK to the
+ *    default env adapter (never hard-fails). Returns the resolution source so
+ *    callers can log/telemeter without re-querying. Never logs secrets.
+ */
+export async function resolveAdapterForProviderInstance(
+  instanceSlug: string,
+  fallbackAdapterType: string = PYMTHOUSE_ADAPTER_SLUG,
+): Promise<InstanceAdapterResolution> {
+  let flagOn = false;
+  try {
+    flagOn = await isFeatureEnabled(PROVIDER_INSTANCES_FLAG);
+  } catch {
+    flagOn = false;
+  }
+
+  if (!flagOn) {
+    return {
+      adapter: instantiate(fallbackAdapterType),
+      source: 'flag-off-default-env',
+      providerInstanceId: null,
+      adapterType: fallbackAdapterType,
+    };
+  }
+
+  try {
+    const row = await prisma.providerInstance.findUnique({
+      where: { slug: instanceSlug },
+      select: {
+        id: true,
+        adapterType: true,
+        slug: true,
+        config: true,
+        secretRef: true,
+        enabled: true,
+      },
+    });
+
+    if (!row || !row.enabled) {
+      return {
+        adapter: instantiate(fallbackAdapterType),
+        source: 'instance-missing-default-env',
+        providerInstanceId: null,
+        adapterType: fallbackAdapterType,
+      };
+    }
+
+    const cached = instanceAdapterCache.get(row.id);
+    if (cached) {
+      return {
+        adapter: cached,
+        source: 'instance',
+        providerInstanceId: row.id,
+        adapterType: row.adapterType,
+      };
+    }
+
+    const built = await buildAdapterForProviderInstance(row);
+    if (built) {
+      instanceAdapterCache.set(row.id, built);
+      return {
+        adapter: built,
+        source: 'instance',
+        providerInstanceId: row.id,
+        adapterType: row.adapterType,
+      };
+    }
+
+    // Config-free adapterType (e.g. stub) or unusable creds → default factory.
+    return {
+      adapter: instantiate(row.adapterType) ?? instantiate(fallbackAdapterType),
+      source: 'instance-error-default-env',
+      providerInstanceId: row.id,
+      adapterType: row.adapterType,
+    };
+  } catch {
+    // DB unavailable / lagging → never hard-fail; keep the global-env behavior.
+    return {
+      adapter: instantiate(fallbackAdapterType),
+      source: 'instance-error-default-env',
+      providerInstanceId: null,
+      adapterType: fallbackAdapterType,
+    };
+  }
+}
+
 // ── Test seams ──
 
 /** Register/override an adapterType factory (tests / future dynamic config). */
@@ -141,4 +260,9 @@ export function registerAdapterFactoryForTests(
 export function resetAdapterFactoriesForTests(): void {
   factories = buildDefaultFactories();
   instanceCache = new Map();
+}
+
+/** Clear the per-ProviderInstance adapter cache (test isolation). */
+export function resetProviderInstanceAdapterCacheForTests(): void {
+  instanceAdapterCache = new Map();
 }

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -31,6 +31,18 @@ export const SDK_CONNECTOR_FLAG = 'sdk_connector';
  */
 export const PYMTHOUSE_BPP_VALIDATE_FLAG = 'pymthouse_bpp_validate';
 
+/**
+ * Canonical key for the multi-app `ProviderInstance` foundation (P0, default
+ * OFF). When OFF, billing-provider resolution falls back to the global
+ * `PYMTHOUSE_*` env single-app path EXACTLY as today (zero regression) and the
+ * `ProviderInstance` table is never read. When ON, the adapter registry can
+ * resolve a per-`ProviderInstance` adapter built from that instance's non-secret
+ * `config` + a `secretRef` → `SecretVault` M2M secret, so multiple pymthouse
+ * apps can coexist. Shared by KNOWN_FLAGS and the registry so the name cannot
+ * drift.
+ */
+export const PROVIDER_INSTANCES_FLAG = 'provider_instances';
+
 export const KNOWN_FLAGS: KnownFlag[] = [
   {
     key: 'enableTeams',
@@ -102,6 +114,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: false,
     description:
       'Resolve a validated key\'s capabilities LIVE from the pymthouse provider (BPP ②) via the M2M client, keyed on the account\'s externalUserId, and surface them at the validation front door. OFF = PymthouseAdapter.validate() is unimplemented (front door falls back to an empty capability set, exactly as today). Requires the provider\'s BPP_VALIDATE_V2 posture in the same environment; pairs with capability_gate (also default OFF).',
+  },
+  {
+    key: PROVIDER_INSTANCES_FLAG,
+    enabled: false,
+    description:
+      'Multi-app foundation (P0): resolve a per-ProviderInstance billing adapter built from the instance\'s non-secret config + a secretRef → SecretVault M2M secret, so multiple pymthouse apps can coexist. OFF = ProviderInstance table is never read and resolution falls back to the global PYMTHOUSE_* env single-app path exactly as today (zero regression).',
   },
 ];
 

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -15,7 +15,7 @@ import {
   type SignerSessionToken,
 } from '@pymthouse/builder-sdk';
 import { createPmtHouseClientFromEnv } from '@pymthouse/builder-sdk/env';
-import type { PmtHouseClient } from '@pymthouse/builder-sdk';
+import { PmtHouseClient } from '@pymthouse/builder-sdk';
 
 const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
 const SUBJECT_ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
@@ -28,6 +28,48 @@ export function getPmtHouseServerClient(): PmtHouseClient {
     cached = createPmtHouseClientFromEnv();
   }
   return cached;
+}
+
+/**
+ * Non-secret connection params for a pymthouse instance, plus the resolved M2M
+ * client secret. Mirrors the env shape `createPmtHouseClientFromEnv` builds, but
+ * sourced explicitly (e.g. from a `ProviderInstance.config` + `SecretVault`)
+ * rather than from global `PYMTHOUSE_*` env. The secret is passed in resolved;
+ * this module never reads or logs it.
+ */
+export interface PmtHouseClientConfig {
+  issuerUrl: string;
+  publicClientId: string;
+  m2mClientId: string;
+  m2mClientSecret: string;
+  allowInsecureHttp?: boolean;
+}
+
+/**
+ * Build a `PmtHouseClient` from an explicit per-instance config (NOT global
+ * env), so multiple pymthouse apps can coexist in one process. Unlike
+ * `getPmtHouseServerClient()` this is NOT a process singleton — the caller owns
+ * caching (e.g. the registry caches per `ProviderInstance.id`). Logging matches
+ * the env client: structured `[pymthouse]` lines that never include the secret.
+ */
+export function createPmtHouseClient(config: PmtHouseClientConfig): PmtHouseClient {
+  return new PmtHouseClient({
+    issuerUrl: config.issuerUrl,
+    publicClientId: config.publicClientId,
+    m2mClientId: config.m2mClientId,
+    m2mClientSecret: config.m2mClientSecret,
+    allowInsecureHttp: config.allowInsecureHttp ?? config.issuerUrl.startsWith('http:'),
+    logger: {
+      debug: (message: string, details?: unknown) => {
+        if (process.env.NODE_ENV !== 'production') {
+          console.debug(`[pymthouse] ${message}`, details ?? {});
+        }
+      },
+      warn: (message: string, details?: unknown) => {
+        console.warn(`[pymthouse] ${message}`, details ?? {});
+      },
+    },
+  });
 }
 
 /** Vitest / isolated tests: clear module-level singleton. */

--- a/packages/database/prisma/migrations/20260624120000_add_provider_instance/migration.sql
+++ b/packages/database/prisma/migrations/20260624120000_add_provider_instance/migration.sql
@@ -1,0 +1,30 @@
+-- NAAP P0: ProviderInstance — per-app provider instance (EXPAND-ONLY, additive).
+--
+-- Multi-app foundation. `BillingProvider` stays the adapter-TYPE catalog
+-- (slug @unique, unchanged); `ProviderInstance` is the per-APP row so MANY
+-- instances may share one `adapterType` (e.g. multiple pymthouse apps). Per-app
+-- creds move OUT of global env: `config` holds NON-SECRET connection params,
+-- `secretRef` points at a SecretVault.key holding the M2M secret (never the
+-- value). Purely additive — no existing table/column/constraint is touched, so
+-- with the `provider_instances` flag OFF nothing reads this table and behavior
+-- is unchanged (zero regression). Idempotent (IF NOT EXISTS) for safe re-apply.
+CREATE TABLE IF NOT EXISTS "public"."ProviderInstance" (
+    "id" TEXT NOT NULL,
+    "adapterType" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "config" JSONB,
+    "secretRef" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProviderInstance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "ProviderInstance_slug_key" ON "public"."ProviderInstance"("slug");
+CREATE INDEX IF NOT EXISTS "ProviderInstance_adapterType_idx" ON "public"."ProviderInstance"("adapterType");
+CREATE INDEX IF NOT EXISTS "ProviderInstance_enabled_idx" ON "public"."ProviderInstance"("enabled");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -197,6 +197,38 @@ model BillingProvider {
   @@schema("public")
 }
 
+// NAAP P0 — per-app provider instance (multi-app foundation).
+//
+// `BillingProvider` stays the adapter-TYPE catalog (slug @unique, one row per
+// provider family). `ProviderInstance` is the per-APP row: MANY instances may
+// share one `adapterType` (e.g. multiple pymthouse apps), each with its own
+// credentials. Per-app creds live here OUT of global env:
+//   - `config` holds NON-SECRET connection params only
+//     (e.g. { issuerUrl, publicClientId, m2mClientId, allowInsecureHttp }).
+//   - `secretRef` points at a `SecretVault.key` holding the M2M client secret;
+//     it NEVER stores the secret value itself.
+// Gated by the `provider_instances` flag (default OFF): with the flag OFF this
+// table is never read and resolution falls back to the global PYMTHOUSE_* env
+// single-app path (zero regression). Expand-only / additive — no existing
+// column or constraint changes.
+model ProviderInstance {
+  id          String   @id @default(uuid())
+  adapterType String
+  slug        String   @unique
+  displayName String
+  config      Json?
+  secretRef   String?
+  status      String   @default("active")
+  enabled     Boolean  @default(true)
+  sortOrder   Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([adapterType])
+  @@index([enabled])
+  @@schema("public")
+}
+
 model BillingProviderOAuthSession {
   loginSessionId    String    @id
   state             String    @unique


### PR DESCRIPTION
## Summary

Phase **P0** of the approved Multi-App / Multi-Provider Billing plan. Lays the `ProviderInstance` foundation + per-config adapter construction so multiple pymthouse apps can coexist — **expand-only, flag-gated, zero regression**. Does **not** start P1.

- **`ProviderInstance` model + expand-only migration.** `BillingProvider` stays the adapter-TYPE catalog (`slug @unique` preserved — per the plan's recommended M1 path; multiple instances are represented as `ProviderInstance` rows, each with its own unique instance slug). Per-app creds move OUT of global env into a **non-secret** `config` (issuerUrl / publicClientId / m2mClientId / allowInsecureHttp) plus a `secretRef` → `SecretVault` holding the M2M secret (never the value). The `PYMTHOUSE_*` env path is **kept** as the default/fallback.
- **Per-config client.** `createPmtHouseClient(config)` builds a `PmtHouseClient` from explicit config; the `getPmtHouseServerClient()` env singleton is unchanged.
- **Per-instance adapter.** `PymthouseAdapter` takes optional `{ client, isConfigured }` overrides; with no override it talks to the global-env singleton exactly as before.
- **Registry resolution.** `resolveAdapterForProviderInstance()` in `registry-db.ts` reads the instance `config`/`secretRef` and builds a per-config adapter cached by `ProviderInstance.id` (multiple pymthouse instances coexist).

## Feature flag

New flag **`provider_instances`**, **default OFF**. With it OFF, resolution returns the default env-backed adapter and performs **no** `ProviderInstance`/`SecretVault` read — byte-for-byte today's single-app `PYMTHOUSE_*` path. ON → per-config construction, with fallback to the env adapter on any missing/disabled row, incomplete config, unresolved secret, or DB error (never hard-fails).

## Guardrails

- Additive + expand-only migration; no destructive change; env path retained.
- **INV-availability** test: flag OFF ⇒ global-env single-app path unchanged (no DB/vault read; adapter uses the env client singleton).
- **INV-secret-isolation** test: `config` never surfaces a secret value; secrets resolve only via `SecretVault`; nothing logs the secret.
- Focused unit tests for per-config construction, multi-instance coexistence, per-id caching, and all fallback paths (flag ON).

## Test plan

- [x] `pnpm vitest` (web-next): **111 files, 1097 passed, 1 skipped**.
- [x] `tsc --noEmit`: no errors in touched files (remaining errors are pre-existing baseline, verified by stashing this PR's changes and re-running tsc — identical error set).
- [ ] Migration applied in preview (`prisma migrate deploy`).
- [ ] Verify flag stays OFF in preview (no behavior change).

Made with [Cursor](https://cursor.com)