### PR TITLE
feat(billing): Subscription model + DevApiKey.subscriptionId (P1)

### DIFF
--- a/apps/web-next/src/lib/billing/backfill-subscriptions.test.ts
+++ b/apps/web-next/src/lib/billing/backfill-subscriptions.test.ts
@@ -1,0 +1,145 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    providerInstance: { findUnique: vi.fn(), create: vi.fn() },
+    team: { findMany: vi.fn() },
+    subscription: { findFirst: vi.fn(), create: vi.fn() },
+    devApiKey: { updateMany: vi.fn() },
+  },
+}));
+
+const readPymthouseEnv = vi.fn();
+vi.mock('@pymthouse/builder-sdk/config', () => ({
+  readPymthouseEnv: () => readPymthouseEnv(),
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  backfillDefaultSubscriptions,
+  DEFAULT_PYMTHOUSE_INSTANCE_SLUG,
+  DEFAULT_PYMTHOUSE_SECRET_REF,
+} from './backfill-subscriptions';
+
+const providerFindUnique = prisma.providerInstance.findUnique as ReturnType<typeof vi.fn>;
+const providerCreate = prisma.providerInstance.create as ReturnType<typeof vi.fn>;
+const teamFindMany = prisma.team.findMany as ReturnType<typeof vi.fn>;
+const subFindFirst = prisma.subscription.findFirst as ReturnType<typeof vi.fn>;
+const subCreate = prisma.subscription.create as ReturnType<typeof vi.fn>;
+const keyUpdateMany = prisma.devApiKey.updateMany as ReturnType<typeof vi.fn>;
+
+const ENV = {
+  issuerUrl: 'https://staging.pymthouse.com',
+  publicClientId: 'app_default',
+  m2mClientId: 'm2m_default',
+  m2mClientSecret: 'TOP-SECRET-VALUE',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('backfillDefaultSubscriptions', () => {
+  it('is a no-op when the global pymthouse env is not configured', async () => {
+    readPymthouseEnv.mockReturnValue(null);
+    const res = await backfillDefaultSubscriptions();
+    expect(res.ran).toBe(false);
+    expect(res.subscriptionsCreated).toBe(0);
+    expect(res.keysLinked).toBe(0);
+    expect(providerCreate).not.toHaveBeenCalled();
+    expect(teamFindMany).not.toHaveBeenCalled();
+  });
+
+  it('first run: seeds the default instance, default subscriptions, and links unlinked keys', async () => {
+    readPymthouseEnv.mockReturnValue(ENV);
+    providerFindUnique.mockResolvedValue(null);
+    providerCreate.mockResolvedValue({ id: 'pi_default' });
+    teamFindMany.mockResolvedValue([
+      { id: 't1', billingAccountId: 'acct_1' },
+      { id: 't2', billingAccountId: 'acct_2' },
+    ]);
+    subFindFirst.mockResolvedValue(null);
+    subCreate.mockResolvedValueOnce({ id: 'sub_1' }).mockResolvedValueOnce({ id: 'sub_2' });
+    keyUpdateMany.mockResolvedValueOnce({ count: 3 }).mockResolvedValueOnce({ count: 1 });
+
+    const res = await backfillDefaultSubscriptions();
+
+    expect(res.ran).toBe(true);
+    expect(res.providerInstanceId).toBe('pi_default');
+    expect(res.providerInstanceCreated).toBe(true);
+    expect(res.subscriptionsCreated).toBe(2);
+    expect(res.keysLinked).toBe(4);
+
+    // Only pymthouse-bound, account-set teams are backfilled.
+    expect(teamFindMany).toHaveBeenCalledWith({
+      where: {
+        billingAccountProviderSlug: 'pymthouse',
+        billingAccountId: { not: null },
+      },
+      select: { id: true, billingAccountId: true },
+    });
+
+    // Default subscription points at the default instance with the team's account.
+    expect(subCreate).toHaveBeenCalledWith({
+      data: {
+        teamId: 't1',
+        providerInstanceId: 'pi_default',
+        providerPlanId: null,
+        accountId: 'acct_1',
+        status: 'active',
+      },
+      select: { id: true },
+    });
+
+    // Only UNLINKED keys are linked (subscriptionId: null filter).
+    expect(keyUpdateMany).toHaveBeenCalledWith({
+      where: { teamId: 't1', subscriptionId: null },
+      data: { subscriptionId: 'sub_1' },
+    });
+  });
+
+  it('INV-secret-isolation: the seeded instance config never contains the M2M secret value', async () => {
+    readPymthouseEnv.mockReturnValue(ENV);
+    providerFindUnique.mockResolvedValue(null);
+    providerCreate.mockResolvedValue({ id: 'pi_default' });
+    teamFindMany.mockResolvedValue([]);
+
+    await backfillDefaultSubscriptions();
+
+    const createArg = providerCreate.mock.calls[0][0];
+    expect(createArg.data.slug).toBe(DEFAULT_PYMTHOUSE_INSTANCE_SLUG);
+    expect(createArg.data.secretRef).toBe(DEFAULT_PYMTHOUSE_SECRET_REF);
+    expect(createArg.data.config).toEqual({
+      issuerUrl: ENV.issuerUrl,
+      publicClientId: ENV.publicClientId,
+      m2mClientId: ENV.m2mClientId,
+    });
+    expect(JSON.stringify(createArg.data)).not.toContain(ENV.m2mClientSecret);
+  });
+
+  it('idempotent re-run: existing instance/subscriptions reused, no new rows, no re-link', async () => {
+    readPymthouseEnv.mockReturnValue(ENV);
+    providerFindUnique.mockResolvedValue({ id: 'pi_default' });
+    teamFindMany.mockResolvedValue([
+      { id: 't1', billingAccountId: 'acct_1' },
+      { id: 't2', billingAccountId: 'acct_2' },
+    ]);
+    subFindFirst.mockResolvedValueOnce({ id: 'sub_1' }).mockResolvedValueOnce({ id: 'sub_2' });
+    keyUpdateMany.mockResolvedValue({ count: 0 });
+
+    const res = await backfillDefaultSubscriptions();
+
+    expect(res.ran).toBe(true);
+    expect(res.providerInstanceCreated).toBe(false);
+    expect(res.subscriptionsCreated).toBe(0);
+    expect(res.keysLinked).toBe(0);
+    expect(providerCreate).not.toHaveBeenCalled();
+    expect(subCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-next/src/lib/billing/backfill-subscriptions.ts
+++ b/apps/web-next/src/lib/billing/backfill-subscriptions.ts
@@ -1,0 +1,176 @@
+/**
+ * Idempotent default-subscription backfill (NAAP P1).
+ *
+ * The P1 migration is a pure schema expand (no data writes), so existing keys
+ * keep `subscriptionId = NULL` and resolve via today's path. This module is the
+ * SEPARATE, explicitly-invoked, idempotent backfill an operator runs to seed the
+ * default multi-app rows for the existing single-app deployment:
+ *
+ *   1. the global `PYMTHOUSE_*` env app  → one default `ProviderInstance`
+ *      (`pymthouse-default`); config holds NON-SECRET params only, the M2M
+ *      secret is referenced by `secretRef` (a SecretVault key), never inlined.
+ *   2. each team bound to a pymthouse `billingAccountRef` → one default
+ *      `Subscription` (providerInstanceId = default, accountId = the team's
+ *      billing account id).
+ *   3. that team's keys with a NULL `subscriptionId` → linked to the default
+ *      subscription.
+ *
+ * Every step is idempotent (re-running creates/links nothing new) and additive —
+ * it never changes a team's billing account or a key's provider resolution
+ * (resolution only consults `subscriptionId` when `multi_subscription` is ON,
+ * which is a later phase). Never logs the secret.
+ */
+
+import 'server-only';
+
+import { readPymthouseEnv } from '@pymthouse/builder-sdk/config';
+
+import { prisma } from '@/lib/db';
+import { PYMTHOUSE_ADAPTER_SLUG } from './pymthouse-adapter';
+
+/** Slug of the default pymthouse instance seeded from the global env app. */
+export const DEFAULT_PYMTHOUSE_INSTANCE_SLUG = 'pymthouse-default';
+
+/**
+ * SecretVault key the default instance's `secretRef` points at. The backfill
+ * does NOT write the secret value (operators provision it in the vault); it only
+ * records the reference so the per-instance adapter can resolve it later.
+ */
+export const DEFAULT_PYMTHOUSE_SECRET_REF = 'pymthouse:default:m2m-secret';
+
+export const SUBSCRIPTION_STATUS_ACTIVE = 'active';
+
+export interface BackfillSubscriptionsResult {
+  /** False when the global pymthouse env is not configured (nothing to seed). */
+  ran: boolean;
+  providerInstanceId: string | null;
+  providerInstanceCreated: boolean;
+  subscriptionsCreated: number;
+  keysLinked: number;
+}
+
+/**
+ * Run the idempotent default-subscription backfill. Safe to call repeatedly:
+ * the second run reports 0 created / 0 linked. Returns counts for logging.
+ */
+export async function backfillDefaultSubscriptions(): Promise<BackfillSubscriptionsResult> {
+  const env = readPymthouseEnv();
+  if (!env) {
+    // No global pymthouse app configured → nothing to backfill (no-op).
+    return {
+      ran: false,
+      providerInstanceId: null,
+      providerInstanceCreated: false,
+      subscriptionsCreated: 0,
+      keysLinked: 0,
+    };
+  }
+
+  const { instanceId, created: providerInstanceCreated } =
+    await ensureDefaultProviderInstance(env);
+
+  const teams = await prisma.team.findMany({
+    where: {
+      billingAccountProviderSlug: PYMTHOUSE_ADAPTER_SLUG,
+      billingAccountId: { not: null },
+    },
+    select: { id: true, billingAccountId: true },
+  });
+
+  let subscriptionsCreated = 0;
+  let keysLinked = 0;
+
+  for (const team of teams) {
+    const accountId = team.billingAccountId;
+    if (!accountId) {
+      continue;
+    }
+
+    const subscriptionId = await ensureDefaultSubscription(team.id, instanceId, accountId);
+    if (subscriptionId.created) {
+      subscriptionsCreated += 1;
+    }
+
+    // Link only this team's UNLINKED keys; already-linked keys are left as-is.
+    const linked = await prisma.devApiKey.updateMany({
+      where: { teamId: team.id, subscriptionId: null },
+      data: { subscriptionId: subscriptionId.id },
+    });
+    keysLinked += linked.count;
+  }
+
+  return {
+    ran: true,
+    providerInstanceId: instanceId,
+    providerInstanceCreated,
+    subscriptionsCreated,
+    keysLinked,
+  };
+}
+
+/**
+ * Ensure the default `ProviderInstance` exists for the global env app. Stores
+ * only NON-SECRET config; `secretRef` points at the vault key. Idempotent: an
+ * existing row is reused untouched (operator edits are preserved).
+ */
+async function ensureDefaultProviderInstance(env: {
+  issuerUrl: string;
+  publicClientId: string;
+  m2mClientId: string;
+}): Promise<{ instanceId: string; created: boolean }> {
+  const existing = await prisma.providerInstance.findUnique({
+    where: { slug: DEFAULT_PYMTHOUSE_INSTANCE_SLUG },
+    select: { id: true },
+  });
+  if (existing) {
+    return { instanceId: existing.id, created: false };
+  }
+
+  const row = await prisma.providerInstance.create({
+    data: {
+      adapterType: PYMTHOUSE_ADAPTER_SLUG,
+      slug: DEFAULT_PYMTHOUSE_INSTANCE_SLUG,
+      displayName: 'Pymthouse (default)',
+      config: {
+        issuerUrl: env.issuerUrl,
+        publicClientId: env.publicClientId,
+        m2mClientId: env.m2mClientId,
+      },
+      secretRef: DEFAULT_PYMTHOUSE_SECRET_REF,
+      status: 'active',
+      enabled: true,
+    },
+    select: { id: true },
+  });
+  return { instanceId: row.id, created: true };
+}
+
+/**
+ * Ensure a default `Subscription` exists for (team, providerInstance, account).
+ * Idempotent via an existence check on that triple — re-runs create nothing.
+ */
+async function ensureDefaultSubscription(
+  teamId: string,
+  providerInstanceId: string,
+  accountId: string,
+): Promise<{ id: string; created: boolean }> {
+  const existing = await prisma.subscription.findFirst({
+    where: { teamId, providerInstanceId, accountId },
+    select: { id: true },
+  });
+  if (existing) {
+    return { id: existing.id, created: false };
+  }
+
+  const row = await prisma.subscription.create({
+    data: {
+      teamId,
+      providerInstanceId,
+      providerPlanId: null,
+      accountId,
+      status: SUBSCRIPTION_STATUS_ACTIVE,
+    },
+    select: { id: true },
+  });
+  return { id: row.id, created: true };
+}

--- a/apps/web-next/src/lib/billing/subscription.test.ts
+++ b/apps/web-next/src/lib/billing/subscription.test.ts
@@ -1,0 +1,100 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    subscription: { findUnique: vi.fn() },
+  },
+}));
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  MULTI_SUBSCRIPTION_FLAG: 'multi_subscription',
+}));
+
+import { prisma } from '@/lib/db';
+import { MULTI_SUBSCRIPTION_FLAG, resolveSubscriptionForKey } from './subscription';
+
+const findUnique = prisma.subscription.findUnique as ReturnType<typeof vi.fn>;
+
+const ACTIVE_ROW = {
+  id: 'sub_1',
+  teamId: 'team_1',
+  providerInstanceId: 'pi_default',
+  providerPlanId: null,
+  accountId: 'acct_1',
+  status: 'active',
+  appId: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveSubscriptionForKey', () => {
+  it('exposes the canonical flag key', () => {
+    expect(MULTI_SUBSCRIPTION_FLAG).toBe('multi_subscription');
+  });
+
+  describe('INV-availability: legacy path is byte-for-byte unchanged', () => {
+    it('flag OFF → legacy(flag_off) and NEVER reads the Subscription table (even if subscriptionId is set)', async () => {
+      isFeatureEnabled.mockResolvedValue(false);
+      const res = await resolveSubscriptionForKey({ subscriptionId: 'sub_1' });
+      expect(res).toEqual({ mode: 'legacy', reason: 'flag_off' });
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it('flag ON + null subscriptionId → legacy(no_subscription), no DB read (today\'s key behavior)', async () => {
+      isFeatureEnabled.mockResolvedValue(true);
+      const res = await resolveSubscriptionForKey({ subscriptionId: null });
+      expect(res).toEqual({ mode: 'legacy', reason: 'no_subscription' });
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON → subscription linkage', () => {
+    beforeEach(() => isFeatureEnabled.mockResolvedValue(true));
+
+    it('active subscription → resolves to the subscription row', async () => {
+      findUnique.mockResolvedValue(ACTIVE_ROW);
+      const res = await resolveSubscriptionForKey({ subscriptionId: 'sub_1' });
+      expect(res).toEqual({ mode: 'subscription', subscription: ACTIVE_ROW });
+      expect(findUnique).toHaveBeenCalledWith({
+        where: { id: 'sub_1' },
+        select: {
+          id: true,
+          teamId: true,
+          providerInstanceId: true,
+          providerPlanId: true,
+          accountId: true,
+          status: true,
+          appId: true,
+        },
+      });
+    });
+
+    it('missing row → fails closed to legacy(subscription_missing)', async () => {
+      findUnique.mockResolvedValue(null);
+      const res = await resolveSubscriptionForKey({ subscriptionId: 'sub_missing' });
+      expect(res).toEqual({ mode: 'legacy', reason: 'subscription_missing' });
+    });
+
+    it('non-active subscription → fails closed to legacy(subscription_inactive)', async () => {
+      findUnique.mockResolvedValue({ ...ACTIVE_ROW, status: 'canceled' });
+      const res = await resolveSubscriptionForKey({ subscriptionId: 'sub_1' });
+      expect(res).toEqual({ mode: 'legacy', reason: 'subscription_inactive' });
+    });
+
+    it('DB error → degrades to legacy(error), never throws', async () => {
+      findUnique.mockRejectedValue(new Error('connection refused'));
+      const res = await resolveSubscriptionForKey({ subscriptionId: 'sub_1' });
+      expect(res).toEqual({ mode: 'legacy', reason: 'error' });
+    });
+  });
+});

--- a/apps/web-next/src/lib/billing/subscription.ts
+++ b/apps/web-next/src/lib/billing/subscription.ts
@@ -1,0 +1,104 @@
+/**
+ * Subscription resolution foundation (NAAP P1, multi-subscription model).
+ *
+ * P1 adds the `Subscription` model + a nullable `DevApiKey.subscriptionId`. This
+ * module is the FLAG-GATED foundation that turns a key's `subscriptionId` into a
+ * `Subscription` row. It is intentionally NOT wired into the native-key resolver
+ * or the validation front door yet — that per-key resolution wiring lands in a
+ * later phase. Exposing it now lets P1 ship the model + an availability
+ * invariant without changing any live resolution path.
+ *
+ * Zero regression: when `multi_subscription` is OFF, or the key has no
+ * `subscriptionId`, this returns a `legacy` resolution so callers stay on
+ * today's `key → team → single billingAccountRef` path. Never logs secrets.
+ */
+
+import 'server-only';
+
+import { prisma } from '@/lib/db';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+
+export { MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+
+/** Active subscription status — others fail closed to the legacy path. */
+export const SUBSCRIPTION_STATUS_ACTIVE = 'active';
+
+/** Minimal `Subscription` shape resolution needs (subset of the Prisma row). */
+export interface SubscriptionRecord {
+  id: string;
+  teamId: string;
+  providerInstanceId: string;
+  providerPlanId: string | null;
+  accountId: string;
+  status: string;
+  appId: string | null;
+}
+
+/** Why a key fell back to the legacy (today's) resolution path. */
+export type LegacyReason =
+  | 'flag_off' // multi_subscription OFF
+  | 'no_subscription' // key has a null subscriptionId
+  | 'subscription_missing' // subscriptionId set but no row found
+  | 'subscription_inactive' // row found but status != active
+  | 'error'; // DB unavailable / lookup threw
+
+export type SubscriptionResolution =
+  | { mode: 'legacy'; reason: LegacyReason }
+  | { mode: 'subscription'; subscription: SubscriptionRecord };
+
+/**
+ * Resolve the `Subscription` a key is linked to, when the multi-subscription
+ * model is enabled.
+ *
+ *  - `multi_subscription` OFF → `{ mode: 'legacy', reason: 'flag_off' }`
+ *    (the table is never read).
+ *  - null `subscriptionId`     → `{ mode: 'legacy', reason: 'no_subscription' }`.
+ *  - row missing / not active  → `legacy` (fail closed to today's path).
+ *  - active row                → `{ mode: 'subscription', subscription }`.
+ *
+ * Callers treat any `legacy` result as "use today's team → single account
+ * resolution", so existing keys (null subscriptionId) are byte-for-byte
+ * unchanged. Never throws — DB errors degrade to `legacy`.
+ */
+export async function resolveSubscriptionForKey(key: {
+  subscriptionId: string | null;
+}): Promise<SubscriptionResolution> {
+  let flagOn = false;
+  try {
+    flagOn = await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG);
+  } catch {
+    flagOn = false;
+  }
+
+  if (!flagOn) {
+    return { mode: 'legacy', reason: 'flag_off' };
+  }
+  if (!key.subscriptionId) {
+    return { mode: 'legacy', reason: 'no_subscription' };
+  }
+
+  try {
+    const row = await prisma.subscription.findUnique({
+      where: { id: key.subscriptionId },
+      select: {
+        id: true,
+        teamId: true,
+        providerInstanceId: true,
+        providerPlanId: true,
+        accountId: true,
+        status: true,
+        appId: true,
+      },
+    });
+
+    if (!row) {
+      return { mode: 'legacy', reason: 'subscription_missing' };
+    }
+    if (row.status !== SUBSCRIPTION_STATUS_ACTIVE) {
+      return { mode: 'legacy', reason: 'subscription_inactive' };
+    }
+    return { mode: 'subscription', subscription: row };
+  } catch {
+    return { mode: 'legacy', reason: 'error' };
+  }
+}

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -43,6 +43,16 @@ export const PYMTHOUSE_BPP_VALIDATE_FLAG = 'pymthouse_bpp_validate';
  */
 export const PROVIDER_INSTANCES_FLAG = 'provider_instances';
 
+/**
+ * Canonical key for the multi-subscription model (P1, default OFF). When OFF, a
+ * key resolves via today's `key → team → single billingAccountRef` path and the
+ * `Subscription` table is never consulted (zero regression). When ON, a key
+ * MAY carry a `DevApiKey.subscriptionId` and resolution can hop through the
+ * subscription (the per-key resolution wiring itself lands in a later phase).
+ * Shared by KNOWN_FLAGS and the subscription resolver so the name cannot drift.
+ */
+export const MULTI_SUBSCRIPTION_FLAG = 'multi_subscription';
+
 export const KNOWN_FLAGS: KnownFlag[] = [
   {
     key: 'enableTeams',
@@ -120,6 +130,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: false,
     description:
       'Multi-app foundation (P0): resolve a per-ProviderInstance billing adapter built from the instance\'s non-secret config + a secretRef → SecretVault M2M secret, so multiple pymthouse apps can coexist. OFF = ProviderInstance table is never read and resolution falls back to the global PYMTHOUSE_* env single-app path exactly as today (zero regression).',
+  },
+  {
+    key: MULTI_SUBSCRIPTION_FLAG,
+    enabled: false,
+    description:
+      'Multi-subscription model (P1): a team may hold many concurrent Subscriptions and a DevApiKey may link to one via DevApiKey.subscriptionId. OFF = the Subscription table is never consulted and a key resolves via today\'s key → team → single billingAccountRef path (zero regression). A null subscriptionId always resolves the legacy way even when ON.',
   },
 ];
 

--- a/packages/database/prisma/migrations/20260624123000_add_subscription/migration.sql
+++ b/packages/database/prisma/migrations/20260624123000_add_subscription/migration.sql
@@ -1,0 +1,36 @@
+-- NAAP P1: Subscription model + DevApiKey.subscriptionId (EXPAND-ONLY, additive).
+--
+-- Multi-subscription foundation. A team may hold MANY concurrent subscriptions;
+-- a DevApiKey MAY link to one. Purely additive:
+--   - new `public.Subscription` table,
+--   - new NULLABLE `plugin_developer_api.DevApiKey.subscriptionId` column.
+-- No existing table/column/constraint is dropped or rewritten and NO data is
+-- backfilled here (expand → migrate → contract). Existing keys keep
+-- subscriptionId = NULL and resolve via today's key → team → single
+-- billingAccountRef path (zero regression). Idempotent (IF NOT EXISTS) for safe
+-- re-apply.
+
+-- CreateTable: Subscription (public)
+CREATE TABLE IF NOT EXISTS "public"."Subscription" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "providerInstanceId" TEXT NOT NULL,
+    "providerPlanId" TEXT,
+    "accountId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "appId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Subscription_teamId_status_idx" ON "public"."Subscription"("teamId", "status");
+CREATE INDEX IF NOT EXISTS "Subscription_providerInstanceId_idx" ON "public"."Subscription"("providerInstanceId");
+
+-- AlterTable: add nullable link from DevApiKey → Subscription (scalar, no FK)
+ALTER TABLE "plugin_developer_api"."DevApiKey" ADD COLUMN IF NOT EXISTS "subscriptionId" TEXT;
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "DevApiKey_subscriptionId_idx" ON "plugin_developer_api"."DevApiKey"("subscriptionId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -229,6 +229,31 @@ model ProviderInstance {
   @@schema("public")
 }
 
+// NAAP P1 — Subscription (multi-subscription model).
+//
+// A team may hold MANY concurrent subscriptions (vs today's single
+// `Team.billingAccountRef`). Each row points at a `ProviderInstance` (the
+// configured app) and carries the provider's opaque `accountId`. `providerPlanId`
+// stays NULLABLE until the synced plan-spec model lands (P4). `appId` optionally
+// attributes the subscription to a registered `Application`. Cross-schema FKs are
+// avoided (scalar references), matching the NAAP-1 pattern. Expand-only/additive;
+// gated by `multi_subscription` (default OFF) so nothing reads it until enabled.
+model Subscription {
+  id                 String   @id @default(uuid())
+  teamId             String
+  providerInstanceId String
+  providerPlanId     String?
+  accountId          String
+  status             String   @default("active")
+  appId              String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  @@index([teamId, status])
+  @@index([providerInstanceId])
+  @@schema("public")
+}
+
 model BillingProviderOAuthSession {
   loginSessionId    String    @id
   state             String    @unique
@@ -1830,6 +1855,12 @@ model DevApiKey {
   // additive — only native keys populate it.
   providerSessionRefEnc String?
   providerSessionRefIv  String?
+  // NAAP P1: optional link to a Subscription (multi-app). Scalar (no cross-schema
+  // FK; Subscription lives in `public`), nullable + additive. NULL ⇒ today's
+  // `key → team → single billingAccountRef` resolution (zero regression); a set
+  // value is consulted only when `multi_subscription` is ON (per-key resolution
+  // wiring lands in a later phase).
+  subscriptionId        String?
   createdAt             DateTime        @default(now())
   lastUsedAt            DateTime?
   revokedAt             DateTime?
@@ -1844,6 +1875,7 @@ model DevApiKey {
   @@index([keyLookupId])
   @@index([seatId])
   @@index([teamId])
+  @@index([subscriptionId])
   @@schema("plugin_developer_api")
 }
 


### PR DESCRIPTION
## Summary

Phase **P1** of the Multi-App / Multi-Provider Billing plan, **stacked on P0** (base = `feat/provider-instances-p0`, PR #398) so this diff is P1-only. **Expand-only, flag-gated, zero regression.** Does **not** start P2.

- **`Subscription` model** (`public`): a team may hold **many concurrent** subscriptions (vs today's single `Team.billingAccountRef`). Each row points at a `ProviderInstance` + the provider's opaque `accountId`. `providerPlanId` stays **nullable** until the synced plan-spec model (P4); `appId` is optional attribution. Cross-schema FKs avoided (scalar refs).
- **`DevApiKey.subscriptionId`** (`plugin_developer_api`): **nullable**, scalar, additive. NULL ⇒ today's `key → team → single billingAccountRef` resolution.
- **Migration is a pure schema expand** — **no data backfill**, so existing keys keep `subscriptionId = NULL` and resolve byte-for-byte as today.
- **`resolveSubscriptionForKey()` foundation** (`subscription.ts`): flag-gated. OFF or null `subscriptionId` → `legacy` (today's path); missing/inactive → fail closed to `legacy`; active → the subscription row. **Not wired** into the native-key resolver or front door yet (that per-key wiring is P2).
- **Idempotent backfill utility** (`backfill-subscriptions.ts`): an explicitly-invoked operator helper that seeds the default `ProviderInstance` (non-secret config + `secretRef`, never the secret value), one default `Subscription` per pymthouse-bound team, and links that team's unlinked keys. Re-runs create/link nothing.

## Feature flag

New flag **`multi_subscription`**, **default OFF**. With it OFF — and/or a null `subscriptionId` — resolution stays on today's `key → team → single account` path and the `Subscription` table is never consulted.

## Guardrails

- Additive + expand-only migration; nullable column; no destructive change; no backfill in the migration (existing key resolution outcomes unchanged).
- **INV-availability**: flag OFF / null `subscriptionId` ⇒ `legacy` with **no** table read (existing keys unchanged).
- **Backfill idempotency** test: second run creates 0 / links 0.
- **INV-secret-isolation** test: seeded instance `config` never carries the M2M secret value.
- Flag-ON subscription-linkage test.

## Test plan

- [x] `pnpm vitest` (web-next): **113 files, 1108 passed, 1 skipped** (+11 new).
- [x] `tsc --noEmit`: no errors in touched files (remaining errors are the pre-existing baseline — identical set to P0).
- [ ] Apply migration in preview (`prisma migrate deploy`).
- [ ] (Optional, operator) run `backfillDefaultSubscriptions()` once `provider_instances` env/vault is provisioned.

## Notes / deferral

- Per-key resolution wiring into the native-key resolver / validation front door is **P2** — intentionally not started.
- The backfill is an operator-invoked utility (a P3 admin/seed surface can call it); it does not auto-run, so keys stay NULL until deliberately backfilled, and even then resolution is unchanged while `multi_subscription` is OFF.
- Review/merge **after** P0 PR #398.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple subscriptions per team, with a safer fallback to the existing behavior when the new mode isn’t enabled.
  * Existing developer API keys can now be associated with a subscription, enabling more precise billing and access tracking.
  * Added a backfill path to populate default subscription data for eligible teams and link unassigned API keys.
* **Bug Fixes**
  * Improved handling of missing, inactive, or unavailable subscription data so resolution continues without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->