### PR TITLE
feat(billing): catalog + subscriptions + per-subscription keys API & dev-manager UI (P3)

### DIFF
--- a/apps/web-next/src/app/api/v1/catalog/route.test.ts
+++ b/apps/web-next/src/app/api/v1/catalog/route.test.ts
@@ -1,0 +1,64 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  MULTI_SUBSCRIPTION_FLAG: 'multi_subscription',
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const prisma = vi.hoisted(() => ({ providerInstance: { findMany: vi.fn() } }));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(headers: Record<string, string> = { cookie: 'naap_auth_token=tok' }): NextRequest {
+  return new NextRequest('http://localhost/api/v1/catalog', { headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1' });
+  prisma.providerInstance.findMany.mockResolvedValue([
+    { id: 'inst-1', slug: 'pymthouse-default', displayName: 'PymtHouse', adapterType: 'pymthouse', enabled: true, sortOrder: 0 },
+  ]);
+});
+
+describe('GET /api/v1/catalog', () => {
+  it('INV: 404 no-op when multi_subscription OFF; never reads the DB', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req());
+    expect(res.status).toBe(404);
+    expect(prisma.providerInstance.findMany).not.toHaveBeenCalled();
+  });
+
+  it('401 without a session token', async () => {
+    const res = await GET(req({}));
+    expect(res.status).toBe(401);
+  });
+
+  it('lists enabled provider instances (no secrets), plans stubbed empty', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.instances).toHaveLength(1);
+    expect(json.data.instances[0]).toEqual({
+      providerInstanceId: 'inst-1',
+      slug: 'pymthouse-default',
+      displayName: 'PymtHouse',
+      adapterType: 'pymthouse',
+      plans: [],
+    });
+    // Catalog only requests enabled instances.
+    expect(prisma.providerInstance.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { enabled: true } }),
+    );
+    expect(JSON.stringify(json.data)).not.toContain('secretRef');
+  });
+});

--- a/apps/web-next/src/app/api/v1/catalog/route.ts
+++ b/apps/web-next/src/app/api/v1/catalog/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Billing catalog (NAAP P3) — BPP developer-facing surface.
+ *
+ *   GET /api/v1/catalog
+ *   auth: NaaP session (cookie or Bearer)
+ *   → { instances: [{ providerInstanceId, slug, displayName, adapterType, plans[] }] }
+ *
+ * Lists the apps/plans a developer can subscribe to across all enabled
+ * `ProviderInstance`s. Plans are empty in P3 — the synced `ProviderPlan` model +
+ * plan-spec pull land in P4; the catalog "exposes what exists" (the instances).
+ *
+ * Gated behind `multi_subscription` (default OFF): 404 when OFF, so the catalog
+ * is inert/hidden and the current single-app dashboard is unchanged. Never emits
+ * secrets — only the instance's public identity is returned.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+import { toCatalogInstanceView } from '@/lib/billing/subscription-catalog';
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function log(level: 'info' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else console.info(line);
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const correlationId = request.headers.get('x-request-id')?.trim() || randomUUID();
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) {
+      return noStore(errors.notFound('Resource'));
+    }
+
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    const instances = await prisma.providerInstance.findMany({
+      where: { enabled: true },
+      orderBy: [{ sortOrder: 'asc' }, { displayName: 'asc' }],
+      select: {
+        id: true,
+        slug: true,
+        displayName: true,
+        adapterType: true,
+        enabled: true,
+        sortOrder: true,
+      },
+    });
+
+    // P4 will join synced ProviderPlan rows here; P3 exposes instances only.
+    const catalog = instances.map((instance) => toCatalogInstanceView(instance));
+
+    log('info', 'catalog.list', { correlationId, instanceCount: catalog.length });
+    return noStore(success({ instances: catalog }));
+  } catch (err) {
+    log('error', 'catalog.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to load catalog'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/route.ts
@@ -1,0 +1,105 @@
+/**
+ * Revoke a subscription-bound native `naap_` key (NAAP P3).
+ *
+ *   DELETE /api/v1/teams/{teamId}/subscriptions/{subId}/keys/{keyId}
+ *
+ * Revocation flips status → REVOKED, invalidating the key INSTANTLY (the P2
+ * resolver rejects any non-ACTIVE key before a provider call). Tenant-scoped:
+ * the key must belong to this team + subscription; a team member may revoke
+ * their own key, an admin any key. Gated behind `multi_subscription`
+ * (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; subId: string; keyId: string }>;
+}
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, subId, keyId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'member');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    // Tenant isolation: the key must belong to this team + subscription.
+    const key = await prisma.devApiKey.findFirst({
+      where: { id: keyId, teamId, subscriptionId: subId },
+      select: { id: true, status: true, userId: true },
+    });
+    if (!key) return noStore(errors.notFound('Key'));
+
+    // Members may revoke their own key; otherwise admin is required.
+    if (key.userId !== user.id) {
+      try {
+        await validateTeamAccess(user.id, teamId, 'admin');
+      } catch (err) {
+        return mapAccessError(err);
+      }
+    }
+
+    if (key.status !== 'REVOKED') {
+      await prisma.devApiKey.update({
+        where: { id: keyId },
+        data: { status: 'REVOKED', revokedAt: new Date() },
+      });
+    }
+
+    log('info', 'subscription_key.revoke', { teamId, correlationId, keyId, subscriptionId: subId });
+    return noStore(success({ revoked: true, keyId }));
+  } catch (err) {
+    log('error', 'subscription_key.revoke.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to revoke key'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/usage/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/usage/route.test.ts
@@ -1,0 +1,83 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  MULTI_SUBSCRIPTION_FLAG: 'multi_subscription',
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({ validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a) }));
+
+const prisma = vi.hoisted(() => ({
+  devApiKey: { findFirst: vi.fn() },
+  devApiUsageLog: { aggregate: vi.fn(), findMany: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(): NextRequest {
+  return new NextRequest('http://localhost/x', { headers: { cookie: 'naap_auth_token=tok' } });
+}
+
+const params = (teamId: string, subId: string, keyId: string) => ({ params: Promise.resolve({ teamId, subId, keyId }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1' });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'member' } });
+  prisma.devApiKey.findFirst.mockResolvedValue({ id: 'key-1' });
+  prisma.devApiUsageLog.aggregate.mockResolvedValue({ _sum: { requestCount: 12, tokensUsed: 340, costIncurred: 1.5 } });
+  prisma.devApiUsageLog.findMany.mockResolvedValue([
+    { id: 'log-1', requestCount: 2, tokensUsed: 40, costIncurred: 0.25, timestamp: new Date('2026-01-01T00:00:00Z') },
+  ]);
+});
+
+describe('GET per-key usage', () => {
+  it('INV: 404 no-op when flag OFF; never reads usage', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req(), params('team-1', 'sub-1', 'key-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiUsageLog.aggregate).not.toHaveBeenCalled();
+  });
+
+  it('INV-scoping: 404 when the key is not in this team+subscription', async () => {
+    prisma.devApiKey.findFirst.mockResolvedValue(null);
+    const res = await GET(req(), params('team-1', 'sub-1', 'key-foreign'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiUsageLog.aggregate).not.toHaveBeenCalled();
+    // The key lookup is scoped to BOTH the team and the subscription.
+    expect(prisma.devApiKey.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'key-foreign', teamId: 'team-1', subscriptionId: 'sub-1' } }),
+    );
+  });
+
+  it('returns per-key totals + recent entries scoped to the key', async () => {
+    const res = await GET(req(), params('team-1', 'sub-1', 'key-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.keyId).toBe('key-1');
+    expect(json.data.subscriptionId).toBe('sub-1');
+    expect(json.data.totals).toEqual({ requestCount: 12, tokensUsed: 340, costIncurred: 1.5 });
+    expect(json.data.entries).toHaveLength(1);
+    expect(prisma.devApiUsageLog.aggregate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { apiKeyId: 'key-1' } }),
+    );
+  });
+
+  it('coerces null sums to 0', async () => {
+    prisma.devApiUsageLog.aggregate.mockResolvedValue({ _sum: { requestCount: null, tokensUsed: null, costIncurred: null } });
+    prisma.devApiUsageLog.findMany.mockResolvedValue([]);
+    const res = await GET(req(), params('team-1', 'sub-1', 'key-1'));
+    const json = await res.json();
+    expect(json.data.totals).toEqual({ requestCount: 0, tokensUsed: 0, costIncurred: 0 });
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/usage/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/usage/route.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-key usage for a subscription-bound key (NAAP P3).
+ *
+ *   GET /api/v1/teams/{teamId}/subscriptions/{subId}/keys/{keyId}/usage
+ *   → { keyId, subscriptionId, totals: { requestCount, tokensUsed, costIncurred }, entries[] }
+ *
+ * Reads `DevApiUsageLog` (already keyed per `apiKeyId`) scoped to the requested
+ * key, which must belong to this team + subscription (tenant isolation, INV-
+ * scoping: a key for subscription A can never read subscription B's usage). The
+ * P2 resolver scopes live metering to {instance, account}; this view rolls the
+ * recorded per-key log up for the developer surface.
+ *
+ * Gated behind `multi_subscription` (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; subId: string; keyId: string }>;
+}
+
+/** Cap on recent usage rows returned (latest-first); totals span all rows. */
+const MAX_USAGE_ENTRIES = 100;
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, subId, keyId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'member');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    // Tenant + subscription isolation: the key must belong to BOTH.
+    const key = await prisma.devApiKey.findFirst({
+      where: { id: keyId, teamId, subscriptionId: subId },
+      select: { id: true },
+    });
+    if (!key) return noStore(errors.notFound('Key'));
+
+    const [totals, entries] = await Promise.all([
+      prisma.devApiUsageLog.aggregate({
+        where: { apiKeyId: keyId },
+        _sum: { requestCount: true, tokensUsed: true, costIncurred: true },
+      }),
+      prisma.devApiUsageLog.findMany({
+        where: { apiKeyId: keyId },
+        orderBy: { timestamp: 'desc' },
+        take: MAX_USAGE_ENTRIES,
+        select: { id: true, requestCount: true, tokensUsed: true, costIncurred: true, timestamp: true },
+      }),
+    ]);
+
+    log('info', 'subscription_key.usage', {
+      teamId,
+      correlationId,
+      keyId,
+      subscriptionId: subId,
+      entryCount: entries.length,
+    });
+
+    return noStore(
+      success({
+        keyId,
+        subscriptionId: subId,
+        totals: {
+          requestCount: totals._sum.requestCount ?? 0,
+          tokensUsed: totals._sum.tokensUsed ?? 0,
+          costIncurred: totals._sum.costIncurred ?? 0,
+        },
+        entries: entries.map((e) => ({
+          id: e.id,
+          requestCount: e.requestCount,
+          tokensUsed: e.tokensUsed,
+          costIncurred: e.costIncurred,
+          timestamp: e.timestamp.toISOString(),
+        })),
+      }),
+    );
+  } catch (err) {
+    log('error', 'subscription_key.usage.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to load usage'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/route.test.ts
@@ -1,0 +1,136 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, POST } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  MULTI_SUBSCRIPTION_FLAG: 'multi_subscription',
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({ validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a) }));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+
+const prisma = vi.hoisted(() => ({
+  subscription: { findFirst: vi.fn() },
+  seat: { findFirst: vi.fn() },
+  devApiKey: { findMany: vi.fn(), count: vi.fn(), create: vi.fn() },
+  providerInstance: { findUnique: vi.fn() },
+  billingProvider: { findUnique: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(init?: { method?: string; body?: unknown }): NextRequest {
+  return new NextRequest('http://localhost/x', {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', 'content-type': 'application/json' },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+const params = (teamId: string, subId: string) => ({ params: Promise.resolve({ teamId, subId }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1' });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'member' } });
+  prisma.subscription.findFirst.mockResolvedValue({
+    id: 'sub-1', providerInstanceId: 'inst-1', accountId: 'acct_sub_42', status: 'active',
+  });
+  prisma.seat.findFirst.mockResolvedValue({ id: 'seat-1', userId: 'user-1', status: 'active', keyLimit: 5 });
+  prisma.devApiKey.findMany.mockResolvedValue([]);
+  prisma.devApiKey.count.mockResolvedValue(0);
+  prisma.providerInstance.findUnique.mockResolvedValue({ id: 'inst-1', adapterType: 'pymthouse', enabled: true });
+  prisma.billingProvider.findUnique.mockResolvedValue({ id: 'bp-1', enabled: true });
+  prisma.devApiKey.create.mockImplementation(async ({ data, select: _s }: { data: Record<string, unknown>; select: unknown }) => ({
+    id: 'key-1',
+    keyPrefix: data.keyPrefix,
+    label: data.label ?? null,
+    status: data.status,
+    seatId: data.seatId,
+    teamId: data.teamId,
+    subscriptionId: data.subscriptionId,
+    createdAt: new Date(),
+    lastUsedAt: null,
+    revokedAt: null,
+  }));
+});
+
+describe('flag OFF (zero regression)', () => {
+  it('GET 404 no-op', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req(), params('team-1', 'sub-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.findMany).not.toHaveBeenCalled();
+  });
+  it('POST 404 no-op (never mints)', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(req({ method: 'POST', body: {} }), params('team-1', 'sub-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST mint (flag ON)', () => {
+  it('mints a naap_ key bound to the subscription and returns it once', async () => {
+    const res = await POST(req({ method: 'POST', body: { label: 'ci' } }), params('team-1', 'sub-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.rawKey).toMatch(/^naap_[0-9a-f]{16}_[0-9a-f]{48}$/);
+    const createArg = prisma.devApiKey.create.mock.calls[0][0].data;
+    expect(createArg.subscriptionId).toBe('sub-1');
+    expect(createArg.seatId).toBe('seat-1');
+    expect(createArg.billingProviderId).toBe('bp-1');
+    expect(createArg.providerSessionRefEnc).toBeTruthy();
+    // Never leak the opaque account pointer in the response.
+    expect(JSON.stringify(json.data)).not.toContain('acct_sub_42');
+  });
+
+  it('404 when the subscription does not belong to the team', async () => {
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    const res = await POST(req({ method: 'POST', body: {} }), params('team-1', 'sub-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.create).not.toHaveBeenCalled();
+  });
+
+  it('400 when the subscription is not active', async () => {
+    prisma.subscription.findFirst.mockResolvedValue({ id: 'sub-1', providerInstanceId: 'inst-1', accountId: 'a', status: 'canceled' });
+    const res = await POST(req({ method: 'POST', body: {} }), params('team-1', 'sub-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('403 when the caller has no active seat', async () => {
+    prisma.seat.findFirst.mockResolvedValue(null);
+    const res = await POST(req({ method: 'POST', body: {} }), params('team-1', 'sub-1'));
+    expect(res.status).toBe(403);
+  });
+
+  it('403 when the seat is over its key limit', async () => {
+    prisma.devApiKey.count.mockResolvedValue(5);
+    const res = await POST(req({ method: 'POST', body: {} }), params('team-1', 'sub-1'));
+    expect(res.status).toBe(403);
+    expect(prisma.devApiKey.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET list (flag ON)', () => {
+  it('lists keys scoped to the subscription + team', async () => {
+    prisma.devApiKey.findMany.mockResolvedValue([{ id: 'key-1', keyPrefix: 'naap_abc...', status: 'ACTIVE', subscriptionId: 'sub-1' }]);
+    const res = await GET(req(), params('team-1', 'sub-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.keys).toHaveLength(1);
+    expect(prisma.devApiKey.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { subscriptionId: 'sub-1', teamId: 'team-1' } }),
+    );
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/route.ts
@@ -1,0 +1,235 @@
+/**
+ * Native `naap_` keys for a SUBSCRIPTION (NAAP P3).
+ *
+ *   GET  /api/v1/teams/{teamId}/subscriptions/{subId}/keys   — list a subscription's keys
+ *   POST /api/v1/teams/{teamId}/subscriptions/{subId}/keys    — mint a key bound to the subscription
+ *
+ * This is the developer-facing "mint a native key" path the env-build worker
+ * found missing a UI for. It extends the seat-keys mint flow: the minted key is
+ * provider-opaque (`naap_…`) and additionally carries `subscriptionId`, so the
+ * P2 per-key resolver hops key → subscription → provider instance + account.
+ * The raw key is returned exactly once.
+ *
+ * Tenant-scoped: caller must be a team member acting through THEIR OWN active
+ * seat (mints require a TeamMember/seat row); per-seat key limits still apply.
+ * Gated behind `multi_subscription` (default OFF): 404 when OFF (no-op). Never
+ * logs/returns the raw key, hash, accountId, or session ref.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+import { encrypt } from '@/lib/gateway/encryption';
+import { deriveKeyLookupId, formatBillingKeyPublicPrefix, hashApiKey } from '@naap/database';
+import { seatCanMintKey } from '@/lib/teams/seats';
+import { generateNativeApiKey } from '@/lib/dev-api/native-key';
+import { SUBSCRIPTION_STATUS_ACTIVE } from '@/lib/billing/subscription-catalog';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; subId: string }>;
+}
+
+const SAFE_KEY_SELECT = {
+  id: true,
+  keyPrefix: true,
+  label: true,
+  status: true,
+  seatId: true,
+  teamId: true,
+  subscriptionId: true,
+  createdAt: true,
+  lastUsedAt: true,
+  revokedAt: true,
+} as const;
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+/** Load a subscription scoped to the team (tenant isolation), or null. */
+async function loadTeamSubscription(teamId: string, subId: string) {
+  return prisma.subscription.findFirst({
+    where: { id: subId, teamId },
+    select: { id: true, providerInstanceId: true, accountId: true, status: true },
+  });
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, subId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'member');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const subscription = await loadTeamSubscription(teamId, subId);
+    if (!subscription) return noStore(errors.notFound('Subscription'));
+
+    const keys = await prisma.devApiKey.findMany({
+      where: { subscriptionId: subId, teamId },
+      orderBy: { createdAt: 'desc' },
+      select: SAFE_KEY_SELECT,
+    });
+    return noStore(success({ keys }));
+  } catch (err) {
+    log('error', 'subscription_key.list.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to list keys'));
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, subId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'member');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const subscription = await loadTeamSubscription(teamId, subId);
+    if (!subscription) return noStore(errors.notFound('Subscription'));
+    if (subscription.status !== SUBSCRIPTION_STATUS_ACTIVE) {
+      return noStore(errors.badRequest('Subscription is not active'));
+    }
+
+    // The caller mints through THEIR OWN active seat in this team.
+    const seat = await prisma.seat.findFirst({
+      where: { teamId, userId: user.id, status: 'active' },
+      select: { id: true, userId: true, status: true, keyLimit: true },
+    });
+    if (!seat) return noStore(errors.forbidden('No active seat in this team'));
+
+    const activeKeyCount = await prisma.devApiKey.count({
+      where: { seatId: seat.id, status: 'ACTIVE' },
+    });
+    if (!seatCanMintKey(seat, activeKeyCount)) {
+      return noStore(errors.forbidden('Seat is not active or has reached its key limit'));
+    }
+
+    // The subscription's provider instance → adapterType → BillingProvider FK.
+    const instance = await prisma.providerInstance.findUnique({
+      where: { id: subscription.providerInstanceId },
+      select: { id: true, adapterType: true, enabled: true },
+    });
+    if (!instance || !instance.enabled) {
+      return noStore(errors.badRequest('Subscription provider instance is unavailable'));
+    }
+    const provider = await prisma.billingProvider.findUnique({
+      where: { slug: instance.adapterType },
+      select: { id: true, enabled: true },
+    });
+    if (!provider || !provider.enabled) {
+      return noStore(errors.badRequest(`Billing provider "${instance.adapterType}" is not enabled for key minting`));
+    }
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      // Body is optional (label only).
+    }
+    const label =
+      typeof body.label === 'string' && body.label.trim() ? body.label.trim().slice(0, 120) : null;
+
+    const { rawKey } = generateNativeApiKey();
+    const keyLookupId = deriveKeyLookupId(rawKey);
+    const keyPrefix = formatBillingKeyPublicPrefix(rawKey);
+    const keyHash = hashApiKey(rawKey);
+    // Store the encrypted, provider-opaque account pointer (the subscription's
+    // accountId). Never store/return the provider token itself.
+    const sessionRef = encrypt(subscription.accountId);
+
+    const created = await prisma.devApiKey.create({
+      data: {
+        userId: user.id,
+        billingProviderId: provider.id,
+        seatId: seat.id,
+        teamId,
+        subscriptionId: subscription.id,
+        keyLookupId,
+        keyPrefix,
+        keyHash,
+        label,
+        status: 'ACTIVE',
+        providerSessionRefEnc: sessionRef.encryptedValue,
+        providerSessionRefIv: sessionRef.iv,
+      },
+      select: SAFE_KEY_SELECT,
+    });
+
+    // Never log the raw key, hash, accountId, or session ref — slug + ids only.
+    log('info', 'subscription_key.mint', {
+      teamId,
+      correlationId,
+      keyId: created.id,
+      subscriptionId: subscription.id,
+      providerInstanceId: subscription.providerInstanceId,
+      adapterType: instance.adapterType,
+    });
+
+    return noStore(
+      success({
+        key: created,
+        rawKey,
+        warning: 'Store this key securely. It is provider-opaque and will not be shown again.',
+      }),
+    );
+  } catch (err) {
+    log('error', 'subscription_key.mint.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to mint key'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/route.ts
@@ -1,0 +1,105 @@
+/**
+ * Cancel / deactivate a subscription (NAAP P3).
+ *
+ *   DELETE /api/v1/teams/{teamId}/subscriptions/{subId}
+ *
+ * Flips `Subscription.status → canceled`. Cancellation fails closed for the
+ * per-key resolver (P2): a non-active subscription resolves to the legacy path,
+ * never a hard error. Keys linked to the subscription keep working via the
+ * legacy fallback (they are NOT auto-revoked here — revoke keys explicitly).
+ *
+ * Tenant-scoped: team admin only (mirrors create). Gated behind
+ * `multi_subscription` (default OFF): 404 when OFF (no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+import {
+  SUBSCRIPTION_STATUS_CANCELED,
+  isCancelableStatus,
+} from '@/lib/billing/subscription-catalog';
+
+interface RouteParams {
+  params: Promise<{ teamId: string; subId: string }>;
+}
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId, subId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'admin');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    // Tenant isolation: the subscription must belong to THIS team.
+    const subscription = await prisma.subscription.findFirst({
+      where: { id: subId, teamId },
+      select: { id: true, status: true },
+    });
+    if (!subscription) return noStore(errors.notFound('Subscription'));
+
+    if (!isCancelableStatus(subscription.status)) {
+      // Already canceled → idempotent success (no state change).
+      return noStore(success({ subscriptionId: subId, status: subscription.status, canceled: true }));
+    }
+
+    await prisma.subscription.update({
+      where: { id: subId },
+      data: { status: SUBSCRIPTION_STATUS_CANCELED },
+    });
+
+    log('info', 'subscriptions.cancel', { teamId, correlationId, subscriptionId: subId });
+    return noStore(success({ subscriptionId: subId, status: SUBSCRIPTION_STATUS_CANCELED, canceled: true }));
+  } catch (err) {
+    log('error', 'subscriptions.cancel.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to cancel subscription'));
+  }
+}

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/route.test.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/route.test.ts
@@ -1,0 +1,142 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { GET, POST } from './route';
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  MULTI_SUBSCRIPTION_FLAG: 'multi_subscription',
+}));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+const validateTeamAccess = vi.fn();
+vi.mock('@/lib/api/teams', () => ({ validateTeamAccess: (...a: unknown[]) => validateTeamAccess(...a) }));
+
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: vi.fn(() => null) }));
+
+const prisma = vi.hoisted(() => ({
+  subscription: { findMany: vi.fn(), create: vi.fn() },
+  providerInstance: { findUnique: vi.fn() },
+  team: { findUnique: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+function req(init?: { method?: string; body?: unknown }): NextRequest {
+  return new NextRequest('http://localhost/x', {
+    method: init?.method,
+    headers: { cookie: 'naap_auth_token=tok', 'content-type': 'application/json' },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+const params = (teamId: string) => ({ params: Promise.resolve({ teamId }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isFeatureEnabled.mockResolvedValue(true);
+  validateSession.mockResolvedValue({ id: 'user-1' });
+  validateTeamAccess.mockResolvedValue({ team: { id: 'team-1' }, member: { role: 'admin' } });
+  prisma.subscription.findMany.mockResolvedValue([]);
+  prisma.providerInstance.findUnique.mockResolvedValue({ id: 'inst-1', enabled: true });
+  prisma.team.findUnique.mockResolvedValue({ billingAccountId: 'acct_team_1' });
+  prisma.subscription.create.mockImplementation(async ({ data, select: _s }: { data: Record<string, unknown>; select: unknown }) => ({
+    id: 'sub-1',
+    teamId: data.teamId,
+    providerInstanceId: data.providerInstanceId,
+    providerPlanId: data.providerPlanId ?? null,
+    accountId: data.accountId,
+    status: data.status,
+    appId: data.appId ?? null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  }));
+});
+
+describe('flag OFF (zero regression)', () => {
+  it('GET 404 no-op', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await GET(req(), params('team-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.subscription.findMany).not.toHaveBeenCalled();
+  });
+  it('POST 404 no-op (never creates)', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await POST(req({ method: 'POST', body: { providerInstanceId: 'inst-1' } }), params('team-1'));
+    expect(res.status).toBe(404);
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET list (flag ON)', () => {
+  it('forbids a non-member', async () => {
+    validateTeamAccess.mockRejectedValue(new Error('Not a member of this team'));
+    const res = await GET(req(), params('team-1'));
+    expect(res.status).toBe(403);
+  });
+  it('lists the team subscriptions (tenant-scoped)', async () => {
+    prisma.subscription.findMany.mockResolvedValue([
+      { id: 'sub-1', teamId: 'team-1', providerInstanceId: 'inst-1', providerPlanId: null, accountId: 'acct_x', status: 'active', appId: null, createdAt: new Date('2026-01-01Z'), updatedAt: new Date('2026-01-01Z') },
+    ]);
+    const res = await GET(req(), params('team-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.subscriptions).toHaveLength(1);
+    expect(prisma.subscription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { teamId: 'team-1' } }),
+    );
+  });
+});
+
+describe('POST create (flag ON)', () => {
+  it('requires admin', async () => {
+    validateTeamAccess.mockImplementation(async (_u: string, _t: string, role: string) => {
+      if (role === 'admin') throw new Error('Requires admin role or higher');
+      return { team: { id: 'team-1' }, member: { role: 'member' } };
+    });
+    const res = await POST(req({ method: 'POST', body: { providerInstanceId: 'inst-1' } }), params('team-1'));
+    expect(res.status).toBe(403);
+    expect(prisma.subscription.create).not.toHaveBeenCalled();
+  });
+
+  it('400 when providerInstanceId is missing', async () => {
+    const res = await POST(req({ method: 'POST', body: {} }), params('team-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 for an unknown/disabled instance', async () => {
+    prisma.providerInstance.findUnique.mockResolvedValue(null);
+    const res = await POST(req({ method: 'POST', body: { providerInstanceId: 'bad' } }), params('team-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a subscription, defaulting accountId to the team binding', async () => {
+    const res = await POST(req({ method: 'POST', body: { providerInstanceId: 'inst-1' } }), params('team-1'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.subscription.providerInstanceId).toBe('inst-1');
+    expect(json.data.subscription.status).toBe('active');
+    const createArg = prisma.subscription.create.mock.calls[0][0].data;
+    expect(createArg.teamId).toBe('team-1');
+    expect(createArg.accountId).toBe('acct_team_1');
+  });
+
+  it('400 when no accountId provided and the team is unbound', async () => {
+    prisma.team.findUnique.mockResolvedValue({ billingAccountId: null });
+    const res = await POST(req({ method: 'POST', body: { providerInstanceId: 'inst-1' } }), params('team-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('uses a caller-supplied accountId when given', async () => {
+    const res = await POST(
+      req({ method: 'POST', body: { providerInstanceId: 'inst-1', accountId: 'acct_custom' } }),
+      params('team-1'),
+    );
+    expect(res.status).toBe(200);
+    expect(prisma.subscription.create.mock.calls[0][0].data.accountId).toBe('acct_custom');
+  });
+});

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/route.ts
@@ -1,0 +1,192 @@
+/**
+ * Team subscriptions (NAAP P3) — multi-app subscribe surface.
+ *
+ *   GET  /api/v1/teams/{teamId}/subscriptions     — list the team's subscriptions
+ *   POST /api/v1/teams/{teamId}/subscriptions      — subscribe to a provider instance
+ *
+ * A team may hold MANY concurrent subscriptions (one per app/plan). Each row
+ * binds {providerInstanceId, providerPlanId?, accountId, appId?}. The legacy
+ * `Team.billingAccountRef` stays as the default subscription's account pointer,
+ * so subscribing is purely additive.
+ *
+ * Tenant-scoped: the caller must be a member of the team (admin to create), via
+ * the same `validateTeamAccess` authz the seat/key routes use. Gated behind
+ * `multi_subscription` (default OFF): 404 when OFF (no-op). Never emits secrets.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+
+import { prisma } from '@/lib/db';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import { validateSession } from '@/lib/api/auth';
+import { validateTeamAccess } from '@/lib/api/teams';
+import { validateCSRF } from '@/lib/api/csrf';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
+import {
+  SUBSCRIPTION_STATUS_ACTIVE,
+  parseCreateSubscriptionBody,
+  toSubscriptionView,
+} from '@/lib/billing/subscription-catalog';
+
+interface RouteParams {
+  params: Promise<{ teamId: string }>;
+}
+
+const SUBSCRIPTION_SELECT = {
+  id: true,
+  teamId: true,
+  providerInstanceId: true,
+  providerPlanId: true,
+  accountId: true,
+  status: true,
+  appId: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+function noStore(res: NextResponse): NextResponse {
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+function correlationIdOf(request: NextRequest): string {
+  return request.headers.get('x-request-id')?.trim() || randomUUID();
+}
+
+function log(level: 'info' | 'warn' | 'error', event: string, fields: Record<string, unknown>): void {
+  const line = JSON.stringify({ level, event, ...fields });
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.info(line);
+}
+
+function mapAccessError(err: unknown): NextResponse {
+  const message = err instanceof Error ? err.message : 'Access error';
+  if (message.includes('not found')) return noStore(errors.notFound('Team'));
+  if (message.includes('Not a member') || message.includes('Requires') || message.includes('role')) {
+    return noStore(errors.forbidden(message));
+  }
+  return noStore(errors.internal(message));
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    try {
+      await validateTeamAccess(user.id, teamId, 'member');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    const subscriptions = await prisma.subscription.findMany({
+      where: { teamId },
+      orderBy: { createdAt: 'desc' },
+      select: SUBSCRIPTION_SELECT,
+    });
+
+    return noStore(success({ subscriptions: subscriptions.map(toSubscriptionView) }));
+  } catch (err) {
+    log('error', 'subscriptions.list.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to list subscriptions'));
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const correlationId = correlationIdOf(request);
+  try {
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+
+    const { teamId } = await params;
+    const token = getAuthToken(request);
+    if (!token) return noStore(errors.unauthorized('No auth token provided'));
+
+    const csrfError = validateCSRF(request, { shadowMode: true });
+    if (csrfError) return csrfError;
+
+    const user = await validateSession(token);
+    if (!user) return noStore(errors.unauthorized('Invalid or expired session'));
+
+    // Creating a subscription is a team-admin action (billing-affecting).
+    try {
+      await validateTeamAccess(user.id, teamId, 'admin');
+    } catch (err) {
+      return mapAccessError(err);
+    }
+
+    let rawBody: unknown = {};
+    try {
+      rawBody = await request.json();
+    } catch {
+      rawBody = {};
+    }
+    const parsed = parseCreateSubscriptionBody(rawBody);
+    if (!parsed.ok) return noStore(errors.badRequest(parsed.error));
+    const input = parsed.value;
+
+    // The instance must exist + be enabled (tenant-neutral catalog row).
+    const instance = await prisma.providerInstance.findUnique({
+      where: { id: input.providerInstanceId },
+      select: { id: true, enabled: true },
+    });
+    if (!instance || !instance.enabled) {
+      return noStore(errors.badRequest('Unknown or disabled provider instance'));
+    }
+
+    // accountId: caller-supplied wins; else fall back to the team's existing
+    // billing-account binding (the default subscription's pointer). Provider
+    // account provisioning via the adapter is deferred (P4 / provider coord).
+    let accountId = input.accountId;
+    if (!accountId) {
+      const team = await prisma.team.findUnique({
+        where: { id: teamId },
+        select: { billingAccountId: true },
+      });
+      accountId = team?.billingAccountId ?? null;
+    }
+    if (!accountId) {
+      return noStore(
+        errors.badRequest('No accountId provided and the team has no billing-account binding'),
+      );
+    }
+
+    const created = await prisma.subscription.create({
+      data: {
+        teamId,
+        providerInstanceId: input.providerInstanceId,
+        providerPlanId: input.providerPlanId,
+        accountId,
+        status: SUBSCRIPTION_STATUS_ACTIVE,
+        appId: input.appId,
+      },
+      select: SUBSCRIPTION_SELECT,
+    });
+
+    // Never log accountId — ids/slugs only.
+    log('info', 'subscriptions.create', {
+      teamId,
+      correlationId,
+      subscriptionId: created.id,
+      providerInstanceId: created.providerInstanceId,
+    });
+
+    return noStore(success({ subscription: toSubscriptionView(created) }));
+  } catch (err) {
+    log('error', 'subscriptions.create.error', {
+      correlationId,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    return noStore(errors.internal('Failed to create subscription'));
+  }
+}

--- a/apps/web-next/src/lib/billing/subscription-catalog.test.ts
+++ b/apps/web-next/src/lib/billing/subscription-catalog.test.ts
@@ -1,0 +1,115 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  SUBSCRIPTION_STATUS_ACTIVE,
+  SUBSCRIPTION_STATUS_CANCELED,
+  SUBSCRIPTION_STATUS_PAUSED,
+  isCancelableStatus,
+  parseCreateSubscriptionBody,
+  toCatalogInstanceView,
+  toSubscriptionView,
+  type CatalogInstanceRow,
+  type SubscriptionRow,
+} from './subscription-catalog';
+
+const instance: CatalogInstanceRow = {
+  id: 'inst-1',
+  slug: 'pymthouse-default',
+  displayName: 'PymtHouse (default)',
+  adapterType: 'pymthouse',
+  enabled: true,
+  sortOrder: 0,
+};
+
+describe('toCatalogInstanceView', () => {
+  it('exposes only non-secret identity fields + empty plans by default', () => {
+    const view = toCatalogInstanceView(instance);
+    expect(view).toEqual({
+      providerInstanceId: 'inst-1',
+      slug: 'pymthouse-default',
+      displayName: 'PymtHouse (default)',
+      adapterType: 'pymthouse',
+      plans: [],
+    });
+    // No secret-bearing fields ever leak into the catalog view.
+    expect(JSON.stringify(view)).not.toContain('secretRef');
+    expect(JSON.stringify(view)).not.toContain('config');
+  });
+
+  it('passes through provided plans (P4 will populate these)', () => {
+    const view = toCatalogInstanceView(instance, [
+      { providerPlanId: 'p1', name: 'Starter', capabilities: ['text-to-image'] },
+    ]);
+    expect(view.plans).toHaveLength(1);
+    expect(view.plans[0].providerPlanId).toBe('p1');
+  });
+});
+
+describe('toSubscriptionView', () => {
+  it('serializes dates and keeps the opaque accountId', () => {
+    const row: SubscriptionRow = {
+      id: 'sub-1',
+      teamId: 'team-1',
+      providerInstanceId: 'inst-1',
+      providerPlanId: null,
+      accountId: 'acct_42',
+      status: 'active',
+      appId: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    };
+    const view = toSubscriptionView(row);
+    expect(view.id).toBe('sub-1');
+    expect(view.accountId).toBe('acct_42');
+    expect(view.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(view.updatedAt).toBe('2026-01-02T00:00:00.000Z');
+    // teamId is internal scoping, not part of the provider-neutral view.
+    expect(view).not.toHaveProperty('teamId');
+  });
+});
+
+describe('isCancelableStatus', () => {
+  it('active + paused are cancelable; canceled is not', () => {
+    expect(isCancelableStatus(SUBSCRIPTION_STATUS_ACTIVE)).toBe(true);
+    expect(isCancelableStatus(SUBSCRIPTION_STATUS_PAUSED)).toBe(true);
+    expect(isCancelableStatus(SUBSCRIPTION_STATUS_CANCELED)).toBe(false);
+    expect(isCancelableStatus('garbage')).toBe(false);
+  });
+});
+
+describe('parseCreateSubscriptionBody', () => {
+  it('requires providerInstanceId', () => {
+    expect(parseCreateSubscriptionBody({}).ok).toBe(false);
+    expect(parseCreateSubscriptionBody({ providerInstanceId: '   ' }).ok).toBe(false);
+    expect(parseCreateSubscriptionBody(null).ok).toBe(false);
+    expect(parseCreateSubscriptionBody('nope').ok).toBe(false);
+  });
+
+  it('trims + defaults optional fields to null', () => {
+    const r = parseCreateSubscriptionBody({ providerInstanceId: '  inst-1 ' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.value).toEqual({
+      providerInstanceId: 'inst-1',
+      providerPlanId: null,
+      accountId: null,
+      appId: null,
+    });
+  });
+
+  it('captures optional providerPlanId / accountId / appId', () => {
+    const r = parseCreateSubscriptionBody({
+      providerInstanceId: 'inst-1',
+      providerPlanId: 'plan-9',
+      accountId: 'acct_7',
+      appId: 'storyboard',
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.value.providerPlanId).toBe('plan-9');
+    expect(r.value.accountId).toBe('acct_7');
+    expect(r.value.appId).toBe('storyboard');
+  });
+});

--- a/apps/web-next/src/lib/billing/subscription-catalog.ts
+++ b/apps/web-next/src/lib/billing/subscription-catalog.ts
@@ -1,0 +1,155 @@
+/**
+ * Catalog + subscription domain logic (NAAP P3, developer-facing surface).
+ *
+ * DB-free request parsing + view-model shaping for the catalog / subscription
+ * endpoints, so the rules can be unit-tested in isolation; the HTTP routes
+ * persist rows and delegate the shaping here. Never emits secrets — a
+ * `ProviderInstance` exposes only its public identity (slug/displayName/
+ * adapterType), never `config`/`secretRef`.
+ *
+ * Everything here is reachable only when `multi_subscription` is ON (the routes
+ * 404 when OFF), so this is purely additive — today's single-app dashboard and
+ * the existing seat/key routes are untouched.
+ */
+
+export const SUBSCRIPTION_STATUS_ACTIVE = 'active';
+export const SUBSCRIPTION_STATUS_CANCELED = 'canceled';
+export const SUBSCRIPTION_STATUS_PAUSED = 'paused';
+
+/** Statuses a caller may transition a subscription FROM via cancel. */
+const CANCELABLE_STATUSES = new Set<string>([
+  SUBSCRIPTION_STATUS_ACTIVE,
+  SUBSCRIPTION_STATUS_PAUSED,
+]);
+
+/** True when a subscription in this status can still be canceled. */
+export function isCancelableStatus(status: string): boolean {
+  return CANCELABLE_STATUSES.has(status);
+}
+
+/** Minimal `ProviderInstance` row the catalog needs (NON-secret fields only). */
+export interface CatalogInstanceRow {
+  id: string;
+  slug: string;
+  displayName: string;
+  adapterType: string;
+  enabled: boolean;
+  sortOrder: number;
+}
+
+/** A plan a developer can subscribe to (stubbed until P4 plan-spec sync). */
+export interface CatalogPlanView {
+  providerPlanId: string;
+  name: string;
+  capabilities: string[];
+}
+
+/** A catalog entry: one provider instance + the plans available on it. */
+export interface CatalogInstanceView {
+  providerInstanceId: string;
+  slug: string;
+  displayName: string;
+  adapterType: string;
+  plans: CatalogPlanView[];
+}
+
+/**
+ * Map a `ProviderInstance` row to its catalog view. Plans are intentionally
+ * empty in P3 — the synced `ProviderPlan` model + plan-spec pull land in P4; the
+ * catalog "exposes what exists", which today is the instances themselves. Only
+ * non-secret identity fields are surfaced (never `config`/`secretRef`).
+ */
+export function toCatalogInstanceView(
+  instance: CatalogInstanceRow,
+  plans: CatalogPlanView[] = [],
+): CatalogInstanceView {
+  return {
+    providerInstanceId: instance.id,
+    slug: instance.slug,
+    displayName: instance.displayName,
+    adapterType: instance.adapterType,
+    plans,
+  };
+}
+
+/** Minimal `Subscription` row the API surfaces. */
+export interface SubscriptionRow {
+  id: string;
+  teamId: string;
+  providerInstanceId: string;
+  providerPlanId: string | null;
+  accountId: string;
+  status: string;
+  appId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Provider-neutral subscription view (no secrets; opaque accountId retained). */
+export interface SubscriptionView {
+  id: string;
+  providerInstanceId: string;
+  providerPlanId: string | null;
+  accountId: string;
+  status: string;
+  appId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toSubscriptionView(row: SubscriptionRow): SubscriptionView {
+  return {
+    id: row.id,
+    providerInstanceId: row.providerInstanceId,
+    providerPlanId: row.providerPlanId,
+    accountId: row.accountId,
+    status: row.status,
+    appId: row.appId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+/** Parsed, validated create-subscription request. */
+export interface CreateSubscriptionInput {
+  providerInstanceId: string;
+  providerPlanId: string | null;
+  /** Caller-supplied provider account pointer; null ⇒ derive from team binding. */
+  accountId: string | null;
+  appId: string | null;
+}
+
+export type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function optionalTrimmed(value: unknown, max = 256): string | null {
+  if (value == null) return null;
+  if (typeof value !== 'string') return null;
+  const v = value.trim();
+  if (v === '') return null;
+  return v.slice(0, max);
+}
+
+/**
+ * Validate a create-subscription body. `providerInstanceId` is required;
+ * `providerPlanId`, `accountId`, and `appId` are optional. Returns a typed
+ * error string (never throws) so the route can 400 with a clear message.
+ */
+export function parseCreateSubscriptionBody(body: unknown): ParseResult<CreateSubscriptionInput> {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'Request body must be a JSON object' };
+  }
+  const b = body as Record<string, unknown>;
+  const providerInstanceId = optionalTrimmed(b.providerInstanceId);
+  if (!providerInstanceId) {
+    return { ok: false, error: 'providerInstanceId is required' };
+  }
+  return {
+    ok: true,
+    value: {
+      providerInstanceId,
+      providerPlanId: optionalTrimmed(b.providerPlanId),
+      accountId: optionalTrimmed(b.accountId),
+      appId: optionalTrimmed(b.appId),
+    },
+  };
+}

--- a/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
+++ b/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
@@ -24,6 +24,7 @@ ChevronUp,
 } from 'lucide-react';
 import { Card, Badge, Modal, Tooltip } from '@naap/ui';
 import type { NetworkModel } from '@naap/plugin-sdk';
+import { SubscriptionsPanel } from './SubscriptionsPanel';
 
 const PIPELINE_COLOR: Record<string, string> = {
   'text-to-image':           '#f59e0b',
@@ -81,11 +82,12 @@ function modelBadgeColor(modelId: string, fallbackPipelineId?: string): string {
   return MODEL_BADGE_COLORS[hashModelId(modelId)];
 }
 
-type TabId = 'models' | 'api-keys' | 'usage' | 'docs';
+type TabId = 'models' | 'api-keys' | 'subscriptions' | 'usage' | 'docs';
 
 const TAB_PATH_SEGMENT: Record<TabId, string> = {
   models: 'models',
   'api-keys': 'keys',
+  subscriptions: 'subscriptions',
   usage: 'usage',
   docs: 'docs',
 };
@@ -93,6 +95,7 @@ const TAB_PATH_SEGMENT: Record<TabId, string> = {
 const TAB_FROM_SEGMENT: Record<string, TabId> = {
   models: 'models',
   keys: 'api-keys',
+  subscriptions: 'subscriptions',
   usage: 'usage',
   docs: 'docs',
   'api-keys': 'api-keys',
@@ -365,6 +368,10 @@ function billingProviderSupportsPythonGatewayDiscovery(slug: string | undefined)
 
 export const DeveloperView: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabId>(() => resolveTabFromPath(window.location.pathname));
+  // P3: the Subscriptions tab appears ONLY when `multi_subscription` is ON. We
+  // probe GET /api/v1/catalog (404 when OFF) — so with the flag OFF the
+  // dev-manager is byte-for-byte today's experience (no extra tab, no new UI).
+  const [multiSubEnabled, setMultiSubEnabled] = useState(false);
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [_loading, setLoading] = useState(true);
   const [showRevoked, setShowRevoked] = useState(false);
@@ -556,6 +563,38 @@ export const DeveloperView: React.FC = () => {
   }, []);
 
   useEffect(() => { loadData(); }, [loadData]);
+
+  // P3 flag probe: enable the Subscriptions tab only when the catalog resolves
+  // (multi_subscription ON). A 404 (flag OFF) leaves the UI exactly as today.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/v1/catalog', { credentials: 'include' });
+        if (!cancelled) setMultiSubEnabled(res.ok);
+      } catch {
+        if (!cancelled) setMultiSubEnabled(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // If the flag is OFF but the URL resolved to /developer/subscriptions, fall
+  // back to the default tab so no orphaned/empty view is shown.
+  useEffect(() => {
+    if (!multiSubEnabled && activeTab === 'subscriptions') {
+      setActiveTab(DEFAULT_TAB);
+    }
+  }, [multiSubEnabled, activeTab]);
+
+  const visibleTabs = useMemo(() => {
+    if (!multiSubEnabled) return tabs;
+    const idx = tabs.findIndex((t) => t.id === 'api-keys');
+    const subTab = { id: 'subscriptions' as TabId, label: 'Subscriptions', icon: <Box size={14} /> };
+    const next = [...tabs];
+    next.splice(idx + 1, 0, subTab);
+    return next;
+  }, [multiSubEnabled]);
 
   useEffect(() => () => {
     pollAbortControllerRef.current?.abort();
@@ -1180,7 +1219,7 @@ result = [...result].sort((a, b) => {
       </div>
       <div className="border-b border-white/10">
         <nav className="flex gap-1">
-          {tabs.map((tab) => (
+          {visibleTabs.map((tab) => (
             <button key={tab.id} onClick={() => handleTabChange(tab.id)}
               className={`flex items-center gap-2 px-3 py-2 text-xs font-medium transition-all border-b-2 ${activeTab === tab.id ? 'text-accent-emerald' : 'text-text-secondary hover:text-text-primary border-transparent'}`}
               style={{ marginBottom: '-1px', borderBottomColor: activeTab === tab.id ? 'var(--accent-emerald)' : 'transparent' }}>
@@ -1545,6 +1584,10 @@ result = [...result].sort((a, b) => {
                 </Card>
               )}
             </div>
+          )}
+
+          {activeTab === 'subscriptions' && multiSubEnabled && (
+            <SubscriptionsPanel />
           )}
 
           {activeTab === 'usage' && (

--- a/plugins/developer-api/frontend/src/pages/SubscriptionsPanel.tsx
+++ b/plugins/developer-api/frontend/src/pages/SubscriptionsPanel.tsx
@@ -1,0 +1,525 @@
+/**
+ * Subscriptions panel (NAAP P3) — developer-facing multi-app surface.
+ *
+ * Browse the catalog of provider instances, subscribe to one or many, and per
+ * subscription: create / list / revoke native `naap_` keys (the mint-key
+ * control that was previously missing a UI) and view per-key usage.
+ *
+ * This panel renders ONLY when the `multi_subscription` flag is ON — the parent
+ * gates it on a successful `GET /api/v1/catalog` probe (404 when OFF), so with
+ * the flag OFF the dev-manager is byte-for-byte today's experience. All calls
+ * are tenant-scoped to the selected team. The raw key is shown exactly once.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Card, Badge, Modal } from '@naap/ui';
+import { Plus, Trash2, Copy, Check, Loader2, BarChart3, Boxes, Key } from 'lucide-react';
+
+interface TeamInfo {
+  id: string;
+  name: string;
+}
+
+interface CatalogInstance {
+  providerInstanceId: string;
+  slug: string;
+  displayName: string;
+  adapterType: string;
+  plans: Array<{ providerPlanId: string; name: string; capabilities: string[] }>;
+}
+
+interface SubscriptionView {
+  id: string;
+  providerInstanceId: string;
+  providerPlanId: string | null;
+  accountId: string;
+  status: string;
+  appId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SubKey {
+  id: string;
+  keyPrefix: string;
+  label: string | null;
+  status: string;
+  subscriptionId: string | null;
+  createdAt: string;
+}
+
+interface KeyUsage {
+  keyId: string;
+  totals: { requestCount: number; tokensUsed: number; costIncurred: number };
+}
+
+const btnPrimary =
+  'flex items-center gap-2 px-3 py-1.5 bg-accent-emerald text-white rounded-md text-xs font-medium hover:bg-accent-emerald/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed';
+const btnGhost =
+  'px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors rounded-md hover:bg-white/5';
+const selectClassName =
+  'bg-bg-tertiary border border-white/10 rounded-md py-1.5 px-2 text-xs text-text-primary focus:outline-none focus:border-accent-blue appearance-none cursor-pointer';
+
+async function fetchCsrfToken(): Promise<string> {
+  try {
+    const res = await fetch('/api/v1/auth/csrf', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      return data.data?.token || data.token || '';
+    }
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+function unwrap<T>(json: { data?: T } & T): T {
+  return (json.data ?? json) as T;
+}
+
+export const SubscriptionsPanel: React.FC = () => {
+  const [teams, setTeams] = useState<TeamInfo[]>([]);
+  const [teamId, setTeamId] = useState<string>('');
+  const [catalog, setCatalog] = useState<CatalogInstance[]>([]);
+  const [subscriptions, setSubscriptions] = useState<SubscriptionView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyInstanceId, setBusyInstanceId] = useState<string | null>(null);
+
+  // Per-subscription key state.
+  const [expandedSubId, setExpandedSubId] = useState<string | null>(null);
+  const [keysBySub, setKeysBySub] = useState<Record<string, SubKey[]>>({});
+  const [usageByKey, setUsageByKey] = useState<Record<string, KeyUsage>>({});
+  const [mintingSubId, setMintingSubId] = useState<string | null>(null);
+  const [createdRawKey, setCreatedRawKey] = useState('');
+  const [rawKeyCopied, setRawKeyCopied] = useState(false);
+
+  const instanceById = useCallback(
+    (id: string) => catalog.find((c) => c.providerInstanceId === id),
+    [catalog],
+  );
+
+  const loadTeams = useCallback(async () => {
+    const res = await fetch('/api/v1/teams', { credentials: 'include' });
+    if (!res.ok) throw new Error(`Failed to load teams (HTTP ${res.status})`);
+    const list = unwrap<{ teams: TeamInfo[] }>(await res.json()).teams ?? [];
+    setTeams(list);
+    setTeamId((prev) => prev || (list[0]?.id ?? ''));
+    return list;
+  }, []);
+
+  const loadCatalog = useCallback(async () => {
+    const res = await fetch('/api/v1/catalog', { credentials: 'include' });
+    if (!res.ok) throw new Error(`Failed to load catalog (HTTP ${res.status})`);
+    setCatalog(unwrap<{ instances: CatalogInstance[] }>(await res.json()).instances ?? []);
+  }, []);
+
+  const loadSubscriptions = useCallback(async (tid: string) => {
+    if (!tid) {
+      setSubscriptions([]);
+      return;
+    }
+    const res = await fetch(`/api/v1/teams/${encodeURIComponent(tid)}/subscriptions`, {
+      credentials: 'include',
+    });
+    if (!res.ok) throw new Error(`Failed to load subscriptions (HTTP ${res.status})`);
+    setSubscriptions(unwrap<{ subscriptions: SubscriptionView[] }>(await res.json()).subscriptions ?? []);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [list] = await Promise.all([loadTeams(), loadCatalog()]);
+        if (cancelled) return;
+        const tid = list[0]?.id ?? '';
+        if (tid) await loadSubscriptions(tid);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load subscriptions');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadTeams, loadCatalog, loadSubscriptions]);
+
+  useEffect(() => {
+    if (!teamId) return;
+    void loadSubscriptions(teamId).catch((e) =>
+      setError(e instanceof Error ? e.message : 'Failed to load subscriptions'),
+    );
+  }, [teamId, loadSubscriptions]);
+
+  const handleSubscribe = useCallback(
+    async (providerInstanceId: string) => {
+      if (!teamId) return;
+      setBusyInstanceId(providerInstanceId);
+      setError(null);
+      try {
+        const csrf = await fetchCsrfToken();
+        const res = await fetch(`/api/v1/teams/${encodeURIComponent(teamId)}/subscriptions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+          credentials: 'include',
+          body: JSON.stringify({ providerInstanceId }),
+        });
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}));
+          throw new Error(j?.error?.message || `Failed to subscribe (HTTP ${res.status})`);
+        }
+        await loadSubscriptions(teamId);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to subscribe');
+      } finally {
+        setBusyInstanceId(null);
+      }
+    },
+    [teamId, loadSubscriptions],
+  );
+
+  const handleCancel = useCallback(
+    async (subId: string) => {
+      if (!teamId) return;
+      setError(null);
+      try {
+        const csrf = await fetchCsrfToken();
+        const res = await fetch(
+          `/api/v1/teams/${encodeURIComponent(teamId)}/subscriptions/${encodeURIComponent(subId)}`,
+          { method: 'DELETE', headers: { 'X-CSRF-Token': csrf }, credentials: 'include' },
+        );
+        if (!res.ok) throw new Error(`Failed to cancel (HTTP ${res.status})`);
+        await loadSubscriptions(teamId);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to cancel subscription');
+      }
+    },
+    [teamId, loadSubscriptions],
+  );
+
+  const loadKeys = useCallback(
+    async (subId: string) => {
+      if (!teamId) return;
+      const res = await fetch(
+        `/api/v1/teams/${encodeURIComponent(teamId)}/subscriptions/${encodeURIComponent(subId)}/keys`,
+        { credentials: 'include' },
+      );
+      if (!res.ok) throw new Error(`Failed to load keys (HTTP ${res.status})`);
+      const keys = unwrap<{ keys: SubKey[] }>(await res.json()).keys ?? [];
+      setKeysBySub((prev) => ({ ...prev, [subId]: keys }));
+    },
+    [teamId],
+  );
+
+  const toggleExpand = useCallback(
+    async (subId: string) => {
+      const next = expandedSubId === subId ? null : subId;
+      setExpandedSubId(next);
+      if (next) await loadKeys(next).catch((e) => setError(e instanceof Error ? e.message : 'Failed'));
+    },
+    [expandedSubId, loadKeys],
+  );
+
+  const handleMintKey = useCallback(
+    async (subId: string) => {
+      if (!teamId) return;
+      setMintingSubId(subId);
+      setError(null);
+      try {
+        const csrf = await fetchCsrfToken();
+        const res = await fetch(
+          `/api/v1/teams/${encodeURIComponent(teamId)}/subscriptions/${encodeURIComponent(subId)}/keys`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+            credentials: 'include',
+            body: JSON.stringify({}),
+          },
+        );
+        const j = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(j?.error?.message || `Failed to mint key (HTTP ${res.status})`);
+        const raw = unwrap<{ rawKey: string }>(j).rawKey ?? '';
+        setCreatedRawKey(raw);
+        setRawKeyCopied(false);
+        await loadKeys(subId);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to mint key');
+      } finally {
+        setMintingSubId(null);
+      }
+    },
+    [teamId, loadKeys],
+  );
+
+  const handleRevokeKey = useCallback(
+    async (subId: string, keyId: string) => {
+      if (!teamId) return;
+      try {
+        const csrf = await fetchCsrfToken();
+        const res = await fetch(
+          `/api/v1/teams/${encodeURIComponent(teamId)}/subscriptions/${encodeURIComponent(subId)}/keys/${encodeURIComponent(keyId)}`,
+          { method: 'DELETE', headers: { 'X-CSRF-Token': csrf }, credentials: 'include' },
+        );
+        if (!res.ok) throw new Error(`Failed to revoke (HTTP ${res.status})`);
+        await loadKeys(subId);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to revoke key');
+      }
+    },
+    [teamId, loadKeys],
+  );
+
+  const loadUsage = useCallback(
+    async (subId: string, keyId: string) => {
+      if (!teamId) return;
+      try {
+        const res = await fetch(
+          `/api/v1/teams/${encodeURIComponent(teamId)}/subscriptions/${encodeURIComponent(subId)}/keys/${encodeURIComponent(keyId)}/usage`,
+          { credentials: 'include' },
+        );
+        if (!res.ok) throw new Error(`Failed to load usage (HTTP ${res.status})`);
+        const usage = unwrap<KeyUsage>(await res.json());
+        setUsageByKey((prev) => ({ ...prev, [keyId]: usage }));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load usage');
+      }
+    },
+    [teamId],
+  );
+
+  const handleCopyRawKey = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(createdRawKey);
+      setRawKeyCopied(true);
+      setTimeout(() => setRawKeyCopied(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  }, [createdRawKey]);
+
+  if (loading) {
+    return (
+      <Card>
+        <div className="flex items-center justify-center gap-3 py-8">
+          <Loader2 size={16} className="animate-spin text-text-secondary" />
+          <span className="text-sm text-text-secondary">Loading subscriptions…</span>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Boxes size={14} className="text-accent-blue" />
+          <h2 className="text-sm font-semibold text-text-primary">Apps &amp; Subscriptions</h2>
+        </div>
+        {teams.length > 0 && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-secondary">Team</span>
+            <select value={teamId} onChange={(e) => setTeamId(e.target.value)} className={selectClassName}>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-sm text-red-300">{error}</div>
+      )}
+
+      {/* ── Catalog ── */}
+      <Card>
+        <h3 className="text-sm font-semibold text-text-primary mb-3">Catalog</h3>
+        {catalog.length === 0 ? (
+          <p className="text-sm text-text-secondary">No provider instances available yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {catalog.map((c) => (
+              <div
+                key={c.providerInstanceId}
+                className="flex items-center justify-between gap-3 p-3 rounded-lg border border-white/10 bg-bg-tertiary/40"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-text-primary truncate">{c.displayName}</p>
+                  <p className="text-xs text-text-secondary font-mono truncate">
+                    {c.slug} · {c.adapterType}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className={btnPrimary}
+                  disabled={!teamId || busyInstanceId === c.providerInstanceId}
+                  onClick={() => handleSubscribe(c.providerInstanceId)}
+                >
+                  {busyInstanceId === c.providerInstanceId ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : (
+                    <Plus size={14} />
+                  )}
+                  Subscribe
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* ── My subscriptions ── */}
+      <Card>
+        <h3 className="text-sm font-semibold text-text-primary mb-3">My subscriptions</h3>
+        {subscriptions.length === 0 ? (
+          <p className="text-sm text-text-secondary">No subscriptions yet. Subscribe to an app above.</p>
+        ) : (
+          <div className="space-y-2">
+            {subscriptions.map((s) => {
+              const inst = instanceById(s.providerInstanceId);
+              const expanded = expandedSubId === s.id;
+              const keys = keysBySub[s.id] ?? [];
+              return (
+                <div key={s.id} className="rounded-lg border border-white/10 overflow-hidden">
+                  <div className="flex items-center justify-between gap-3 p-3 bg-bg-tertiary/40">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-text-primary truncate">
+                          {inst?.displayName ?? s.providerInstanceId}
+                        </span>
+                        <Badge variant={s.status === 'active' ? 'emerald' : 'rose'}>{s.status}</Badge>
+                      </div>
+                      <p className="text-xs text-text-secondary font-mono truncate">{s.id}</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button type="button" className={btnGhost} onClick={() => toggleExpand(s.id)}>
+                        <span className="inline-flex items-center gap-1">
+                          <Key size={14} /> {expanded ? 'Hide keys' : 'Keys'}
+                        </span>
+                      </button>
+                      {s.status === 'active' && (
+                        <button
+                          type="button"
+                          className="p-1.5 hover:bg-white/5 rounded-md text-accent-rose"
+                          title="Cancel subscription"
+                          onClick={() => handleCancel(s.id)}
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  {expanded && (
+                    <div className="border-t border-white/10 p-3 space-y-3">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-text-secondary">
+                          {keys.length} key{keys.length !== 1 ? 's' : ''}
+                        </span>
+                        <button
+                          type="button"
+                          className={btnPrimary}
+                          disabled={s.status !== 'active' || mintingSubId === s.id}
+                          onClick={() => handleMintKey(s.id)}
+                        >
+                          {mintingSubId === s.id ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : (
+                            <Plus size={14} />
+                          )}
+                          Create Key
+                        </button>
+                      </div>
+                      {keys.length === 0 ? (
+                        <p className="text-xs text-text-secondary">No keys for this subscription yet.</p>
+                      ) : (
+                        <div className="space-y-1.5">
+                          {keys.map((k) => {
+                            const usage = usageByKey[k.id];
+                            return (
+                              <div
+                                key={k.id}
+                                className="flex items-center justify-between gap-3 rounded-md border border-white/5 px-3 py-2"
+                              >
+                                <div className="min-w-0">
+                                  <span className="text-sm font-mono text-text-primary">
+                                    {k.label ? `${k.label} · ` : ''}
+                                    {k.keyPrefix}
+                                  </span>
+                                  {usage && (
+                                    <span className="ml-2 text-xs text-text-secondary">
+                                      {usage.totals.requestCount.toLocaleString()} req
+                                    </span>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <Badge variant={k.status === 'ACTIVE' ? 'emerald' : 'rose'}>{k.status}</Badge>
+                                  <button
+                                    type="button"
+                                    className="p-1.5 hover:bg-white/5 rounded-md text-text-secondary"
+                                    title="View usage"
+                                    onClick={() => loadUsage(s.id, k.id)}
+                                  >
+                                    <BarChart3 size={15} />
+                                  </button>
+                                  {k.status !== 'REVOKED' && (
+                                    <button
+                                      type="button"
+                                      className="p-1.5 hover:bg-white/5 rounded-md text-accent-rose"
+                                      title="Revoke key"
+                                      onClick={() => handleRevokeKey(s.id, k.id)}
+                                    >
+                                      <Trash2 size={15} />
+                                    </button>
+                                  )}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Card>
+
+      {/* ── New-key reveal (shown once) ── */}
+      <Modal isOpen={createdRawKey !== ''} onClose={() => setCreatedRawKey('')} title="API Key Created" size="lg">
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            Store this key securely. It is provider-opaque and will not be shown again.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 bg-bg-tertiary border border-white/10 rounded-lg py-2 px-3 font-mono text-sm text-accent-emerald break-all select-all">
+              {createdRawKey}
+            </code>
+            <button
+              type="button"
+              onClick={handleCopyRawKey}
+              className="flex-shrink-0 p-2 bg-bg-tertiary border border-white/10 rounded-lg hover:bg-white/5 transition-colors"
+              title="Copy to clipboard"
+            >
+              {rawKeyCopied ? <Check size={18} className="text-emerald-400" /> : <Copy size={18} className="text-text-secondary" />}
+            </button>
+          </div>
+          <div className="flex justify-end">
+            <button type="button" className={btnPrimary} onClick={() => setCreatedRawKey('')}>
+              Done
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default SubscriptionsPanel;


### PR DESCRIPTION
## Phase P3 — developer-facing surface (stacked on P2)

Builds the **catalog → subscribe → keys-per-subscription → per-key usage** developer surface for the multi-app billing model. Everything is gated behind **`multi_subscription` (default OFF)**, so with the flag OFF the current single-app dashboard and the existing seat/key routes are **byte-for-byte unchanged**.

- **Base:** `feat/per-key-resolution-p2` (P2 PR #400) — diff is P3-only.
- Stacking: P0 #398 → P1 #399 → P2 #400 → **P3 (this PR)**.

## Backend routes (flag-gated → 404 when OFF; tenant-scoped via `validateTeamAccess`)
- `GET /api/v1/catalog` — list enabled `ProviderInstance`s a developer can subscribe to (plans stubbed `[]` until the P4 plan-spec sync; exposes only public identity, never `config`/`secretRef`).
- `GET/POST /api/v1/teams/{teamId}/subscriptions` — list / create subscriptions (create = team admin).
- `DELETE /api/v1/teams/{teamId}/subscriptions/{subId}` — cancel/deactivate (idempotent).
- `GET/POST /api/v1/teams/{teamId}/subscriptions/{subId}/keys` — list / **mint `naap_` keys bound to the subscription** (this is the native-key mint path the env-build worker found missing a UI). Reuses the seat-mint rules: caller's own active seat + per-seat key limit; stores the encrypted, provider-opaque account pointer.
- `DELETE …/keys/{keyId}` — revoke (fails closed instantly — non-ACTIVE keys reject before any provider call).
- `GET …/keys/{keyId}/usage` — per-key usage rollup from `DevApiUsageLog` (INV-scoping: a key lookup is scoped to BOTH team + subscription, so subscription A can never read B's usage).

## Dev-manager UI (`plugins/developer-api/frontend`)
- New **flag-gated "Subscriptions" tab** in `DeveloperView`, shown **only when the `GET /api/v1/catalog` probe resolves** (404 ⇒ no tab, today's UI). Self-contained `SubscriptionsPanel.tsx`:
  - Browse the catalog and **subscribe** to apps.
  - List / cancel subscriptions (team selector when the user has multiple teams).
  - Per subscription: **Create Key** (the new mint-native-key control), list, revoke, and view per-key usage. **Raw key shown exactly once.**
- The existing "Create Key" (provider-OAuth) flow is untouched.

## Flag(s)
- Reuses **`multi_subscription`** (default **OFF**). No new flag added.

## Guardrails / tests
- **INV no-regression:** every new route returns **404 with no DB read** when the flag is OFF; UI tab hidden. Existing seat/key routes keep current behavior (`subscriptionId` absent).
- New tests: DB-free `subscription-catalog` helper unit test + API tests for catalog / subscribe / keys-per-subscription / usage (incl. tenant + cross-subscription isolation).
- `npx vitest run`: **119 files, 1152 passed, 1 skipped**.
- `tsc --noEmit`: **15 pre-existing errors, none in touched files** (baseline unchanged).
- `vite build` (developer-api frontend): **green**.
- No secrets in logs/UI; `accountId` never logged.

## Deferred (not in P3)
- Provider account **provisioning via adapter** (no SPI exists yet) — `accountId` defaults to the team's existing billing binding or a caller-supplied value; provisioning is owned by P4 / provider coordination.
- Synced `ProviderPlan` rows (catalog plans are `[]`) — **P4**.

Do **not** merge. P4 not started.

Made with [Cursor](https://cursor.com)