### PR TITLE
feat(billing): per-key subscription resolution in the live front door (P2)

### DIFF
--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -18,6 +18,11 @@ vi.mock('@/lib/billing/registry', () => ({
   getBillingProviderAdapter: (...a: unknown[]) => getBillingProviderAdapter(...a),
 }));
 
+const resolveKeyProviderBinding = vi.fn();
+vi.mock('@/lib/billing/key-provider-binding', () => ({
+  resolveKeyProviderBinding: (...a: unknown[]) => resolveKeyProviderBinding(...a),
+}));
+
 const prisma = vi.hoisted(() => ({
   devApiKey: { findUnique: vi.fn(), update: vi.fn() },
   team: { findUnique: vi.fn() },
@@ -66,6 +71,8 @@ beforeEach(() => {
   });
   prisma.devApiKey.update.mockResolvedValue({});
   getBillingProviderAdapter.mockReturnValue(adapterMock());
+  // Default: legacy binding → today's exact path (existing tests unchanged).
+  resolveKeyProviderBinding.mockResolvedValue({ mode: 'legacy', reason: 'flag_off' });
 });
 
 describe('flag OFF (zero regression / fallback)', () => {
@@ -165,6 +172,69 @@ describe('resolution (provider-agnostic, BPP ③)', () => {
   it('400 for a malformed X-App-Id', async () => {
     const res = await POST(req(rawKey, { 'x-app-id': 'bad id!' }));
     expect(res.status).toBe(400);
+  });
+});
+
+describe('P2 per-key subscription resolution (multi_subscription)', () => {
+  it('INV: legacy binding (flag OFF / null subscriptionId) is byte-for-byte today', async () => {
+    // Default binding is legacy. Resolution uses team account + global adapter.
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+    expect(d.billingAccount).toEqual({ id: 'acct_om_1', providerSlug: 'pymthouse' });
+    // The key's subscriptionId is consulted via the binding resolver…
+    expect(resolveKeyProviderBinding).toHaveBeenCalledTimes(1);
+    // …and on legacy the global registry adapter IS used (today's path).
+    expect(getBillingProviderAdapter).toHaveBeenCalledWith('pymthouse');
+  });
+
+  it('flag ON + linked subscription → per-instance adapter + per-account scoping', async () => {
+    prisma.devApiKey.findUnique.mockResolvedValue({
+      id: 'key-1', userId: 'user-1', keyHash, status: 'ACTIVE',
+      seatId: 'seat-1', teamId: 'team-1', subscriptionId: 'sub-1',
+    });
+    // A DISTINCT per-instance adapter (different account + capabilities) so we
+    // can prove resolution scoped to the subscription, not the team account.
+    const instanceAdapter = adapterMock({
+      slug: 'pymthouse',
+      mintSignerSession: vi.fn(async () => ({ accessToken: 'instance-tok', tokenType: 'Bearer', expiresIn: 3600 })),
+      validate: vi.fn(async () => ({ valid: true, capabilities: ['video:gen'], quota: { remaining: 3 } })),
+    });
+    resolveKeyProviderBinding.mockResolvedValue({
+      mode: 'subscription',
+      subscription: { id: 'sub-1', teamId: 'team-1', providerInstanceId: 'inst-1', providerPlanId: null, accountId: 'acct_sub_99', status: 'active', appId: null },
+      adapter: instanceAdapter,
+      billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_sub_99' },
+    });
+
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+
+    // Account + capabilities + signer all come from the SUBSCRIPTION/instance.
+    expect(d.billingAccount).toEqual({ id: 'acct_sub_99', providerSlug: 'pymthouse' });
+    expect(d.capabilities).toEqual(['video:gen']);
+    expect(d.quota).toEqual({ remaining: 3 });
+    expect(d.signerSession.accessToken).toBe('instance-tok');
+    // Per-account scoping: validate + mint keyed off the subscription account.
+    expect(instanceAdapter.validate).toHaveBeenCalledWith('acct_sub_99');
+    expect(instanceAdapter.mintSignerSession).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'acct_sub_99' }),
+    );
+    // The global env adapter is NEVER consulted in subscription mode.
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+    // The binding resolver received the key's subscriptionId + teamId.
+    expect(resolveKeyProviderBinding).toHaveBeenCalledWith({ subscriptionId: 'sub-1', teamId: 'team-1' });
+  });
+
+  it('subscription mode still fails safe (503) when the instance adapter is unconfigured', async () => {
+    resolveKeyProviderBinding.mockResolvedValue({
+      mode: 'subscription',
+      subscription: { id: 'sub-1', teamId: 'team-1', providerInstanceId: 'inst-1', providerPlanId: null, accountId: 'acct_sub_99', status: 'active', appId: null },
+      adapter: adapterMock({ isConfigured: vi.fn(() => false) }),
+      billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_sub_99' },
+    });
+    expect((await POST(req(rawKey))).status).toBe(503);
   });
 });
 

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -30,6 +30,7 @@ import { isFeatureEnabled } from '@/lib/feature-flags';
 import { parseApiKey } from '@naap/database';
 import { AdapterNotImplementedError } from '@/lib/billing/adapter';
 import { getBillingProviderAdapter } from '@/lib/billing/registry';
+import { resolveKeyProviderBinding } from '@/lib/billing/key-provider-binding';
 import {
   resolveNativeKeyToProviderSession,
   verifyNativeKeyHash,
@@ -109,6 +110,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         status: true,
         seatId: true,
         teamId: true,
+        subscriptionId: true,
       },
     });
     // Constant-time hash check; uniform failure whether the row is missing or
@@ -128,9 +130,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         })
       : null;
 
+    // P2: resolve the per-key subscription hop. `multi_subscription` OFF or a
+    // null `subscriptionId` ⇒ `legacy`, so the native-key resolver + capability
+    // lookup below take today's exact team-account / global-env path. ON + a
+    // linked, active, same-team subscription ⇒ a per-instance adapter scoped to
+    // the subscription's account (per-key auth/capabilities/usage). Never
+    // hard-fails: missing/inactive/unresolved ⇒ legacy.
+    const binding = await resolveKeyProviderBinding({
+      subscriptionId: key.subscriptionId,
+      teamId: key.teamId,
+    });
+
     const resolved = await resolveNativeKeyToProviderSession(
       { status: key.status, seatId: key.seatId, teamId: key.teamId },
       team,
+      binding.mode === 'subscription'
+        ? { override: { adapter: binding.adapter, billingAccountRef: binding.billingAccountRef } }
+        : undefined,
     );
     if (!resolved.valid || !resolved.signerSession || !resolved.billingAccountRef) {
       // Map fail-safe reasons: provider lag → 503; binding issues → 403.
@@ -151,7 +167,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // CLOSED to an empty capability set — the key is still valid; NAAP-E gates.
     let capabilities: string[] = [];
     let quota: { remaining: number; resetAt?: string } | null = null;
-    const adapter = getBillingProviderAdapter(ref.providerSlug);
+    // Capability resolution scopes to the SAME adapter/account the signer used:
+    // the per-instance adapter in subscription mode, else today's slug→adapter.
+    const adapter =
+      binding.mode === 'subscription' ? binding.adapter : getBillingProviderAdapter(ref.providerSlug);
     if (adapter) {
       try {
         const v = await adapter.validate(ref.accountId);
@@ -202,6 +221,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       providerSlug: ref.providerSlug,
       hasApp: Boolean(appId),
       capabilityCount: capabilities.length,
+      subscriptionScoped: binding.mode === 'subscription',
     });
     return noStore(success(body));
   } catch (err) {

--- a/apps/web-next/src/lib/billing/key-provider-binding.test.ts
+++ b/apps/web-next/src/lib/billing/key-provider-binding.test.ts
@@ -1,0 +1,100 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const resolveSubscriptionForKey = vi.fn();
+vi.mock('./subscription', () => ({
+  resolveSubscriptionForKey: (...a: unknown[]) => resolveSubscriptionForKey(...a),
+}));
+
+const resolveAdapterForProviderInstanceById = vi.fn();
+vi.mock('./registry-db', () => ({
+  resolveAdapterForProviderInstanceById: (...a: unknown[]) =>
+    resolveAdapterForProviderInstanceById(...a),
+}));
+
+import { resolveKeyProviderBinding } from './key-provider-binding';
+
+function fakeAdapter() {
+  return { slug: 'pymthouse', isConfigured: () => true, mintSignerSession: vi.fn() };
+}
+
+const sub = {
+  id: 'sub-1',
+  teamId: 'team-1',
+  providerInstanceId: 'inst-1',
+  providerPlanId: null,
+  accountId: 'acct_sub_42',
+  status: 'active',
+  appId: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveKeyProviderBinding — legacy passthrough (zero regression)', () => {
+  it('flag OFF → legacy; never resolves an instance adapter', async () => {
+    resolveSubscriptionForKey.mockResolvedValue({ mode: 'legacy', reason: 'flag_off' });
+    const r = await resolveKeyProviderBinding({ subscriptionId: 'sub-1', teamId: 'team-1' });
+    expect(r).toEqual({ mode: 'legacy', reason: 'flag_off' });
+    expect(resolveAdapterForProviderInstanceById).not.toHaveBeenCalled();
+  });
+
+  it('null subscriptionId → legacy (no_subscription)', async () => {
+    resolveSubscriptionForKey.mockResolvedValue({ mode: 'legacy', reason: 'no_subscription' });
+    const r = await resolveKeyProviderBinding({ subscriptionId: null, teamId: 'team-1' });
+    expect(r).toEqual({ mode: 'legacy', reason: 'no_subscription' });
+    expect(resolveAdapterForProviderInstanceById).not.toHaveBeenCalled();
+  });
+
+  it('missing/inactive subscription → legacy (fail closed)', async () => {
+    resolveSubscriptionForKey.mockResolvedValue({ mode: 'legacy', reason: 'subscription_inactive' });
+    const r = await resolveKeyProviderBinding({ subscriptionId: 'sub-1', teamId: 'team-1' });
+    expect(r).toEqual({ mode: 'legacy', reason: 'subscription_inactive' });
+  });
+});
+
+describe('resolveKeyProviderBinding — isolation + fallback', () => {
+  it('subscription belonging to another team → legacy (team_mismatch)', async () => {
+    resolveSubscriptionForKey.mockResolvedValue({ mode: 'subscription', subscription: sub });
+    const r = await resolveKeyProviderBinding({ subscriptionId: 'sub-1', teamId: 'team-OTHER' });
+    expect(r).toEqual({ mode: 'legacy', reason: 'team_mismatch' });
+    expect(resolveAdapterForProviderInstanceById).not.toHaveBeenCalled();
+  });
+
+  it('unresolved instance adapter → legacy (instance_unresolved)', async () => {
+    resolveSubscriptionForKey.mockResolvedValue({ mode: 'subscription', subscription: sub });
+    resolveAdapterForProviderInstanceById.mockResolvedValue({
+      adapter: undefined,
+      source: 'instance-missing-default-env',
+      providerInstanceId: null,
+      adapterType: 'pymthouse',
+    });
+    const r = await resolveKeyProviderBinding({ subscriptionId: 'sub-1', teamId: 'team-1' });
+    expect(r).toEqual({ mode: 'legacy', reason: 'instance_unresolved' });
+  });
+});
+
+describe('resolveKeyProviderBinding — per-instance/per-account resolution', () => {
+  it('active, same-team subscription → subscription mode scoped to {instance, account}', async () => {
+    const adapter = fakeAdapter();
+    resolveSubscriptionForKey.mockResolvedValue({ mode: 'subscription', subscription: sub });
+    resolveAdapterForProviderInstanceById.mockResolvedValue({
+      adapter,
+      source: 'instance',
+      providerInstanceId: 'inst-1',
+      adapterType: 'pymthouse',
+    });
+
+    const r = await resolveKeyProviderBinding({ subscriptionId: 'sub-1', teamId: 'team-1' });
+
+    expect(resolveAdapterForProviderInstanceById).toHaveBeenCalledWith('inst-1');
+    expect(r.mode).toBe('subscription');
+    if (r.mode !== 'subscription') throw new Error('expected subscription');
+    expect(r.adapter).toBe(adapter);
+    // billingAccountRef points at the subscription's account, provider = adapterType.
+    expect(r.billingAccountRef).toEqual({ providerSlug: 'pymthouse', accountId: 'acct_sub_42' });
+    expect(r.subscription.id).toBe('sub-1');
+  });
+});

--- a/apps/web-next/src/lib/billing/key-provider-binding.ts
+++ b/apps/web-next/src/lib/billing/key-provider-binding.ts
@@ -1,0 +1,85 @@
+/**
+ * Per-key provider binding (NAAP P2).
+ *
+ * Wires the P0 per-instance adapter + the P1 subscription model into LIVE key
+ * resolution. Given a key's `subscriptionId` (+ owning `teamId`), it resolves
+ * the subscription hop:
+ *
+ *     key → Subscription → ProviderInstance → per-instance adapter + accountId
+ *
+ * This is the ONLY new branch the front door / native-key resolver take. It is
+ * reachable only when `multi_subscription` is ON AND the key has a non-null
+ * `subscriptionId` (gated inside `resolveSubscriptionForKey`). Every other case —
+ * flag OFF, null subscription, missing/inactive subscription, a subscription
+ * that does not belong to the key's team, or an unresolved instance — returns
+ * `{ mode: 'legacy' }`, so callers fall through to today's exact code path
+ * (team `billingAccountRef` → global env adapter). Never hard-fails an existing
+ * key; never logs secrets.
+ */
+
+import 'server-only';
+
+import type { BillingAccountRef } from '@/lib/teams/billing-account-ref';
+import type { BillingProviderAdapter } from './adapter';
+import { resolveAdapterForProviderInstanceById } from './registry-db';
+import {
+  resolveSubscriptionForKey,
+  type LegacyReason,
+  type SubscriptionRecord,
+} from './subscription';
+
+/** Why a key fell back to the legacy (today's) resolution path. */
+export type KeyBindingLegacyReason =
+  | LegacyReason // flag_off | no_subscription | subscription_missing | subscription_inactive | error
+  | 'team_mismatch' // subscription does not belong to the key's team (isolation)
+  | 'instance_unresolved'; // no adapter could be resolved for the instance
+
+export type KeyProviderBinding =
+  | { mode: 'legacy'; reason: KeyBindingLegacyReason }
+  | {
+      mode: 'subscription';
+      subscription: SubscriptionRecord;
+      adapter: BillingProviderAdapter;
+      billingAccountRef: BillingAccountRef;
+    };
+
+/**
+ * Resolve the live provider binding for a key.
+ *
+ * Returns `subscription` mode ONLY when the multi-subscription model is ON, the
+ * key links an active subscription that belongs to the key's team, and a
+ * per-instance adapter resolves. The returned `billingAccountRef` uses the
+ * instance's `adapterType` as the provider slug and the subscription's opaque
+ * `accountId` — so capability resolution, the signer mint, and usage all scope
+ * to {providerInstance, accountId} for that key. Any other outcome is `legacy`.
+ */
+export async function resolveKeyProviderBinding(key: {
+  subscriptionId: string | null;
+  teamId: string | null;
+}): Promise<KeyProviderBinding> {
+  const sub = await resolveSubscriptionForKey({ subscriptionId: key.subscriptionId });
+  if (sub.mode === 'legacy') {
+    return { mode: 'legacy', reason: sub.reason };
+  }
+
+  // Cross-tenant isolation: a key may only resolve its OWN team's subscription.
+  if (!key.teamId || sub.subscription.teamId !== key.teamId) {
+    return { mode: 'legacy', reason: 'team_mismatch' };
+  }
+
+  const adapterRes = await resolveAdapterForProviderInstanceById(sub.subscription.providerInstanceId);
+  if (!adapterRes.adapter) {
+    // Unresolved instance → fall back to legacy (never hard-fail an existing key).
+    return { mode: 'legacy', reason: 'instance_unresolved' };
+  }
+
+  return {
+    mode: 'subscription',
+    subscription: sub.subscription,
+    adapter: adapterRes.adapter,
+    billingAccountRef: {
+      providerSlug: adapterRes.adapterType,
+      accountId: sub.subscription.accountId,
+    },
+  };
+}

--- a/apps/web-next/src/lib/billing/registry-db.ts
+++ b/apps/web-next/src/lib/billing/registry-db.ts
@@ -168,6 +168,57 @@ export async function resolveAdapterForProviderInstance(
   instanceSlug: string,
   fallbackAdapterType: string = PYMTHOUSE_ADAPTER_SLUG,
 ): Promise<InstanceAdapterResolution> {
+  return resolveInstanceAdapter(
+    () =>
+      prisma.providerInstance.findUnique({
+        where: { slug: instanceSlug },
+        select: PROVIDER_INSTANCE_SELECT,
+      }),
+    fallbackAdapterType,
+  );
+}
+
+/**
+ * Same as {@link resolveAdapterForProviderInstance} but keyed by the
+ * `ProviderInstance.id`. Used by the per-key subscription hop (P2), where the
+ * `Subscription` row stores `providerInstanceId` rather than the instance slug.
+ * Identical flag-gating + fallback semantics (zero regression when OFF).
+ */
+export async function resolveAdapterForProviderInstanceById(
+  providerInstanceId: string,
+  fallbackAdapterType: string = PYMTHOUSE_ADAPTER_SLUG,
+): Promise<InstanceAdapterResolution> {
+  return resolveInstanceAdapter(
+    () =>
+      prisma.providerInstance.findUnique({
+        where: { id: providerInstanceId },
+        select: PROVIDER_INSTANCE_SELECT,
+      }),
+    fallbackAdapterType,
+  );
+}
+
+const PROVIDER_INSTANCE_SELECT = {
+  id: true,
+  adapterType: true,
+  slug: true,
+  config: true,
+  secretRef: true,
+  enabled: true,
+} as const;
+
+/** Shared flag-gate + per-config build + fallback, parameterized by the lookup. */
+async function resolveInstanceAdapter(
+  lookup: () => Promise<{
+    id: string;
+    adapterType: string;
+    slug: string;
+    config: unknown;
+    secretRef: string | null;
+    enabled: boolean;
+  } | null>,
+  fallbackAdapterType: string,
+): Promise<InstanceAdapterResolution> {
   let flagOn = false;
   try {
     flagOn = await isFeatureEnabled(PROVIDER_INSTANCES_FLAG);
@@ -185,17 +236,7 @@ export async function resolveAdapterForProviderInstance(
   }
 
   try {
-    const row = await prisma.providerInstance.findUnique({
-      where: { slug: instanceSlug },
-      select: {
-        id: true,
-        adapterType: true,
-        slug: true,
-        config: true,
-        secretRef: true,
-        enabled: true,
-      },
-    });
+    const row = await lookup();
 
     if (!row || !row.enabled) {
       return {

--- a/apps/web-next/src/lib/dev-api/native-key.test.ts
+++ b/apps/web-next/src/lib/dev-api/native-key.test.ts
@@ -141,3 +141,49 @@ describe('resolveNativeKeyToProviderSession — provider-agnostic mapping', () =
     expect(res.signerSession).toBeUndefined();
   });
 });
+
+describe('resolveNativeKeyToProviderSession — P2 per-subscription override', () => {
+  it('mints against the override instance adapter + account (not the team path)', async () => {
+    const instanceAdapter = fakeAdapter('pymthouse');
+    const res = await resolveNativeKeyToProviderSession(activeKey, pymtTeam, {
+      email: 'u@e.co',
+      override: {
+        adapter: instanceAdapter as never,
+        billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_sub_42' },
+      },
+    });
+    expect(res.valid).toBe(true);
+    // Account comes from the subscription binding, NOT team.billingAccountId.
+    expect(res.billingAccountRef).toEqual({ providerSlug: 'pymthouse', accountId: 'acct_sub_42' });
+    expect(instanceAdapter.mintSignerSession).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: 'acct_sub_42', email: 'u@e.co' }),
+    );
+    // The legacy global-registry adapter is never consulted in override mode.
+    expect(getBillingProviderAdapter).not.toHaveBeenCalled();
+  });
+
+  it('revocation still short-circuits before any override adapter call', async () => {
+    const instanceAdapter = fakeAdapter('pymthouse');
+    const res = await resolveNativeKeyToProviderSession({ ...activeKey, status: 'REVOKED' }, pymtTeam, {
+      override: {
+        adapter: instanceAdapter as never,
+        billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_sub_42' },
+      },
+    });
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('revoked');
+    expect(instanceAdapter.mintSignerSession).not.toHaveBeenCalled();
+  });
+
+  it('fails safe when the override instance adapter is unconfigured', async () => {
+    const instanceAdapter = fakeAdapter('pymthouse', { isConfigured: vi.fn(() => false) });
+    const res = await resolveNativeKeyToProviderSession(activeKey, pymtTeam, {
+      override: {
+        adapter: instanceAdapter as never,
+        billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_sub_42' },
+      },
+    });
+    expect(res.valid).toBe(false);
+    expect(res.reason).toBe('provider_unavailable');
+  });
+});

--- a/apps/web-next/src/lib/dev-api/native-key.ts
+++ b/apps/web-next/src/lib/dev-api/native-key.ts
@@ -16,7 +16,7 @@ import { randomBytes, timingSafeEqual } from 'node:crypto';
 
 import { hashApiKey } from '@naap/database';
 import { getBillingProviderAdapter } from '@/lib/billing/registry';
-import type { SignerSessionToken } from '@/lib/billing/adapter';
+import type { BillingProviderAdapter, SignerSessionToken } from '@/lib/billing/adapter';
 import {
   type BillingAccountRef,
   type TeamBillingBinding,
@@ -70,6 +70,18 @@ export interface NativeKeyRecord {
   teamId: string | null;
 }
 
+/**
+ * P2 per-subscription binding override. When the caller has resolved the key's
+ * subscription hop (`key → Subscription → ProviderInstance`), it passes the
+ * resolved per-instance adapter + account pointer here; the resolver mints
+ * against THIS adapter/account instead of the team's legacy `billingAccountRef`.
+ * Absent/null ⇒ today's exact path (zero regression).
+ */
+export interface SubscriptionBindingOverride {
+  adapter: BillingProviderAdapter;
+  billingAccountRef: BillingAccountRef;
+}
+
 export type ResolveFailureReason =
   | 'revoked'
   | 'unbound_seat'
@@ -98,21 +110,32 @@ export interface ResolvedProviderSession {
  *
  * @param key   the stored key record (status + seat/team attribution)
  * @param team  the seat's team billing binding, or null if unresolved
+ * @param opts  optional email + a P2 per-subscription binding `override`
  */
 export async function resolveNativeKeyToProviderSession(
   key: NativeKeyRecord,
   team: TeamBillingBinding | null,
-  opts?: { email?: string },
+  opts?: { email?: string; override?: SubscriptionBindingOverride | null },
 ): Promise<ResolvedProviderSession> {
   // Revocation/expiry invalidates instantly — before touching any provider.
   if (key.status !== 'ACTIVE') return { valid: false, reason: 'revoked' };
   if (!key.teamId) return { valid: false, reason: 'unbound_seat' };
   if (!team || team.id !== key.teamId) return { valid: false, reason: 'team_unbound' };
 
-  const ref = teamBillingAccountRef(team);
-  if (!ref) return { valid: false, reason: 'team_unbound' };
+  // P2: when a per-subscription binding is supplied, mint against THAT instance
+  // adapter + account. Otherwise fall through to today's exact team-account path.
+  let ref: BillingAccountRef;
+  let adapter: BillingProviderAdapter | undefined;
+  if (opts?.override) {
+    ref = opts.override.billingAccountRef;
+    adapter = opts.override.adapter;
+  } else {
+    const legacyRef = teamBillingAccountRef(team);
+    if (!legacyRef) return { valid: false, reason: 'team_unbound' };
+    ref = legacyRef;
+    adapter = getBillingProviderAdapter(ref.providerSlug);
+  }
 
-  const adapter = getBillingProviderAdapter(ref.providerSlug);
   if (!adapter || !adapter.isConfigured()) {
     return { valid: false, reason: 'provider_unavailable', billingAccountRef: ref };
   }


### PR DESCRIPTION
## Summary
Phase **P2** of the multi-app billing plan — wires the P0 (`ProviderInstance`) + P1 (`Subscription`) foundations into the **live** key-validation front door so an API key actually resolves through its subscription. Stacked on **P1** (`feat/subscriptions-p1`, #399); diff is P2-only. No schema/migration change.

When `multi_subscription` is **ON** and a native `naap_` key has a non-null `subscriptionId`, the front door resolves `key → Subscription → ProviderInstance → per-instance adapter (+ accountId)` and uses that per-instance adapter — scoped to the subscription's `accountId` — for the signer mint **and** the capability/quota lookup. Each key authenticates, is capability-gated, and meters independently.

With the flag **OFF** or a **null** `subscriptionId` (or a missing/inactive/foreign-team subscription, or an unresolved instance) the path is **byte-for-byte today's behavior** (team `billingAccountRef` → global env adapter). Fail-closed: any resolution problem degrades to legacy — an existing key is never hard-failed.

## Flags (both default OFF)
- `multi_subscription` (P1) — gates the subscription hop (master switch).
- `provider_instances` (P0) — gates per-instance vs. default env adapter.

## Live resolution paths touched
- `apps/web-next/src/app/api/v1/keys/validate/route.ts` — BPP ③ front door: compute binding, pass a per-subscription `override` to the resolver, scope the capability adapter to the same instance/account.
- `apps/web-next/src/lib/dev-api/native-key.ts` — `resolveNativeKeyToProviderSession` gains an optional `override`; legacy team-account path unchanged.

## New / supporting code
- `apps/web-next/src/lib/billing/key-provider-binding.ts` — subscription hop + cross-team isolation + graceful legacy fallback.
- `apps/web-next/src/lib/billing/registry-db.ts` — adds `resolveAdapterForProviderInstanceById` (id-keyed sibling of the P0 slug resolver).

## Tests
- INV no-regression: flag OFF / null subscriptionId → today's path (front-door + resolver + binding).
- Per-key scoping: flag ON + linked subscription → per-instance adapter, `billingAccount.id` = subscription `accountId`, validate/mint keyed off it, global env adapter never consulted.
- Isolation / fail-safe: foreign-team → legacy; unresolved instance → legacy; unconfigured adapter → 503.
- vitest full suite green (114 files, 1120 passed, 1 skipped). `tsc --noEmit`: only the 15 pre-existing baseline errors (none in touched files).

Base: `feat/subscriptions-p1`. Do not merge.

Made with [Cursor](https://cursor.com)