### PR TITLE
feat(billing): plan-spec sync + per-app discovery generation (P4)

### DIFF
--- a/apps/web-next/src/app/api/v1/billing/plans/refresh/route.ts
+++ b/apps/web-next/src/app/api/v1/billing/plans/refresh/route.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /api/v1/orchestrator-leaderboard-adjacent billing plan-spec sync (P4).
+ *
+ *   POST /api/v1/billing/plans/refresh
+ *   auth: Authorization: Bearer <CRON_SECRET>   (same pattern as plans/refresh)
+ *
+ * Cron-triggered PULL sync: for each enabled `ProviderInstance`, pull its
+ * published plans into `ProviderPlan` rows and auto-generate per-app
+ * `DiscoveryPlan`s (Deliverable 2). Gated by `plan_spec_sync` (default OFF):
+ * with the flag OFF the handler is a strict no-op (`{ skipped: true }`) — no
+ * ProviderInstance is read, no sync runs, discovery is unchanged. Idempotent +
+ * graceful by construction (see `syncAllProviderInstancePlans`).
+ */
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { verifyCronAuth } from '@/lib/orchestrator-leaderboard/cron-auth';
+import { syncAllProviderInstancePlans } from '@/lib/billing/plan-spec-sync';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!verifyCronAuth(request)) {
+    return NextResponse.json(
+      { success: false, error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const result = await syncAllProviderInstancePlans();
+    if (!result.enabled) {
+      return NextResponse.json({ success: true, data: { skipped: true, reason: 'flag_off' } });
+    }
+    const plansUpserted = result.instances.reduce((n, i) => n + i.plansUpserted, 0);
+    const discoveryPlansUpserted = result.instances.reduce(
+      (n, i) => n + i.discoveryPlansUpserted,
+      0,
+    );
+    return NextResponse.json({
+      success: true,
+      data: {
+        skipped: false,
+        instances: result.instances.length,
+        plansUpserted,
+        discoveryPlansUpserted,
+      },
+    });
+  } catch (err) {
+    console.error('[billing/plans/refresh] syncAllProviderInstancePlans failed:', err);
+    return NextResponse.json(
+      { success: false, error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web-next/src/app/api/v1/catalog/route.test.ts
+++ b/apps/web-next/src/app/api/v1/catalog/route.test.ts
@@ -9,13 +9,24 @@ const isFeatureEnabled = vi.fn();
 vi.mock('@/lib/feature-flags', () => ({
   isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
   MULTI_SUBSCRIPTION_FLAG: 'multi_subscription',
+  PLAN_SPEC_SYNC_FLAG: 'plan_spec_sync',
 }));
 
 const validateSession = vi.fn();
 vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
 
-const prisma = vi.hoisted(() => ({ providerInstance: { findMany: vi.fn() } }));
+const prisma = vi.hoisted(() => ({
+  providerInstance: { findMany: vi.fn() },
+  providerPlan: { findMany: vi.fn() },
+}));
 vi.mock('@/lib/db', () => ({ prisma }));
+
+/** Default: multi_subscription ON, plan_spec_sync OFF (so plans stay []). */
+function flagState(plan_spec_sync = false): void {
+  isFeatureEnabled.mockImplementation(async (flag: string) =>
+    flag === 'plan_spec_sync' ? plan_spec_sync : true,
+  );
+}
 
 function req(headers: Record<string, string> = { cookie: 'naap_auth_token=tok' }): NextRequest {
   return new NextRequest('http://localhost/api/v1/catalog', { headers });
@@ -23,11 +34,12 @@ function req(headers: Record<string, string> = { cookie: 'naap_auth_token=tok' }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  isFeatureEnabled.mockResolvedValue(true);
+  flagState(false);
   validateSession.mockResolvedValue({ id: 'user-1' });
   prisma.providerInstance.findMany.mockResolvedValue([
     { id: 'inst-1', slug: 'pymthouse-default', displayName: 'PymtHouse', adapterType: 'pymthouse', enabled: true, sortOrder: 0 },
   ]);
+  prisma.providerPlan.findMany.mockResolvedValue([]);
 });
 
 describe('GET /api/v1/catalog', () => {
@@ -43,7 +55,7 @@ describe('GET /api/v1/catalog', () => {
     expect(res.status).toBe(401);
   });
 
-  it('lists enabled provider instances (no secrets), plans stubbed empty', async () => {
+  it('INV: plan_spec_sync OFF → plans empty and ProviderPlan is never read', async () => {
     const res = await GET(req());
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -55,10 +67,35 @@ describe('GET /api/v1/catalog', () => {
       adapterType: 'pymthouse',
       plans: [],
     });
+    expect(prisma.providerPlan.findMany).not.toHaveBeenCalled();
     // Catalog only requests enabled instances.
     expect(prisma.providerInstance.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { enabled: true } }),
     );
     expect(JSON.stringify(json.data)).not.toContain('secretRef');
+  });
+
+  it('plan_spec_sync ON → joins synced ProviderPlan rows into the catalog', async () => {
+    flagState(true);
+    prisma.providerPlan.findMany.mockResolvedValue([
+      {
+        providerInstanceId: 'inst-1',
+        providerPlanId: 'plan_basic',
+        name: 'Basic',
+        capabilities: ['image-to-image/nano-banana'],
+        enabled: true,
+      },
+    ]);
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.instances[0].plans).toEqual([
+      { providerPlanId: 'plan_basic', name: 'Basic', capabilities: ['image-to-image/nano-banana'] },
+    ]);
+    expect(prisma.providerPlan.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { providerInstanceId: { in: ['inst-1'] }, enabled: true },
+      }),
+    );
   });
 });

--- a/apps/web-next/src/app/api/v1/catalog/route.ts
+++ b/apps/web-next/src/app/api/v1/catalog/route.ts
@@ -6,8 +6,9 @@
  *   → { instances: [{ providerInstanceId, slug, displayName, adapterType, plans[] }] }
  *
  * Lists the apps/plans a developer can subscribe to across all enabled
- * `ProviderInstance`s. Plans are empty in P3 — the synced `ProviderPlan` model +
- * plan-spec pull land in P4; the catalog "exposes what exists" (the instances).
+ * `ProviderInstance`s. Each instance's `plans[]` is populated from the synced
+ * `ProviderPlan` rows when `plan_spec_sync` is ON (P4); when OFF the catalog
+ * exposes the instances with empty `plans[]` (P3 behavior — what exists today).
  *
  * Gated behind `multi_subscription` (default OFF): 404 when OFF, so the catalog
  * is inert/hidden and the current single-app dashboard is unchanged. Never emits

--- a/apps/web-next/src/app/api/v1/catalog/route.ts
+++ b/apps/web-next/src/app/api/v1/catalog/route.ts
@@ -20,8 +20,12 @@ import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/db';
 import { success, errors, getAuthToken } from '@/lib/api/response';
 import { validateSession } from '@/lib/api/auth';
-import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG } from '@/lib/feature-flags';
-import { toCatalogInstanceView } from '@/lib/billing/subscription-catalog';
+import { isFeatureEnabled, MULTI_SUBSCRIPTION_FLAG, PLAN_SPEC_SYNC_FLAG } from '@/lib/feature-flags';
+import {
+  toCatalogInstanceView,
+  toCatalogPlanView,
+  type CatalogPlanView,
+} from '@/lib/billing/subscription-catalog';
 
 function noStore(res: NextResponse): NextResponse {
   res.headers.set('Cache-Control', 'no-store');
@@ -59,8 +63,35 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       },
     });
 
-    // P4 will join synced ProviderPlan rows here; P3 exposes instances only.
-    const catalog = instances.map((instance) => toCatalogInstanceView(instance));
+    // P4: join synced ProviderPlan rows so the catalog exposes subscribable
+    // plans. Only when `plan_spec_sync` is ON — OFF leaves ProviderPlan unread
+    // and plans `[]` (P3 behavior), so discovery/catalog stay today's static.
+    const plansByInstance = new Map<string, CatalogPlanView[]>();
+    if (await isFeatureEnabled(PLAN_SPEC_SYNC_FLAG)) {
+      const instanceIds = instances.map((i) => i.id);
+      if (instanceIds.length > 0) {
+        const providerPlans = await prisma.providerPlan.findMany({
+          where: { providerInstanceId: { in: instanceIds }, enabled: true },
+          orderBy: [{ name: 'asc' }],
+          select: {
+            providerInstanceId: true,
+            providerPlanId: true,
+            name: true,
+            capabilities: true,
+            enabled: true,
+          },
+        });
+        for (const row of providerPlans) {
+          const list = plansByInstance.get(row.providerInstanceId) ?? [];
+          list.push(toCatalogPlanView(row));
+          plansByInstance.set(row.providerInstanceId, list);
+        }
+      }
+    }
+
+    const catalog = instances.map((instance) =>
+      toCatalogInstanceView(instance, plansByInstance.get(instance.id) ?? []),
+    );
 
     log('info', 'catalog.list', { correlationId, instanceCount: catalog.length });
     return noStore(success({ instances: catalog }));

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -31,6 +31,7 @@ import { parseApiKey } from '@naap/database';
 import { AdapterNotImplementedError } from '@/lib/billing/adapter';
 import { getBillingProviderAdapter } from '@/lib/billing/registry';
 import { resolveKeyProviderBinding } from '@/lib/billing/key-provider-binding';
+import { resolveKeyDiscovery } from '@/lib/billing/key-discovery';
 import {
   resolveNativeKeyToProviderSession,
   verifyNativeKeyHash,
@@ -203,6 +204,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return noStore(errors.forbidden('Requested capability not granted'));
     }
 
+    // P4: select the per-app discovery this key is matched to
+    // (key → subscription → ProviderPlan → DiscoveryPlan). Reachable only in
+    // subscription mode AND when `plan_spec_sync` is ON with a synced plan;
+    // otherwise null ⇒ no `discovery` field ⇒ byte-for-byte today's response.
+    const resolvedDiscovery =
+      binding.mode === 'subscription'
+        ? await resolveKeyDiscovery(binding.subscription)
+        : null;
+    const discovery = resolvedDiscovery
+      ? { planId: resolvedDiscovery.discoveryPlanId, url: resolvedDiscovery.url }
+      : null;
+
     // Fire-and-forget last-used update; never block validation on it.
     prisma.devApiKey.update({ where: { id: key.id }, data: { lastUsedAt: new Date() } }).catch(() => {});
 
@@ -213,6 +226,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       capabilities,
       quota,
       signerSession: resolved.signerSession,
+      discovery,
     });
 
     log('info', 'keys.validate.ok', {
@@ -222,6 +236,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       hasApp: Boolean(appId),
       capabilityCount: capabilities.length,
       subscriptionScoped: binding.mode === 'subscription',
+      hasDiscovery: Boolean(discovery),
     });
     return noStore(success(body));
   } catch (err) {

--- a/apps/web-next/src/lib/billing/auto-discovery-plan.test.ts
+++ b/apps/web-next/src/lib/billing/auto-discovery-plan.test.ts
@@ -1,0 +1,124 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from 'vitest';
+
+import type { PymthouseDiscoveryPlanRow } from '@/lib/pymthouse-discovery-plans';
+import {
+  AUTO_DISCOVERY_DEFAULT_TOP_N,
+  buildAutoDiscoveryPlanId,
+  computeProviderPlanRevision,
+  planRowToCapabilities,
+  toAutoDiscoveryPlanFields,
+} from './auto-discovery-plan';
+
+const ROW: PymthouseDiscoveryPlanRow = {
+  id: 'plan_basic',
+  name: 'Basic',
+  status: 'active',
+  discoveryPolicy: null,
+  capabilities: [
+    { pipeline: 'live-video-to-video', modelId: 'scope', discoveryPolicy: null },
+    { pipeline: 'image-to-image', modelId: 'nano-banana', discoveryPolicy: null },
+  ],
+};
+
+describe('buildAutoDiscoveryPlanId', () => {
+  it('is the deterministic "${instance}:${plan}" key', () => {
+    expect(buildAutoDiscoveryPlanId('pi_1', 'plan_basic')).toBe('pi_1:plan_basic');
+  });
+});
+
+describe('planRowToCapabilities', () => {
+  it('normalizes caps to sorted, de-duped pipeline/modelId strings', () => {
+    expect(planRowToCapabilities(ROW)).toEqual([
+      'image-to-image/nano-banana',
+      'live-video-to-video/scope',
+    ]);
+  });
+
+  it('drops caps missing a pipeline or model', () => {
+    const row: PymthouseDiscoveryPlanRow = {
+      ...ROW,
+      capabilities: [
+        { pipeline: '', modelId: 'x', discoveryPolicy: null },
+        { pipeline: 'p', modelId: '', discoveryPolicy: null },
+        { pipeline: 'p', modelId: 'm', discoveryPolicy: null },
+      ],
+    };
+    expect(planRowToCapabilities(row)).toEqual(['p/m']);
+  });
+});
+
+describe('computeProviderPlanRevision', () => {
+  it('is stable for the same content (idempotent) and order-independent on caps', () => {
+    const a = computeProviderPlanRevision({
+      name: 'Basic',
+      capabilities: ['b/y', 'a/x'],
+      discoveryPolicy: { topN: 5 },
+    });
+    const b = computeProviderPlanRevision({
+      name: 'Basic',
+      capabilities: ['a/x', 'b/y'],
+      discoveryPolicy: { topN: 5 },
+    });
+    expect(a).toBe(b);
+  });
+
+  it('changes when the spec changes', () => {
+    const base = computeProviderPlanRevision({
+      name: 'Basic',
+      capabilities: ['a/x'],
+      discoveryPolicy: null,
+    });
+    expect(
+      computeProviderPlanRevision({ name: 'Basic', capabilities: ['a/x', 'b/y'], discoveryPolicy: null }),
+    ).not.toBe(base);
+    expect(
+      computeProviderPlanRevision({ name: 'Pro', capabilities: ['a/x'], discoveryPolicy: null }),
+    ).not.toBe(base);
+    expect(
+      computeProviderPlanRevision({ name: 'Basic', capabilities: ['a/x'], discoveryPolicy: { topN: 1 } }),
+    ).not.toBe(base);
+  });
+});
+
+describe('toAutoDiscoveryPlanFields', () => {
+  it('defaults topN and nulls policy fields when no discoveryPolicy', () => {
+    const fields = toAutoDiscoveryPlanFields({
+      adapterType: 'pymthouse',
+      name: 'Basic',
+      capabilities: ['a/x'],
+      discoveryPolicy: null,
+    });
+    expect(fields).toEqual({
+      name: 'Basic',
+      billingProviderSlug: 'pymthouse',
+      capabilities: ['a/x'],
+      topN: AUTO_DISCOVERY_DEFAULT_TOP_N,
+      slaWeights: null,
+      slaMinScore: null,
+      sortBy: null,
+      filters: null,
+    });
+  });
+
+  it('flows discoveryPolicy straight through onto the DiscoveryPlan fields', () => {
+    const fields = toAutoDiscoveryPlanFields({
+      adapterType: 'pymthouse',
+      name: 'Pro',
+      capabilities: ['a/x'],
+      discoveryPolicy: {
+        topN: 25,
+        sortBy: 'latency',
+        slaMinScore: 0.8,
+        slaWeights: { latency: 0.5 },
+        filters: { priceMax: 100 },
+      },
+    });
+    expect(fields.topN).toBe(25);
+    expect(fields.sortBy).toBe('latency');
+    expect(fields.slaMinScore).toBe(0.8);
+    expect(fields.slaWeights).toEqual({ latency: 0.5 });
+    expect(fields.filters).toEqual({ priceMax: 100 });
+  });
+});

--- a/apps/web-next/src/lib/billing/auto-discovery-plan.ts
+++ b/apps/web-next/src/lib/billing/auto-discovery-plan.ts
@@ -1,0 +1,123 @@
+/**
+ * Auto per-app discovery generation — DB-free mapping (NAAP P4, Deliverable 2).
+ *
+ * Turns a synced provider plan-spec (`ProviderPlan`, pulled per
+ * `ProviderInstance`) into:
+ *   - the normalized `capabilities` list (`pipeline/modelId` strings),
+ *   - a content `revision` fingerprint (idempotency key for the sync),
+ *   - the `DiscoveryPlan` field set the orchestrator-leaderboard already serves
+ *     via `GET /plans/:id/python-gateway` (capability-filtered + tier-shuffled).
+ *
+ * Pure + side-effect free so it can be unit-tested without a DB. The persistence
+ * (upsert) lives in `plan-spec-sync.ts`; the request-time selection lives in
+ * `key-discovery.ts`. Both reuse {@link buildAutoDiscoveryPlanId} so the
+ * key → ProviderPlan → DiscoveryPlan id mapping cannot drift.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type {
+  DiscoveryPolicy,
+  PymthouseDiscoveryPlanRow,
+} from '@/lib/pymthouse-discovery-plans';
+
+/** DiscoveryPlan.topN default when the provider plan-spec sets no policy topN. */
+export const AUTO_DISCOVERY_DEFAULT_TOP_N = 10;
+
+/**
+ * Deterministic `DiscoveryPlan.billingPlanId` for an auto-generated per-app
+ * discovery: `"${providerInstanceId}:${providerPlanId}"`. This is the stable
+ * idempotency key (the column is `@unique`) AND the bridge the request-time
+ * resolver uses to map `key → Subscription → ProviderPlan → DiscoveryPlan`.
+ */
+export function buildAutoDiscoveryPlanId(
+  providerInstanceId: string,
+  providerPlanId: string,
+): string {
+  return `${providerInstanceId}:${providerPlanId}`;
+}
+
+/**
+ * Normalize a pulled plan row's capabilities into the leaderboard
+ * `pipeline/modelId` strings, de-duplicated and sorted for a stable fingerprint.
+ * Rows missing either part are dropped (they cannot match an orchestrator).
+ */
+export function planRowToCapabilities(row: PymthouseDiscoveryPlanRow): string[] {
+  const set = new Set<string>();
+  for (const cap of row.capabilities) {
+    const pipeline = cap.pipeline.trim();
+    const modelId = cap.modelId.trim();
+    if (!pipeline || !modelId) continue;
+    set.add(`${pipeline}/${modelId}`);
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Content fingerprint of the meaningful, discovery-affecting fields of a plan
+ * spec. Re-running the sync recomputes the same revision for an unchanged spec,
+ * so the upsert is idempotent and only a genuine change re-generates the
+ * `DiscoveryPlan`. Stable JSON (sorted keys) keeps the hash order-independent.
+ */
+export function computeProviderPlanRevision(input: {
+  name: string;
+  capabilities: string[];
+  discoveryPolicy: DiscoveryPolicy | null;
+}): string {
+  const payload = stableStringify({
+    name: input.name,
+    capabilities: [...input.capabilities].sort((a, b) => a.localeCompare(b)),
+    discoveryPolicy: input.discoveryPolicy ?? null,
+  });
+  return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+/** DiscoveryPlan fields auto-derived from a ProviderPlan spec. */
+export interface AutoDiscoveryPlanFields {
+  name: string;
+  billingProviderSlug: string;
+  capabilities: string[];
+  topN: number;
+  slaWeights: DiscoveryPolicy['slaWeights'] | null;
+  slaMinScore: number | null;
+  sortBy: string | null;
+  filters: DiscoveryPolicy['filters'] | null;
+}
+
+/**
+ * Map a synced provider plan-spec onto the `DiscoveryPlan` field set. The
+ * `discoveryPolicy` (topN/sortBy/slaMinScore/slaWeights/filters) flows straight
+ * through onto the DiscoveryPlan, so the existing per-cap filter + tier-shuffle
+ * serve the per-app discovery with no route change.
+ */
+export function toAutoDiscoveryPlanFields(input: {
+  adapterType: string;
+  name: string;
+  capabilities: string[];
+  discoveryPolicy: DiscoveryPolicy | null;
+}): AutoDiscoveryPlanFields {
+  const policy = input.discoveryPolicy;
+  return {
+    name: input.name,
+    billingProviderSlug: input.adapterType,
+    capabilities: input.capabilities,
+    topN: policy?.topN ?? AUTO_DISCOVERY_DEFAULT_TOP_N,
+    slaWeights: policy?.slaWeights ?? null,
+    slaMinScore: policy?.slaMinScore ?? null,
+    sortBy: policy?.sortBy ?? null,
+    filters: policy?.filters ?? null,
+  };
+}
+
+/** Stable JSON stringify (recursively sorted object keys) for fingerprinting. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => stableStringify(v)).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort((a, b) => a.localeCompare(b));
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}

--- a/apps/web-next/src/lib/billing/key-discovery.test.ts
+++ b/apps/web-next/src/lib/billing/key-discovery.test.ts
@@ -1,0 +1,86 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    discoveryPlan: { findUnique: vi.fn() },
+  },
+}));
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  PLAN_SPEC_SYNC_FLAG: 'plan_spec_sync',
+}));
+
+import { prisma } from '@/lib/db';
+import { buildDiscoveryUrl, resolveKeyDiscovery } from './key-discovery';
+
+const findUnique = prisma.discoveryPlan.findUnique as ReturnType<typeof vi.fn>;
+
+const SUB = { providerInstanceId: 'pi_1', providerPlanId: 'plan_basic' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('buildDiscoveryUrl', () => {
+  it('targets the per-app python-gateway route', () => {
+    expect(buildDiscoveryUrl('dp_1')).toBe(
+      '/api/v1/orchestrator-leaderboard/plans/dp_1/python-gateway',
+    );
+  });
+});
+
+describe('resolveKeyDiscovery', () => {
+  describe('INV: returns null (no discovery field) without reading DB', () => {
+    it('flag OFF → null and NEVER reads DiscoveryPlan (today\'s response)', async () => {
+      isFeatureEnabled.mockResolvedValue(false);
+      expect(await resolveKeyDiscovery(SUB)).toBeNull();
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+
+    it('subscription without providerPlanId → null, no flag check, no DB read', async () => {
+      const res = await resolveKeyDiscovery({ providerInstanceId: 'pi_1', providerPlanId: null });
+      expect(res).toBeNull();
+      expect(isFeatureEnabled).not.toHaveBeenCalled();
+      expect(findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flag ON', () => {
+    beforeEach(() => isFeatureEnabled.mockResolvedValue(true));
+
+    it('selects the auto DiscoveryPlan by "${instance}:${plan}" and returns its id + URL', async () => {
+      findUnique.mockResolvedValue({ id: 'dp_42', enabled: true });
+      const res = await resolveKeyDiscovery(SUB);
+      expect(findUnique).toHaveBeenCalledWith({
+        where: { billingPlanId: 'pi_1:plan_basic' },
+        select: { id: true, enabled: true },
+      });
+      expect(res).toEqual({
+        discoveryPlanId: 'dp_42',
+        url: '/api/v1/orchestrator-leaderboard/plans/dp_42/python-gateway',
+      });
+    });
+
+    it('no matching plan → null (graceful, e.g. sync has not run yet)', async () => {
+      findUnique.mockResolvedValue(null);
+      expect(await resolveKeyDiscovery(SUB)).toBeNull();
+    });
+
+    it('disabled plan → null', async () => {
+      findUnique.mockResolvedValue({ id: 'dp_42', enabled: false });
+      expect(await resolveKeyDiscovery(SUB)).toBeNull();
+    });
+
+    it('DB error → null, never throws', async () => {
+      findUnique.mockRejectedValue(new Error('db down'));
+      expect(await resolveKeyDiscovery(SUB)).toBeNull();
+    });
+  });
+});

--- a/apps/web-next/src/lib/billing/key-discovery.ts
+++ b/apps/web-next/src/lib/billing/key-discovery.ts
@@ -1,0 +1,86 @@
+/**
+ * Per-key discovery selection (NAAP P4, Deliverable 2 §4.4).
+ *
+ * Closes the "which discovery does THIS api key get?" hop. Reusing the P2
+ * binding, the presented `naap_` key resolves
+ *
+ *     key → Subscription → ProviderPlan → DiscoveryPlan
+ *
+ * and this module turns the resolved subscription into the per-app discovery
+ * URL the orchestrator-leaderboard already serves
+ * (`/api/v1/orchestrator-leaderboard/plans/{discoveryPlanId}/python-gateway`).
+ * The validate front door surfaces that URL as an ADDITIVE response field; the
+ * actual signer/SDK auto-config wiring is P5.
+ *
+ * Zero regression: gated by `plan_spec_sync` (default OFF). With the flag OFF,
+ * a subscription without `providerPlanId`, or no matching/enabled auto
+ * `DiscoveryPlan`, this returns null and the validate response is byte-for-byte
+ * today's (no `discovery` field). Never throws — any error degrades to null.
+ */
+
+import 'server-only';
+
+import { prisma } from '@/lib/db';
+import { isFeatureEnabled, PLAN_SPEC_SYNC_FLAG } from '@/lib/feature-flags';
+
+import { buildAutoDiscoveryPlanId } from './auto-discovery-plan';
+import type { SubscriptionRecord } from './subscription';
+
+/** Resolved per-key discovery: the auto DiscoveryPlan id + its python-gateway URL. */
+export interface KeyDiscoveryResolution {
+  discoveryPlanId: string;
+  url: string;
+}
+
+/** Build the per-app discovery (python-gateway) URL for a DiscoveryPlan id. */
+export function buildDiscoveryUrl(discoveryPlanId: string): string {
+  return `/api/v1/orchestrator-leaderboard/plans/${encodeURIComponent(discoveryPlanId)}/python-gateway`;
+}
+
+/**
+ * Resolve the per-app discovery URL for a subscription, selected by its
+ * `key → Subscription → ProviderPlan → DiscoveryPlan` chain.
+ *
+ *  - `plan_spec_sync` OFF        → null (table never read; today's behavior).
+ *  - subscription w/o plan id    → null (no synced plan to key off).
+ *  - no matching/enabled plan    → null (graceful — e.g. sync hasn't run yet).
+ *  - matching enabled plan       → `{ discoveryPlanId, url }`.
+ *
+ * Never throws — DB errors degrade to null so the validate front door is never
+ * hard-failed by discovery resolution.
+ */
+export async function resolveKeyDiscovery(
+  subscription: Pick<SubscriptionRecord, 'providerInstanceId' | 'providerPlanId'>,
+): Promise<KeyDiscoveryResolution | null> {
+  if (!subscription.providerPlanId) {
+    return null;
+  }
+
+  let flagOn = false;
+  try {
+    flagOn = await isFeatureEnabled(PLAN_SPEC_SYNC_FLAG);
+  } catch {
+    flagOn = false;
+  }
+  if (!flagOn) {
+    return null;
+  }
+
+  const billingPlanId = buildAutoDiscoveryPlanId(
+    subscription.providerInstanceId,
+    subscription.providerPlanId,
+  );
+
+  try {
+    const plan = await prisma.discoveryPlan.findUnique({
+      where: { billingPlanId },
+      select: { id: true, enabled: true },
+    });
+    if (!plan || !plan.enabled) {
+      return null;
+    }
+    return { discoveryPlanId: plan.id, url: buildDiscoveryUrl(plan.id) };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web-next/src/lib/billing/plan-spec-sync.test.ts
+++ b/apps/web-next/src/lib/billing/plan-spec-sync.test.ts
@@ -1,0 +1,234 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    providerInstance: { findMany: vi.fn() },
+    providerPlan: { findUnique: vi.fn(), upsert: vi.fn() },
+    discoveryPlan: { upsert: vi.fn() },
+  },
+}));
+
+const isFeatureEnabled = vi.fn();
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  PLAN_SPEC_SYNC_FLAG: 'plan_spec_sync',
+}));
+
+vi.mock('./pymthouse-adapter', () => ({ PYMTHOUSE_ADAPTER_SLUG: 'pymthouse' }));
+
+const parsePymthouseInstanceConfig = vi.fn();
+const getProviderInstanceSecret = vi.fn();
+vi.mock('./provider-instance', () => ({
+  parsePymthouseInstanceConfig: (...a: unknown[]) => parsePymthouseInstanceConfig(...a),
+  getProviderInstanceSecret: (...a: unknown[]) => getProviderInstanceSecret(...a),
+}));
+
+const getBuilderApiV1BaseFromIssuerUrl = vi.fn();
+vi.mock('@pymthouse/builder-sdk/config', () => ({
+  getBuilderApiV1BaseFromIssuerUrl: (...a: unknown[]) => getBuilderApiV1BaseFromIssuerUrl(...a),
+}));
+
+vi.mock('@/lib/pymthouse-discovery-plans', () => ({
+  fetchPymthouseDiscoveryPlans: vi.fn(),
+}));
+
+import { prisma } from '@/lib/db';
+import {
+  computeProviderPlanRevision,
+  planRowToCapabilities,
+} from './auto-discovery-plan';
+import type { PymthouseDiscoveryPlanRow } from '@/lib/pymthouse-discovery-plans';
+import type { ProviderInstanceRecord } from './provider-instance';
+import {
+  syncAllProviderInstancePlans,
+  syncProviderInstancePlans,
+} from './plan-spec-sync';
+
+const findManyInstances = prisma.providerInstance.findMany as ReturnType<typeof vi.fn>;
+const findUniquePlan = prisma.providerPlan.findUnique as ReturnType<typeof vi.fn>;
+const upsertPlan = prisma.providerPlan.upsert as ReturnType<typeof vi.fn>;
+const upsertDiscovery = prisma.discoveryPlan.upsert as ReturnType<typeof vi.fn>;
+
+const PYMTHOUSE_INSTANCE: ProviderInstanceRecord = {
+  id: 'pi_1',
+  adapterType: 'pymthouse',
+  slug: 'app-one',
+  config: { issuerUrl: 'https://op.example', publicClientId: 'pub', m2mClientId: 'm2m' },
+  secretRef: 'vault:pi_1:m2m',
+  enabled: true,
+};
+
+const PLAN_ROW: PymthouseDiscoveryPlanRow = {
+  id: 'plan_basic',
+  name: 'Basic',
+  status: 'active',
+  discoveryPolicy: { topN: 5 },
+  capabilities: [
+    { pipeline: 'live-video-to-video', modelId: 'scope', discoveryPolicy: null },
+    { pipeline: 'image-to-image', modelId: 'nano-banana', discoveryPolicy: null },
+  ],
+};
+
+function expectedRevision(): string {
+  return computeProviderPlanRevision({
+    name: PLAN_ROW.name,
+    capabilities: planRowToCapabilities(PLAN_ROW),
+    discoveryPolicy: PLAN_ROW.discoveryPolicy,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  parsePymthouseInstanceConfig.mockReturnValue({
+    issuerUrl: 'https://op.example',
+    publicClientId: 'pub',
+    m2mClientId: 'm2m',
+  });
+  getBuilderApiV1BaseFromIssuerUrl.mockReturnValue('https://api.example/api/v1');
+  getProviderInstanceSecret.mockResolvedValue('s3cret');
+  upsertPlan.mockResolvedValue({});
+  upsertDiscovery.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('syncAllProviderInstancePlans (flag gating)', () => {
+  it('INV: flag OFF → no-op, never reads ProviderInstance/ProviderPlan', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    const res = await syncAllProviderInstancePlans();
+    expect(res).toEqual({ enabled: false, instances: [] });
+    expect(findManyInstances).not.toHaveBeenCalled();
+    expect(upsertPlan).not.toHaveBeenCalled();
+    expect(upsertDiscovery).not.toHaveBeenCalled();
+  });
+
+  it('flag ON → iterates enabled instances and aggregates', async () => {
+    isFeatureEnabled.mockResolvedValue(true);
+    findManyInstances.mockResolvedValue([PYMTHOUSE_INSTANCE]);
+    findUniquePlan.mockResolvedValue(null);
+    const pull = vi.fn().mockResolvedValue({ plans: [PLAN_ROW] });
+
+    const res = await syncAllProviderInstancePlans({ pull });
+    expect(res.enabled).toBe(true);
+    expect(res.instances).toHaveLength(1);
+    expect(res.instances[0]).toMatchObject({
+      providerInstanceId: 'pi_1',
+      status: 'synced',
+      plansUpserted: 1,
+      discoveryPlansUpserted: 1,
+    });
+  });
+});
+
+describe('syncProviderInstancePlans (per-instance pull → persistence)', () => {
+  it('pulls with the instance creds (not global env) and upserts ProviderPlan keyed [instance, plan]', async () => {
+    findUniquePlan.mockResolvedValue(null);
+    const pull = vi.fn().mockResolvedValue({ plans: [PLAN_ROW] });
+
+    const res = await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+
+    expect(pull).toHaveBeenCalledWith(
+      {
+        apiV1Base: 'https://api.example/api/v1',
+        publicClientId: 'pub',
+        m2mClientId: 'm2m',
+        m2mClientSecret: 's3cret',
+      },
+      undefined,
+    );
+    expect(upsertPlan).toHaveBeenCalledTimes(1);
+    const upsertArg = upsertPlan.mock.calls[0][0];
+    expect(upsertArg.where).toEqual({
+      providerInstanceId_providerPlanId: { providerInstanceId: 'pi_1', providerPlanId: 'plan_basic' },
+    });
+    expect(upsertArg.create.capabilities).toEqual([
+      'image-to-image/nano-banana',
+      'live-video-to-video/scope',
+    ]);
+    expect(upsertArg.create.revision).toBe(expectedRevision());
+    expect(res).toMatchObject({ status: 'synced', plansUpserted: 1, discoveryPlansUpserted: 1 });
+  });
+
+  it('auto-generates a per-app DiscoveryPlan keyed "${instance}:${plan}" with public visibility', async () => {
+    findUniquePlan.mockResolvedValue(null);
+    const pull = vi.fn().mockResolvedValue({ plans: [PLAN_ROW] });
+
+    await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+
+    expect(upsertDiscovery).toHaveBeenCalledTimes(1);
+    const arg = upsertDiscovery.mock.calls[0][0];
+    expect(arg.where).toEqual({ billingPlanId: 'pi_1:plan_basic' });
+    expect(arg.create).toMatchObject({
+      billingPlanId: 'pi_1:plan_basic',
+      billingProviderSlug: 'pymthouse',
+      name: 'Basic',
+      visibility: 'public',
+      topN: 5,
+      enabled: true,
+    });
+    expect(arg.create.capabilities).toEqual([
+      'image-to-image/nano-banana',
+      'live-video-to-video/scope',
+    ]);
+  });
+
+  it('IDEMPOTENT: unchanged revision re-touches ProviderPlan but does NOT regenerate DiscoveryPlan', async () => {
+    findUniquePlan.mockResolvedValue({ revision: expectedRevision() });
+    const pull = vi.fn().mockResolvedValue({ plans: [PLAN_ROW] });
+
+    const res = await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+
+    expect(upsertPlan).toHaveBeenCalledTimes(1);
+    expect(upsertDiscovery).not.toHaveBeenCalled();
+    expect(res).toMatchObject({ status: 'synced', plansUpserted: 1, discoveryPlansUpserted: 0 });
+  });
+
+  it('changed revision regenerates the DiscoveryPlan', async () => {
+    findUniquePlan.mockResolvedValue({ revision: 'stale-revision' });
+    const pull = vi.fn().mockResolvedValue({ plans: [PLAN_ROW] });
+
+    const res = await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+
+    expect(upsertDiscovery).toHaveBeenCalledTimes(1);
+    expect(res.discoveryPlansUpserted).toBe(1);
+  });
+
+  describe('graceful degradation (never hard-fail)', () => {
+    it('missing M2M secret → unavailable, no upserts', async () => {
+      getProviderInstanceSecret.mockResolvedValue(null);
+      const pull = vi.fn();
+      const res = await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+      expect(res.status).toBe('unavailable');
+      expect(pull).not.toHaveBeenCalled();
+      expect(upsertPlan).not.toHaveBeenCalled();
+    });
+
+    it('provider plan API unavailable (null pull) → unavailable, no upserts', async () => {
+      findUniquePlan.mockResolvedValue(null);
+      const pull = vi.fn().mockResolvedValue(null);
+      const res = await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+      expect(res.status).toBe('unavailable');
+      expect(upsertPlan).not.toHaveBeenCalled();
+    });
+
+    it('pull throws → unavailable, never throws', async () => {
+      const pull = vi.fn().mockRejectedValue(new Error('network'));
+      const res = await syncProviderInstancePlans(PYMTHOUSE_INSTANCE, { pull });
+      expect(res.status).toBe('unavailable');
+    });
+
+    it('non-pymthouse adapterType → unsupported (no plan-spec pull yet)', async () => {
+      const pull = vi.fn();
+      const res = await syncProviderInstancePlans(
+        { ...PYMTHOUSE_INSTANCE, adapterType: 'stub' },
+        { pull },
+      );
+      expect(res.status).toBe('unsupported');
+      expect(pull).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web-next/src/lib/billing/plan-spec-sync.ts
+++ b/apps/web-next/src/lib/billing/plan-spec-sync.ts
@@ -1,0 +1,324 @@
+/**
+ * Plan-spec PULL & per-app discovery sync (NAAP P4, Deliverable 2).
+ *
+ * Generalizes the single-app `fetchPymthouseDiscoveryPlans()` (global
+ * `PYMTHOUSE_*` env) into a PER-`ProviderInstance` pull that:
+ *   1. derives the instance's pull creds from its NON-SECRET `config` + the M2M
+ *      secret in `SecretVault` (never global env, never logged),
+ *   2. upserts each pulled plan as a `ProviderPlan` row keyed
+ *      `[providerInstanceId, providerPlanId]` with a content `revision`,
+ *   3. on a NEW or CHANGED revision, auto-creates/refreshes the per-app
+ *      `DiscoveryPlan` (`billingPlanId = "${instanceId}:${planId}"`) the
+ *      orchestrator-leaderboard already serves — no manual `createPlan`.
+ *
+ * Zero regression: gated by `plan_spec_sync` (default OFF). With the flag OFF
+ * this module is a no-op — `ProviderPlan`/auto-`DiscoveryPlan` are never read or
+ * written, and discovery stays exactly today's static `storyboard-default`
+ * behavior. Idempotent: re-running with an unchanged spec recomputes the same
+ * revision and writes nothing new (no duplicate rows). Graceful: a provider
+ * whose plan API is unavailable (null pull) is skipped, never hard-failing the
+ * whole sync or live discovery.
+ */
+
+import 'server-only';
+
+import { Prisma } from '@naap/database';
+import { getBuilderApiV1BaseFromIssuerUrl } from '@pymthouse/builder-sdk/config';
+
+import { prisma } from '@/lib/db';
+import { isFeatureEnabled, PLAN_SPEC_SYNC_FLAG } from '@/lib/feature-flags';
+import {
+  fetchPymthouseDiscoveryPlans,
+  type PymthouseDiscoveryPlansCreds,
+  type PymthouseDiscoveryPlansResponse,
+} from '@/lib/pymthouse-discovery-plans';
+
+import {
+  buildAutoDiscoveryPlanId,
+  computeProviderPlanRevision,
+  planRowToCapabilities,
+  toAutoDiscoveryPlanFields,
+} from './auto-discovery-plan';
+import { PYMTHOUSE_ADAPTER_SLUG } from './pymthouse-adapter';
+import {
+  getProviderInstanceSecret,
+  parsePymthouseInstanceConfig,
+  type ProviderInstanceRecord,
+} from './provider-instance';
+
+export { PLAN_SPEC_SYNC_FLAG } from '@/lib/feature-flags';
+
+/** Per-instance pull dependency (injectable for tests). */
+export type PlanPullFn = (
+  creds: PymthouseDiscoveryPlansCreds,
+  signal?: AbortSignal,
+) => Promise<PymthouseDiscoveryPlansResponse | null>;
+
+const defaultPlanPull: PlanPullFn = (creds, signal) =>
+  fetchPymthouseDiscoveryPlans({ creds, signal });
+
+/** Coerce a validated policy object to Prisma Json input (or skip when null). */
+function jsonOrUndefined(value: unknown): Prisma.InputJsonValue | undefined {
+  return value == null ? undefined : (value as Prisma.InputJsonValue);
+}
+
+/** Outcome of syncing a single ProviderInstance. */
+export interface InstanceSyncResult {
+  providerInstanceId: string;
+  /**
+   * - `synced`: pull succeeded (rows upserted; may be 0 plans).
+   * - `unavailable`: provider plan API/creds unavailable → skipped (graceful).
+   * - `unsupported`: adapterType has no plan-spec pull yet → skipped.
+   */
+  status: 'synced' | 'unavailable' | 'unsupported';
+  plansUpserted: number;
+  discoveryPlansUpserted: number;
+}
+
+export interface SyncAllResult {
+  /** False when `plan_spec_sync` is OFF (no-op, table untouched). */
+  enabled: boolean;
+  instances: InstanceSyncResult[];
+}
+
+/**
+ * Build the per-instance pymthouse pull creds from a `ProviderInstance` row.
+ * Returns null when the adapterType is non-pymthouse, the non-secret config is
+ * incomplete, the issuer URL cannot resolve an API base, or the M2M secret is
+ * missing — callers skip (graceful) rather than throw. The secret is read only
+ * via `SecretVault` and never logged.
+ */
+export async function buildPymthousePullCreds(
+  instance: ProviderInstanceRecord,
+): Promise<PymthouseDiscoveryPlansCreds | null> {
+  if (instance.adapterType !== PYMTHOUSE_ADAPTER_SLUG) {
+    return null;
+  }
+  const config = parsePymthouseInstanceConfig(instance.config);
+  if (!config || !instance.secretRef) {
+    return null;
+  }
+  let apiV1Base: string;
+  try {
+    apiV1Base = getBuilderApiV1BaseFromIssuerUrl(config.issuerUrl);
+  } catch {
+    return null;
+  }
+  if (!apiV1Base) {
+    return null;
+  }
+  const m2mClientSecret = await getProviderInstanceSecret(instance.secretRef);
+  if (!m2mClientSecret) {
+    return null;
+  }
+  return {
+    apiV1Base,
+    publicClientId: config.publicClientId,
+    m2mClientId: config.m2mClientId,
+    m2mClientSecret,
+  };
+}
+
+/**
+ * Upsert one pulled plan into `ProviderPlan` (idempotent on
+ * `[providerInstanceId, providerPlanId]`) and, when the spec is new or its
+ * revision changed, refresh the auto per-app `DiscoveryPlan`. Returns whether a
+ * DiscoveryPlan write happened so the caller can count regenerations.
+ */
+async function upsertPlanAndDiscovery(
+  instance: ProviderInstanceRecord,
+  plan: PymthouseDiscoveryPlansResponse['plans'][number],
+): Promise<{ discoveryUpserted: boolean }> {
+  const capabilities = planRowToCapabilities(plan);
+  const revision = computeProviderPlanRevision({
+    name: plan.name,
+    capabilities,
+    discoveryPolicy: plan.discoveryPolicy,
+  });
+
+  const existing = await prisma.providerPlan.findUnique({
+    where: {
+      providerInstanceId_providerPlanId: {
+        providerInstanceId: instance.id,
+        providerPlanId: plan.id,
+      },
+    },
+    select: { revision: true },
+  });
+
+  const revisionChanged = !existing || existing.revision !== revision;
+
+  await prisma.providerPlan.upsert({
+    where: {
+      providerInstanceId_providerPlanId: {
+        providerInstanceId: instance.id,
+        providerPlanId: plan.id,
+      },
+    },
+    create: {
+      providerInstanceId: instance.id,
+      providerPlanId: plan.id,
+      name: plan.name,
+      capabilities,
+      discoveryPolicy: jsonOrUndefined(plan.discoveryPolicy),
+      revision,
+      source: 'pull',
+      enabled: true,
+      syncedAt: new Date(),
+    },
+    update: {
+      name: plan.name,
+      capabilities,
+      discoveryPolicy: jsonOrUndefined(plan.discoveryPolicy),
+      revision,
+      source: 'pull',
+      enabled: true,
+      syncedAt: new Date(),
+    },
+  });
+
+  // Idempotent: only (re)generate the per-app discovery when the spec changed.
+  if (!revisionChanged) {
+    return { discoveryUpserted: false };
+  }
+
+  const billingPlanId = buildAutoDiscoveryPlanId(instance.id, plan.id);
+  const fields = toAutoDiscoveryPlanFields({
+    adapterType: instance.adapterType,
+    name: plan.name,
+    capabilities,
+    discoveryPolicy: plan.discoveryPolicy,
+  });
+
+  await prisma.discoveryPlan.upsert({
+    where: { billingPlanId },
+    create: {
+      billingPlanId,
+      billingProviderSlug: fields.billingProviderSlug,
+      name: fields.name,
+      visibility: 'public',
+      capabilities: fields.capabilities,
+      topN: fields.topN,
+      slaWeights: jsonOrUndefined(fields.slaWeights),
+      slaMinScore: fields.slaMinScore ?? undefined,
+      sortBy: fields.sortBy ?? undefined,
+      filters: jsonOrUndefined(fields.filters),
+      enabled: true,
+    },
+    update: {
+      billingProviderSlug: fields.billingProviderSlug,
+      name: fields.name,
+      capabilities: fields.capabilities,
+      topN: fields.topN,
+      slaWeights: jsonOrUndefined(fields.slaWeights),
+      slaMinScore: fields.slaMinScore ?? undefined,
+      sortBy: fields.sortBy ?? undefined,
+      filters: jsonOrUndefined(fields.filters),
+      enabled: true,
+    },
+  });
+
+  return { discoveryUpserted: true };
+}
+
+/**
+ * Sync a single `ProviderInstance`'s published plans → `ProviderPlan` rows +
+ * auto `DiscoveryPlan`s. Never throws: unsupported adapter / unavailable
+ * provider degrade to a skipped result.
+ */
+export async function syncProviderInstancePlans(
+  instance: ProviderInstanceRecord,
+  deps?: { pull?: PlanPullFn; signal?: AbortSignal },
+): Promise<InstanceSyncResult> {
+  const base: InstanceSyncResult = {
+    providerInstanceId: instance.id,
+    status: 'unavailable',
+    plansUpserted: 0,
+    discoveryPlansUpserted: 0,
+  };
+
+  const creds = await buildPymthousePullCreds(instance);
+  if (!creds) {
+    return {
+      ...base,
+      status: instance.adapterType === PYMTHOUSE_ADAPTER_SLUG ? 'unavailable' : 'unsupported',
+    };
+  }
+
+  const pull = deps?.pull ?? defaultPlanPull;
+  let pulled: PymthouseDiscoveryPlansResponse | null;
+  try {
+    pulled = await pull(creds, deps?.signal);
+  } catch {
+    return base;
+  }
+  if (!pulled) {
+    return base;
+  }
+
+  let plansUpserted = 0;
+  let discoveryPlansUpserted = 0;
+  for (const plan of pulled.plans) {
+    try {
+      const res = await upsertPlanAndDiscovery(instance, plan);
+      plansUpserted += 1;
+      if (res.discoveryUpserted) discoveryPlansUpserted += 1;
+    } catch (err) {
+      console.error('[plan-spec-sync] upsert failed', {
+        providerInstanceId: instance.id,
+        providerPlanId: plan.id,
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+    }
+  }
+
+  return {
+    providerInstanceId: instance.id,
+    status: 'synced',
+    plansUpserted,
+    discoveryPlansUpserted,
+  };
+}
+
+/**
+ * Flag-gated sync of ALL enabled `ProviderInstance`s. With `plan_spec_sync` OFF
+ * this is a strict no-op (`{ enabled: false }`) — the table is never read or
+ * written and discovery is unchanged. Never throws.
+ */
+export async function syncAllProviderInstancePlans(deps?: {
+  pull?: PlanPullFn;
+  signal?: AbortSignal;
+}): Promise<SyncAllResult> {
+  let flagOn = false;
+  try {
+    flagOn = await isFeatureEnabled(PLAN_SPEC_SYNC_FLAG);
+  } catch {
+    flagOn = false;
+  }
+  if (!flagOn) {
+    return { enabled: false, instances: [] };
+  }
+
+  let instances: ProviderInstanceRecord[];
+  try {
+    instances = await prisma.providerInstance.findMany({
+      where: { enabled: true },
+      select: {
+        id: true,
+        adapterType: true,
+        slug: true,
+        config: true,
+        secretRef: true,
+        enabled: true,
+      },
+    });
+  } catch {
+    return { enabled: true, instances: [] };
+  }
+
+  const results: InstanceSyncResult[] = [];
+  for (const instance of instances) {
+    results.push(await syncProviderInstancePlans(instance, deps));
+  }
+  return { enabled: true, instances: results };
+}

--- a/apps/web-next/src/lib/billing/subscription-catalog.ts
+++ b/apps/web-next/src/lib/billing/subscription-catalog.ts
@@ -72,10 +72,10 @@ export interface CatalogInstanceView {
 }
 
 /**
- * Map a `ProviderInstance` row to its catalog view. Plans are intentionally
- * empty in P3 — the synced `ProviderPlan` model + plan-spec pull land in P4; the
- * catalog "exposes what exists", which today is the instances themselves. Only
- * non-secret identity fields are surfaced (never `config`/`secretRef`).
+ * Map a `ProviderInstance` row to its catalog view. `plans` are passed in by the
+ * route: empty when `plan_spec_sync` is OFF (P3 behavior), or the synced
+ * `ProviderPlan`-derived views when it is ON (P4). Only non-secret identity
+ * fields are surfaced (never `config`/`secretRef`).
  */
 export function toCatalogInstanceView(
   instance: CatalogInstanceRow,

--- a/apps/web-next/src/lib/billing/subscription-catalog.ts
+++ b/apps/web-next/src/lib/billing/subscription-catalog.ts
@@ -37,11 +37,29 @@ export interface CatalogInstanceRow {
   sortOrder: number;
 }
 
-/** A plan a developer can subscribe to (stubbed until P4 plan-spec sync). */
+/** A plan a developer can subscribe to (populated by the P4 plan-spec sync). */
 export interface CatalogPlanView {
   providerPlanId: string;
   name: string;
   capabilities: string[];
+}
+
+/** Minimal synced `ProviderPlan` row the catalog surfaces (non-secret fields). */
+export interface CatalogProviderPlanRow {
+  providerInstanceId: string;
+  providerPlanId: string;
+  name: string;
+  capabilities: string[];
+  enabled: boolean;
+}
+
+/** Map a synced `ProviderPlan` row to its catalog plan view (P4). */
+export function toCatalogPlanView(row: CatalogProviderPlanRow): CatalogPlanView {
+  return {
+    providerPlanId: row.providerPlanId,
+    name: row.name,
+    capabilities: row.capabilities,
+  };
 }
 
 /** A catalog entry: one provider instance + the plans available on it. */

--- a/apps/web-next/src/lib/dev-api/validate-key.test.ts
+++ b/apps/web-next/src/lib/dev-api/validate-key.test.ts
@@ -73,4 +73,20 @@ describe('buildFrontDoorResponse (BPP ③ shape)', () => {
     const res = buildFrontDoorResponse({ ...base, quota: { remaining: 10, resetAt: '2026-12-31T00:00:00Z' } });
     expect(res.quota).toEqual({ remaining: 10, resetAt: '2026-12-31T00:00:00Z' });
   });
+
+  it('INV (P4): omits the discovery field by default (byte-for-byte today)', () => {
+    expect(buildFrontDoorResponse(base).discovery).toBeUndefined();
+    expect(buildFrontDoorResponse({ ...base, discovery: null }).discovery).toBeUndefined();
+  });
+
+  it('P4: includes the per-app discovery field only when resolved', () => {
+    const res = buildFrontDoorResponse({
+      ...base,
+      discovery: { planId: 'dp_1', url: '/api/v1/orchestrator-leaderboard/plans/dp_1/python-gateway' },
+    });
+    expect(res.discovery).toEqual({
+      planId: 'dp_1',
+      url: '/api/v1/orchestrator-leaderboard/plans/dp_1/python-gateway',
+    });
+  });
 });

--- a/apps/web-next/src/lib/dev-api/validate-key.ts
+++ b/apps/web-next/src/lib/dev-api/validate-key.ts
@@ -52,6 +52,14 @@ export function extractAppId(header: string | null): string | null | typeof INVA
   return v;
 }
 
+/** Per-app discovery the resolved key is matched to (NAAP P4, additive). */
+export interface FrontDoorDiscovery {
+  /** Auto-generated DiscoveryPlan id (key → subscription → ProviderPlan → plan). */
+  planId: string;
+  /** python-gateway URL serving this app's capability-matched orchestrators. */
+  url: string;
+}
+
 /** BPP ③ front-door response (provider-neutral). */
 export interface FrontDoorResponse {
   valid: true;
@@ -61,6 +69,11 @@ export interface FrontDoorResponse {
   capabilities: string[];
   quota: { remaining: number; resetAt?: string } | null;
   signerSession: SignerSession;
+  /**
+   * Present ONLY when `plan_spec_sync` is ON and the key resolves to a synced
+   * per-app discovery (P4). Omitted otherwise — byte-for-byte today's response.
+   */
+  discovery?: FrontDoorDiscovery;
 }
 
 export interface BuildFrontDoorInput {
@@ -71,6 +84,7 @@ export interface BuildFrontDoorInput {
   capabilities?: string[] | null;
   quota?: { remaining: number; resetAt?: string } | null;
   signerSession: SignerSession;
+  discovery?: FrontDoorDiscovery | null;
 }
 
 /**
@@ -92,6 +106,9 @@ export function buildFrontDoorResponse(input: BuildFrontDoorInput): FrontDoorRes
   };
   if (input.appId) {
     res.app = { id: input.appId, ...(input.appScopes ? { scopes: input.appScopes } : {}) };
+  }
+  if (input.discovery) {
+    res.discovery = input.discovery;
   }
   return res;
 }

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -53,6 +53,19 @@ export const PROVIDER_INSTANCES_FLAG = 'provider_instances';
  */
 export const MULTI_SUBSCRIPTION_FLAG = 'multi_subscription';
 
+/**
+ * Canonical key for the plan-spec → per-app discovery sync (P4, Deliverable 2,
+ * default OFF). When OFF, the `ProviderPlan` table is never read or written, no
+ * sync runs, the catalog exposes no plans, and discovery is EXACTLY today's
+ * static `storyboard-default` / manual behavior (golden-set parity, zero
+ * regression). When ON, a per-`ProviderInstance` pull upserts `ProviderPlan`
+ * rows and auto-generates per-app `DiscoveryPlan`s, and the validate front door
+ * may expose the per-key discovery URL (key → subscription → ProviderPlan →
+ * DiscoveryPlan). Shared by KNOWN_FLAGS and the sync/discovery resolver so the
+ * name cannot drift.
+ */
+export const PLAN_SPEC_SYNC_FLAG = 'plan_spec_sync';
+
 export const KNOWN_FLAGS: KnownFlag[] = [
   {
     key: 'enableTeams',
@@ -136,6 +149,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: false,
     description:
       'Multi-subscription model (P1): a team may hold many concurrent Subscriptions and a DevApiKey may link to one via DevApiKey.subscriptionId. OFF = the Subscription table is never consulted and a key resolves via today\'s key → team → single billingAccountRef path (zero regression). A null subscriptionId always resolves the legacy way even when ON.',
+  },
+  {
+    key: PLAN_SPEC_SYNC_FLAG,
+    enabled: false,
+    description:
+      'Plan-spec → per-app discovery sync (P4): pull each ProviderInstance\'s published plans into ProviderPlan rows and auto-generate per-app DiscoveryPlans; the validate front door may expose the per-key discovery URL (key → subscription → ProviderPlan → DiscoveryPlan). OFF = no sync runs, ProviderPlan is never read/written, the catalog exposes no plans, and discovery is exactly today\'s static storyboard-default behavior (golden-set parity, zero regression).',
   },
 ];
 

--- a/apps/web-next/src/lib/pymthouse-discovery-plans.test.ts
+++ b/apps/web-next/src/lib/pymthouse-discovery-plans.test.ts
@@ -36,7 +36,7 @@ describe('pymthouse-discovery-plans', () => {
     vi.stubEnv('PYMTHOUSE_M2M_CLIENT_ID', 'm2m_x');
     vi.stubEnv('PMTHOUSE_M2M_CLIENT_SECRET', 'secret');
 
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
       Promise.resolve({
         ok: true,
         json: async () => ({
@@ -49,8 +49,73 @@ describe('pymthouse-discovery-plans', () => {
     const out = await fetchPymthouseDiscoveryPlans({ skipCache: true });
     expect(out?.plans).toHaveLength(1);
     expect(out?.plans[0].id).toBe('p1');
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/apps/app_x/plans');
-    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('discovery');
+    const [firstUrl] = fetchMock.mock.calls[0];
+    expect(String(firstUrl)).toContain('/apps/app_x/plans');
+    expect(String(firstUrl)).not.toContain('discovery');
+  });
+
+  it('P4: per-instance creds pull a SPECIFIC app (env + cache bypassed)', async () => {
+    // No PYMTHOUSE_* env set — proves the pull uses the supplied creds, not env.
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          plans: [{ id: 'p9', name: 'Inst', status: 'active', discoveryPolicy: null, capabilities: [] }],
+        }),
+      } as Response),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await fetchPymthouseDiscoveryPlans({
+      creds: {
+        apiV1Base: 'https://inst.example/api/v1',
+        publicClientId: 'app_inst',
+        m2mClientId: 'm2m_inst',
+        m2mClientSecret: 'sek',
+      },
+    });
+    expect(out?.plans[0].id).toBe('p9');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://inst.example/api/v1/apps/app_inst/plans');
+    const headers = init?.headers as Record<string, string> | undefined;
+    expect(headers?.Authorization).toBe(
+      `Basic ${Buffer.from('m2m_inst:sek', 'utf8').toString('base64')}`,
+    );
+  });
+
+  it('P4: per-instance creds never read the global-env cache', async () => {
+    // Seed the global-env cache via the env path.
+    vi.stubEnv('PYMTHOUSE_ISSUER_URL', 'http://localhost:3001/api/v1/oidc');
+    vi.stubEnv('PMTHOUSE_CLIENT_ID', 'app_x');
+    vi.stubEnv('PYMTHOUSE_M2M_CLIENT_ID', 'm2m_x');
+    vi.stubEnv('PMTHOUSE_M2M_CLIENT_SECRET', 'secret');
+    const envFetch = vi.fn(async () =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({ plans: [{ id: 'env', name: 'E', status: 'active', discoveryPolicy: null, capabilities: [] }] }),
+      } as Response),
+    );
+    vi.stubGlobal('fetch', envFetch);
+    await fetchPymthouseDiscoveryPlans();
+
+    // A per-instance pull must NOT return the cached env plan; it fetches fresh.
+    const instFetch = vi.fn(async () =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({ plans: [{ id: 'inst', name: 'I', status: 'active', discoveryPolicy: null, capabilities: [] }] }),
+      } as Response),
+    );
+    vi.stubGlobal('fetch', instFetch);
+    const out = await fetchPymthouseDiscoveryPlans({
+      creds: {
+        apiV1Base: 'https://inst.example/api/v1',
+        publicClientId: 'app_inst',
+        m2mClientId: 'm2m_inst',
+        m2mClientSecret: 'sek',
+      },
+    });
+    expect(out?.plans[0].id).toBe('inst');
+    expect(instFetch).toHaveBeenCalledTimes(1);
   });
 
   it('mapPymthousePlansResponse drops network default and inactive', () => {

--- a/apps/web-next/src/lib/pymthouse-discovery-plans.ts
+++ b/apps/web-next/src/lib/pymthouse-discovery-plans.ts
@@ -205,26 +205,51 @@ export function mapPymthousePlansResponse(raw: unknown): PymthouseDiscoveryPlans
 }
 
 /**
+ * Explicit per-instance pymthouse connection creds (NAAP P4). When supplied to
+ * {@link fetchPymthouseDiscoveryPlans}, the pull uses THESE creds (a specific
+ * `ProviderInstance`'s app) instead of the global `PYMTHOUSE_*` env, and the
+ * process-wide env cache is bypassed (each instance is independent). The M2M
+ * secret is used only to build the Basic auth header and is never logged.
+ */
+export interface PymthouseDiscoveryPlansCreds {
+  apiV1Base: string;
+  publicClientId: string;
+  m2mClientId: string;
+  m2mClientSecret: string;
+}
+
+/**
  * GET `/api/v1/apps/{publicClientId}/plans` using M2M Basic auth. Pipeline/model caps use `/manifest`.
  * Returns null if env incomplete or request fails.
+ *
+ * P4: pass `opts.creds` to pull a SPECIFIC `ProviderInstance`'s plans with that
+ * instance's app creds (env + cache bypassed). With no `creds`, behavior is
+ * byte-for-byte today's global-env single-app pull (the default-instance path).
  */
 export async function fetchPymthouseDiscoveryPlans(opts?: {
   skipCache?: boolean;
   signal?: AbortSignal;
+  creds?: PymthouseDiscoveryPlansCreds;
 }): Promise<PymthouseDiscoveryPlansResponse | null> {
-  const base = getPymthouseApiV1Base();
-  const publicId =
-    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID?.trim() || process.env.PMTHOUSE_CLIENT_ID?.trim();
-  const m2mId =
-    process.env.PYMTHOUSE_M2M_CLIENT_ID?.trim() || process.env.PMTHOUSE_M2M_CLIENT_ID?.trim();
-  const m2mSecret =
-    process.env.PYMTHOUSE_M2M_CLIENT_SECRET?.trim() || process.env.PMTHOUSE_M2M_CLIENT_SECRET?.trim();
+  const perInstance = opts?.creds;
+  const base = perInstance ? perInstance.apiV1Base.trim() : getPymthouseApiV1Base();
+  const publicId = perInstance
+    ? perInstance.publicClientId.trim()
+    : process.env.PYMTHOUSE_PUBLIC_CLIENT_ID?.trim() || process.env.PMTHOUSE_CLIENT_ID?.trim();
+  const m2mId = perInstance
+    ? perInstance.m2mClientId.trim()
+    : process.env.PYMTHOUSE_M2M_CLIENT_ID?.trim() || process.env.PMTHOUSE_M2M_CLIENT_ID?.trim();
+  const m2mSecret = perInstance
+    ? perInstance.m2mClientSecret
+    : process.env.PYMTHOUSE_M2M_CLIENT_SECRET?.trim() || process.env.PMTHOUSE_M2M_CLIENT_SECRET?.trim();
   if (!base || !publicId || !m2mId || !m2mSecret) {
     return null;
   }
 
   const now = Date.now();
-  if (!opts?.skipCache && cache.data && now - cache.at < cache.ttlMs) {
+  // The process-wide cache only applies to the global-env path; a per-instance
+  // pull (P4) is always fresh so instances never share each other's cache.
+  if (!perInstance && !opts?.skipCache && cache.data && now - cache.at < cache.ttlMs) {
     return cache.data;
   }
 
@@ -249,7 +274,10 @@ export async function fetchPymthouseDiscoveryPlans(opts?: {
   if (!body || !Array.isArray(body.plans)) {
     return null;
   }
-  cache = { at: now, data: body, ttlMs: cache.ttlMs };
+  // Only the global-env pull populates the shared cache.
+  if (!perInstance) {
+    cache = { at: now, data: body, ttlMs: cache.ttlMs };
+  }
   return body;
 }
 

--- a/packages/database/prisma/migrations/20260624130000_add_provider_plan/migration.sql
+++ b/packages/database/prisma/migrations/20260624130000_add_provider_plan/migration.sql
@@ -1,0 +1,34 @@
+-- NAAP P4: ProviderPlan model (synced plan-spec, EXPAND-ONLY, additive).
+--
+-- Deliverable 2 (pull direction): the Source-of-Truth for a provider app's
+-- published plans, pulled per ProviderInstance and upserted keyed
+-- [providerInstanceId, providerPlanId] with a content `revision`. Purely
+-- additive — a single new `public.ProviderPlan` table; no existing
+-- table/column/constraint is dropped or rewritten and NO data is backfilled.
+-- Gated by `plan_spec_sync` (default OFF): nothing reads or writes this table
+-- until the flag is ON, so discovery stays exactly today's static behavior
+-- (zero regression). Idempotent (IF NOT EXISTS) for safe re-apply.
+
+-- CreateTable: ProviderPlan (public)
+CREATE TABLE IF NOT EXISTS "public"."ProviderPlan" (
+    "id" TEXT NOT NULL,
+    "providerInstanceId" TEXT NOT NULL,
+    "providerPlanId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "capabilities" TEXT[],
+    "sla" JSONB,
+    "pricing" JSONB,
+    "discoveryPolicy" JSONB,
+    "revision" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'pull',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "syncedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProviderPlan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: idempotent upsert key + instance lookup
+CREATE UNIQUE INDEX IF NOT EXISTS "ProviderPlan_providerInstanceId_providerPlanId_key" ON "public"."ProviderPlan"("providerInstanceId", "providerPlanId");
+CREATE INDEX IF NOT EXISTS "ProviderPlan_providerInstanceId_idx" ON "public"."ProviderPlan"("providerInstanceId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -254,6 +254,40 @@ model Subscription {
   @@schema("public")
 }
 
+// NAAP P4 — synced provider plan-spec (Deliverable 2, PULL direction).
+//
+// The Source-of-Truth for a provider app's published plans, pulled per
+// `ProviderInstance` (using THAT instance's creds, never global env) from the
+// provider's plan API and upserted here keyed `[providerInstanceId,
+// providerPlanId]`. `capabilities` are normalized `pipeline/modelId` strings;
+// `discoveryPolicy`/`sla`/`pricing` keep the provider's policy blobs. `revision`
+// is a content fingerprint so re-running the sync is idempotent and only a
+// changed spec re-generates the per-app `DiscoveryPlan`. `source` records how
+// the row arrived ("pull" today; "push" reserved for the optional ingest seam).
+// Cross-schema FKs avoided (scalar `providerInstanceId`). Expand-only/additive;
+// gated by `plan_spec_sync` (default OFF) so nothing reads or writes it until
+// enabled — discovery stays exactly today's static behavior when OFF.
+model ProviderPlan {
+  id                 String   @id @default(uuid())
+  providerInstanceId String
+  providerPlanId     String
+  name               String
+  capabilities       String[]
+  sla                Json?
+  pricing            Json?
+  discoveryPolicy    Json?
+  revision           String
+  source             String   @default("pull")
+  enabled            Boolean  @default(true)
+  syncedAt           DateTime @default(now())
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  @@unique([providerInstanceId, providerPlanId])
+  @@index([providerInstanceId])
+  @@schema("public")
+}
+
 model BillingProviderOAuthSession {
   loginSessionId    String    @id
   state             String    @unique


### PR DESCRIPTION
## Summary

Phase **P4** of the multi-app billing plan — Deliverable 2, **PULL** direction. Closes the plan-spec → per-app discovery gap. **Stacked on #401** (base `feat/catalog-subscriptions-ui-p3`). All new behavior is gated behind a new **`plan_spec_sync`** flag (default **OFF**).

### What's added
- **`ProviderPlan` model** (expand-only migration `20260624130000_add_provider_plan`): synced per-instance plan specs keyed `[providerInstanceId, providerPlanId]` with a content `revision`.
- **Per-instance plan-spec pull**: `fetchPymthouseDiscoveryPlans()` generalized to accept a specific `ProviderInstance`'s creds (issuer/publicClientId/m2mClientId + `SecretVault` M2M secret), bypassing the global `PYMTHOUSE_*` env and the shared cache. Env path is byte-for-byte unchanged when no creds are passed.
- **Sync + auto-discovery** (`plan-spec-sync.ts`): upserts `ProviderPlan` rows and, on a new/changed revision, auto-creates/refreshes the per-app `DiscoveryPlan` (`billingPlanId = "${instanceId}:${planId}"`, `visibility=public`, `discoveryPolicy` → topN/sortBy/sla/filters). Idempotent; graceful when a provider's plan API is unavailable. Cron-protected `POST /api/v1/billing/plans/refresh`.
- **Key-matched discovery** (`key-discovery.ts`): the validate front door resolves `key → Subscription → ProviderPlan → DiscoveryPlan` (reusing the P2 binding) and exposes the per-app discovery URL (`/orchestrator-leaderboard/plans/{id}/python-gateway`) as an **additive** `discovery` field.
- **Catalog**: joins synced `ProviderPlan` rows (was stubbed `[]` in P3), only when `plan_spec_sync` is ON.

### How the API key selects discovery
The presented `naap_` key → `DevApiKey.subscriptionId` → `Subscription` (P2) → `Subscription.providerPlanId` + `providerInstanceId` → auto `DiscoveryPlan` keyed `"${providerInstanceId}:${providerPlanId}"` → its `python-gateway` URL is returned in the validate response.

## Zero-regression guardrails
- Flag **OFF** → no sync runs, `ProviderPlan` is never read/written, the catalog exposes no plans, the validate response **omits** `discovery`, and `storyboard-default` discovery is byte-for-byte today's. The **golden-set parity** test is untouched and green.
- Additive + expand-only migration (new table only; nullable JSON columns; idempotent `IF NOT EXISTS`). No env path removed.
- Sync is idempotent (unchanged revision → no `DiscoveryPlan` regeneration, no duplicate rows) and never hard-fails discovery (graceful fallback to static).

## Test plan
- [x] New unit tests: per-instance pull (env+cache bypass), `ProviderPlan` persistence, auto `DiscoveryPlan` generation, **idempotency**, key→plan→discovery selection, additive `discovery` field.
- [x] INV no-regression: `plan_spec_sync` OFF → discovery/catalog/validate identical to today; golden-set parity unchanged.
- [x] `pnpm vitest` (web-next): **122 files, 1181 passed, 1 skipped**.
- [x] `tsc --noEmit`: no new errors in touched files (pre-existing baseline only).

## Deferred to P5
Signer/SDK auto-config wiring (simple-infra/storyboard): the SDK passing the resolved per-key `discovery_url` to the remote signer. P4 only makes NaaP serve the right per-app discovery and expose its URL.

Made with [Cursor](https://cursor.com)