### PR TITLE
fix(billing): mint opaque pmth_ signer session per ProviderInstance

### DIFF
--- a/apps/web-next/src/lib/billing/provider-instance.ts
+++ b/apps/web-next/src/lib/billing/provider-instance.ts
@@ -118,7 +118,20 @@ export async function buildAdapterForProviderInstance(
       return undefined;
     }
     const client = createPmtHouseClient({ ...config, m2mClientSecret });
-    return new PymthouseAdapter({ client, isConfigured: () => true });
+    return new PymthouseAdapter({
+      client,
+      isConfigured: () => true,
+      // Per-instance signer-session exchange binds to THIS app's issuer/creds so
+      // the opaque `pmth_…` mint targets the right token endpoint (not global env).
+      signerExchange: {
+        issuerUrl: config.issuerUrl,
+        m2mClientId: config.m2mClientId,
+        m2mClientSecret,
+        ...(config.allowInsecureHttp !== undefined
+          ? { allowInsecureHttp: config.allowInsecureHttp }
+          : {}),
+      },
+    });
   }
   return undefined;
 }

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -14,7 +14,12 @@ import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
 
 import type { MeScopeUsagePayload, PmtHouseClient, UsageApiResponse } from '@pymthouse/builder-sdk';
 
-import { getPmtHouseServerClient } from '@/lib/pymthouse-client';
+import {
+  getPmtHouseServerClient,
+  mintOpaqueSignerSessionForExternalUser,
+  mintSignerSessionForExternalUser,
+  type PymthouseSignerExchangeConfig,
+} from '@/lib/pymthouse-client';
 import { isFeatureEnabled, PYMTHOUSE_BPP_VALIDATE_FLAG } from '@/lib/feature-flags';
 import { resolvePymthouseCapabilities } from './pymthouse-capabilities';
 import {
@@ -47,6 +52,13 @@ export const PYMTHOUSE_ADAPTER_SLUG = 'pymthouse';
 export interface PymthouseAdapterOptions {
   client?: PmtHouseClient;
   isConfigured?: () => boolean;
+  /**
+   * Per-instance signer-session exchange config (issuer + M2M creds). Required
+   * alongside a `client` override so {@link PymthouseAdapter.mintSignerSession}
+   * exchanges against THIS app's token endpoint. Omitted for the global-env
+   * adapter, which uses the `PYMTHOUSE_*` env exchange.
+   */
+  signerExchange?: PymthouseSignerExchangeConfig;
 }
 
 export class PymthouseAdapter implements BillingProviderAdapter {
@@ -54,10 +66,12 @@ export class PymthouseAdapter implements BillingProviderAdapter {
 
   private readonly clientOverride?: PmtHouseClient;
   private readonly isConfiguredOverride?: () => boolean;
+  private readonly signerExchange?: PymthouseSignerExchangeConfig;
 
   constructor(options: PymthouseAdapterOptions = {}) {
     this.clientOverride = options.client;
     this.isConfiguredOverride = options.isConfigured;
+    this.signerExchange = options.signerExchange;
   }
 
   /**
@@ -197,11 +211,30 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     }));
   }
 
+  /**
+   * Mint an OPAQUE `pmth_…` signer session for the account.
+   *
+   * Uses the NaaP opaque-session workaround (upsert user → mint user JWT →
+   * token-exchange WITHOUT `resource`) rather than the SDK 0.4.3
+   * `PmtHouseClient.mintSignerSessionForExternalUser`, which sets `resource` and
+   * is routed by PymtHouse to signer-JWT exchange (no opaque `pmth_…` session) —
+   * causing the validate front door's signer mint to fail. For a per-instance
+   * adapter the exchange binds to THAT app's issuer/creds; the global-env adapter
+   * uses the `PYMTHOUSE_*` env path.
+   */
   async mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken> {
-    const session = await this.client().mintSignerSessionForExternalUser({
-      externalUserId: input.externalUserId,
-      ...(input.email != null ? { email: input.email } : {}),
-    });
+    const session =
+      this.clientOverride && this.signerExchange
+        ? await mintOpaqueSignerSessionForExternalUser({
+            client: this.clientOverride,
+            exchange: this.signerExchange,
+            externalUserId: input.externalUserId,
+            ...(input.email != null ? { email: input.email } : {}),
+          })
+        : await mintSignerSessionForExternalUser({
+            externalUserId: input.externalUserId,
+            ...(input.email != null ? { email: input.email } : {}),
+          });
     return {
       accessToken: session.accessToken,
       tokenType: session.tokenType,

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -78,17 +78,20 @@ export function resetPmtHouseServerClientForTests(): void {
 }
 
 /**
- * Exchange a short-lived user JWT for an opaque `pmth_…` signer session.
- *
- * `@pymthouse/builder-sdk@0.4.3` `PmtHouseClient.mintSignerSessionForExternalUser` sets
- * `resource` to the OIDC issuer URL. Current PymtHouse routes that to signer-JWT
- * exchange (no `issued_token_type`, returns another JWT). Omitting `resource` selects
- * gateway opaque-session exchange instead.
+ * Non-secret connection params + M2M secret needed to perform the opaque
+ * signer-session token-exchange. Mirrors {@link PmtHouseClientConfig} but only
+ * the subset the exchange step needs, so a per-`ProviderInstance` adapter can
+ * exchange against ITS app's token endpoint/creds (not the global env).
  */
-async function exchangeUserJwtForOpaqueSignerSession(
-  userJwt: string,
-  scope: string = SIGN_JOB_SCOPE,
-): Promise<SignerSessionToken> {
+export interface PymthouseSignerExchangeConfig {
+  issuerUrl: string;
+  m2mClientId: string;
+  m2mClientSecret: string;
+  allowInsecureHttp?: boolean;
+}
+
+/** Resolve the global `PYMTHOUSE_*` env into a signer-exchange config (or throw). */
+function globalSignerExchangeConfig(): PymthouseSignerExchangeConfig {
   const env = readPymthouseEnv();
   if (!env) {
     throw new PmtHouseError(PYMTHOUSE_NOT_CONFIGURED_MESSAGE, {
@@ -96,11 +99,32 @@ async function exchangeUserJwtForOpaqueSignerSession(
       code: 'pymthouse_required',
     });
   }
+  return {
+    issuerUrl: env.issuerUrl,
+    m2mClientId: env.m2mClientId,
+    m2mClientSecret: env.m2mClientSecret,
+  };
+}
 
+/**
+ * Exchange a short-lived user JWT for an opaque `pmth_…` signer session, using an
+ * EXPLICIT connection config (per-instance or global).
+ *
+ * `@pymthouse/builder-sdk@0.4.3` `PmtHouseClient.mintSignerSessionForExternalUser` sets
+ * `resource` to the OIDC issuer URL. Current PymtHouse routes that to signer-JWT
+ * exchange (no `issued_token_type`, returns another JWT). Omitting `resource` selects
+ * gateway opaque-session exchange instead.
+ */
+async function exchangeUserJwtForOpaqueSignerSessionWith(
+  userJwt: string,
+  cfg: PymthouseSignerExchangeConfig,
+  scope: string = SIGN_JOB_SCOPE,
+): Promise<SignerSessionToken> {
   const allowInsecureHttp =
-    process.env.PYMTHOUSE_ALLOW_INSECURE_HTTP === '1' || env.issuerUrl.startsWith('http:');
+    cfg.allowInsecureHttp ??
+    (process.env.PYMTHOUSE_ALLOW_INSECURE_HTTP === '1' || cfg.issuerUrl.startsWith('http:'));
 
-  const as = await loadAuthorizationServer(env.issuerUrl, fetch, { allowInsecureHttp });
+  const as = await loadAuthorizationServer(cfg.issuerUrl, fetch, { allowInsecureHttp });
   const tokenEndpoint = as.token_endpoint;
   if (!tokenEndpoint) {
     throw new PmtHouseError('OIDC discovery document is missing token_endpoint', {
@@ -121,7 +145,7 @@ async function exchangeUserJwtForOpaqueSignerSession(
   const response = await fetch(tokenEndpoint, {
     method: 'POST',
     headers: {
-      Authorization: `Basic ${Buffer.from(`${env.m2mClientId}:${env.m2mClientSecret}`).toString('base64')}`,
+      Authorization: `Basic ${Buffer.from(`${cfg.m2mClientId}:${cfg.m2mClientSecret}`).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded',
       Accept: 'application/json',
     },
@@ -178,25 +202,49 @@ async function exchangeUserJwtForOpaqueSignerSession(
   });
 }
 
-/** Mint an opaque `pmth_…` signer session for a NaaP user (workaround for SDK 0.4.3 routing). */
-export async function mintSignerSessionForExternalUser(input: {
+/**
+ * Mint an opaque `pmth_…` signer session for a NaaP user against an EXPLICIT
+ * client + exchange config (workaround for SDK 0.4.3 `resource` routing).
+ *
+ * This is the multi-app-safe core: the per-`ProviderInstance` adapter passes ITS
+ * client + ITS app's exchange config so the upsert/user-token/exchange all bind
+ * to the same app. The global path ({@link mintSignerSessionForExternalUser})
+ * delegates here with the env client + env config.
+ */
+export async function mintOpaqueSignerSessionForExternalUser(input: {
+  client: PmtHouseClient;
+  exchange: PymthouseSignerExchangeConfig;
   externalUserId: string;
   email?: string;
   scope?: string;
 }): Promise<SignerSessionToken> {
-  const client = getPmtHouseServerClient();
   const scope = input.scope?.trim() || SIGN_JOB_SCOPE;
 
-  await client.upsertAppUser({
+  await input.client.upsertAppUser({
     externalUserId: input.externalUserId,
     email: input.email,
     status: 'active',
   });
 
-  const userToken = await client.mintUserAccessToken({
+  const userToken = await input.client.mintUserAccessToken({
     externalUserId: input.externalUserId,
     scope,
   });
 
-  return exchangeUserJwtForOpaqueSignerSession(userToken.access_token, scope);
+  return exchangeUserJwtForOpaqueSignerSessionWith(userToken.access_token, input.exchange, scope);
+}
+
+/** Mint an opaque `pmth_…` signer session for a NaaP user (global `PYMTHOUSE_*` env). */
+export async function mintSignerSessionForExternalUser(input: {
+  externalUserId: string;
+  email?: string;
+  scope?: string;
+}): Promise<SignerSessionToken> {
+  return mintOpaqueSignerSessionForExternalUser({
+    client: getPmtHouseServerClient(),
+    exchange: globalSignerExchangeConfig(),
+    externalUserId: input.externalUserId,
+    ...(input.email != null ? { email: input.email } : {}),
+    ...(input.scope != null ? { scope: input.scope } : {}),
+  });
 }


### PR DESCRIPTION
## Summary
Surfaced while running the multi-app billing E2E (P0–P5) on an isolated preview: the **key-validation front door** (`POST /api/v1/keys/validate`) returned **HTTP 503** for both legacy seat-bound and subscription-bound `naap_` keys because the signer-session mint failed.

Root cause: `PymthouseAdapter.mintSignerSession` called the SDK 0.4.3 `PmtHouseClient.mintSignerSessionForExternalUser`, which sets `resource` to the OIDC issuer. Current PymtHouse routes a `resource`-bearing token-exchange to **signer-JWT** exchange (returns another JWT, **no opaque `pmth_…` session**), so the front door could not produce a usable signer session.

This routes the mint through the existing **opaque-session workaround** (upsert user → mint user JWT → token-exchange **without** `resource`) and makes it **multi-app safe**: a per-`ProviderInstance` adapter exchanges against **that app's** issuer/M2M creds via a new `signerExchange` option, while the global-env adapter keeps using the `PYMTHOUSE_*` env exchange.

## Changes
- **`pymthouse-client.ts`** — extract `exchangeUserJwtForOpaqueSignerSessionWith(userJwt, cfg)` (explicit per-app config) and export `mintOpaqueSignerSessionForExternalUser({ client, exchange, … })`. `mintSignerSessionForExternalUser` now delegates to it with the global env client + config (behavior preserved).
- **`pymthouse-adapter.ts`** — add `signerExchange?: PymthouseSignerExchangeConfig` option; `mintSignerSession` mints via the opaque workaround (per-instance override when a `client` + `signerExchange` are present, else global env).
- **`provider-instance.ts`** — pass the instance's `issuerUrl` + M2M client id/secret as `signerExchange` when building a per-instance adapter.

## Safety / regression
- **Additive & backward-compatible:** the global path delegates to the same opaque exchange it already used; the new per-instance path only engages when an adapter is constructed with **both** a client override and `signerExchange` (i.e. a configured `ProviderInstance`).
- No new env vars, no schema changes, no secrets. Gated behind the existing `pymthouse_bpp_validate` / native-key flags via the call sites.

## Test plan
- [x] On preview, `POST /api/v1/keys/validate` now returns **HTTP 200** with `valid: true`, `capabilities: ["*"]`, and an opaque `pmth_…` `signerSession` for **both** legacy seat-bound and subscription-bound keys (previously 503).
- [x] UI-minted subscription key (dev-manager P3 "Create Key") validates 200 with a `pmth_…` session.
- [ ] CI: typecheck + unit tests (`pymthouse-adapter` / billing).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing sign-in now supports per-instance configuration for token exchange, improving compatibility across multiple app instances.
  * Opaque signer sessions can now be created with an explicit exchange setup instead of relying on shared global settings.

* **Bug Fixes**
  * Improved session minting behavior for billing providers when instance-specific credentials are used.
  * Added fallback handling so existing signer-session creation continues to work with the default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->