### PR TITLE
feat(billing): per-key remote signer endpoint at validate front door (P6)

### DIFF
--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -9,7 +9,10 @@ import { generateNativeApiKey } from '@/lib/dev-api/native-key';
 import { hashApiKey } from '@naap/database';
 
 const isFeatureEnabled = vi.fn();
-vi.mock('@/lib/feature-flags', () => ({ isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a) }));
+vi.mock('@/lib/feature-flags', () => ({
+  isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  PER_KEY_REMOTE_SIGNER_FLAG: 'per_key_remote_signer',
+}));
 
 vi.mock('@/lib/api/rate-limit', () => ({ enforceRateLimit: vi.fn(() => null) }));
 
@@ -235,6 +238,64 @@ describe('P2 per-key subscription resolution (multi_subscription)', () => {
       billingAccountRef: { providerSlug: 'pymthouse', accountId: 'acct_sub_99' },
     });
     expect((await POST(req(rawKey))).status).toBe(503);
+  });
+});
+
+describe('per-key remote signer (per_key_remote_signer)', () => {
+  // Front door ON; per_key_remote_signer toggled per test; all others OFF.
+  const flags = (perKeySigner: boolean) =>
+    isFeatureEnabled.mockImplementation(async (key: string) =>
+      key === 'key_validation_front_door' ? true : key === 'per_key_remote_signer' ? perKeySigner : false,
+    );
+
+  const endpoint = { url: 'https://signer-dmz.pymthouse.com', headers: { Authorization: 'Bearer pmth_abc' } };
+
+  it('flag OFF → returns the provider token-bundle form (byte-for-byte today, INV)', async () => {
+    flags(false);
+    const resolveSignerEndpoint = vi.fn(async () => endpoint);
+    getBillingProviderAdapter.mockReturnValue(adapterMock({ resolveSignerEndpoint }));
+
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+    // Token-bundle form preserved; the endpoint resolver is NEVER called.
+    expect(d.signerSession).toEqual({ accessToken: 'signer-tok', tokenType: 'Bearer', expiresIn: 3600 });
+    expect(resolveSignerEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('flag ON → returns the SignerSession ENDPOINT form { url, headers }', async () => {
+    flags(true);
+    const resolveSignerEndpoint = vi.fn(async () => endpoint);
+    getBillingProviderAdapter.mockReturnValue(adapterMock({ resolveSignerEndpoint }));
+
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    const d = (await res.json()).data;
+    expect(d.signerSession).toEqual(endpoint);
+    // The minted token-bundle session is handed to the resolver.
+    expect(resolveSignerEndpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'signer-tok' }),
+    );
+  });
+
+  it('flag ON + adapter without resolveSignerEndpoint → keeps token form (no-op)', async () => {
+    flags(true);
+    // Default adapterMock has no resolveSignerEndpoint.
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.signerSession.accessToken).toBe('signer-tok');
+  });
+
+  it('flag ON + resolver throws → fails SAFE to the token form (never 500)', async () => {
+    flags(true);
+    const resolveSignerEndpoint = vi.fn(async () => {
+      throw new Error('signer routing unavailable');
+    });
+    getBillingProviderAdapter.mockReturnValue(adapterMock({ resolveSignerEndpoint }));
+
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+    expect((await res.json()).data.signerSession.accessToken).toBe('signer-tok');
   });
 });
 

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -26,9 +26,9 @@ import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/db';
 import { error, errors, success } from '@/lib/api/response';
 import { enforceRateLimit } from '@/lib/api/rate-limit';
-import { isFeatureEnabled } from '@/lib/feature-flags';
+import { isFeatureEnabled, PER_KEY_REMOTE_SIGNER_FLAG } from '@/lib/feature-flags';
 import { parseApiKey } from '@naap/database';
-import { AdapterNotImplementedError } from '@/lib/billing/adapter';
+import { AdapterNotImplementedError, type SignerSession } from '@/lib/billing/adapter';
 import { getBillingProviderAdapter } from '@/lib/billing/registry';
 import { resolveKeyProviderBinding } from '@/lib/billing/key-provider-binding';
 import { resolveKeyDiscovery } from '@/lib/billing/key-discovery';
@@ -163,15 +163,42 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const ref = resolved.billingAccountRef;
 
+    // Capability resolution AND the optional per-key signer-endpoint resolution
+    // both scope to the SAME adapter/account the signer was minted against: the
+    // per-instance adapter in subscription mode, else today's slug→adapter.
+    const adapter =
+      binding.mode === 'subscription' ? binding.adapter : getBillingProviderAdapter(ref.providerSlug);
+
+    // Per-key remote signer (default OFF → byte-for-byte today's response). When
+    // ON and the resolved adapter can expose a remote signer DMZ, swap the
+    // provider token-bundle session for the SignerSession ENDPOINT form
+    // { url, headers } so the SDK service signs + pays through the funded
+    // per-key wallet. Fails SAFE: any resolution error keeps the token-bundle
+    // form (the SDK service falls back to its static signer), never 500s.
+    let signerSession: SignerSession = resolved.signerSession;
+    if (
+      adapter?.resolveSignerEndpoint &&
+      (await isFeatureEnabled(PER_KEY_REMOTE_SIGNER_FLAG))
+    ) {
+      try {
+        signerSession = await adapter.resolveSignerEndpoint(resolved.signerSession);
+        log('info', 'keys.validate.signer_endpoint', {
+          correlationId,
+          providerSlug: ref.providerSlug,
+        });
+      } catch {
+        log('warn', 'keys.validate.signer_endpoint_unavailable', {
+          correlationId,
+          providerSlug: ref.providerSlug,
+        });
+      }
+    }
+
     // Best-effort capabilities/quota from the provider (BPP ②). When the
     // provider hasn't wired validate yet (AdapterNotImplementedError), fail
     // CLOSED to an empty capability set — the key is still valid; NAAP-E gates.
     let capabilities: string[] = [];
     let quota: { remaining: number; resetAt?: string } | null = null;
-    // Capability resolution scopes to the SAME adapter/account the signer used:
-    // the per-instance adapter in subscription mode, else today's slug→adapter.
-    const adapter =
-      binding.mode === 'subscription' ? binding.adapter : getBillingProviderAdapter(ref.providerSlug);
     if (adapter) {
       try {
         const v = await adapter.validate(ref.accountId);
@@ -225,7 +252,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       billingAccountRef: ref,
       capabilities,
       quota,
-      signerSession: resolved.signerSession,
+      signerSession,
       discovery,
     });
 

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -178,6 +178,18 @@ export interface BillingProviderAdapter {
    */
   mintSignerSession(input: MintSignerSessionInput): Promise<SignerSessionToken>;
 
+  /**
+   * BPP per-key remote signer (endpoint form) — OPTIONAL. Resolve a minted
+   * token-bundle session into the {@link SignerSessionEndpoint} form: the
+   * provider's per-key remote signer DMZ `url` plus opaque-to-apps `headers`
+   * carrying that session (so a downstream SDK/gateway can sign + pay directly
+   * against the per-key funded wallet). Providers that cannot expose a remote
+   * signer DMZ omit this; the front door then keeps the token-bundle form.
+   * Gated at the front door by `PER_KEY_REMOTE_SIGNER_FLAG` (default OFF), so a
+   * provider implementing this is still a no-op until the flag is enabled.
+   */
+  resolveSignerEndpoint?(session: SignerSessionToken): Promise<SignerSessionEndpoint>;
+
   /** BPP ⑧ — receive a curated orchestrator list for a plan. */
   receiveCuratedOrchestrators(plan: string, list: CuratedOrchestrator[]): Promise<void>;
 

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -6,6 +6,7 @@ const fetchUsageForExternalUser = vi.fn();
 const getUsage = vi.fn();
 const getUserSubscription = vi.fn();
 const listBillingProducts = vi.fn();
+const getSignerRouting = vi.fn();
 
 vi.mock('@/lib/pymthouse-client', () => ({
   getPmtHouseServerClient: () => ({
@@ -13,6 +14,7 @@ vi.mock('@/lib/pymthouse-client', () => ({
     getUsage,
     getUserSubscription,
     listBillingProducts,
+    getSignerRouting,
   }),
 }));
 
@@ -118,6 +120,49 @@ describe('PymthouseAdapter per-instance client (P0, zero regression)', () => {
   it('isConfigured honors the injected override, else delegates to the env check', () => {
     expect(new PymthouseAdapter({ isConfigured: () => false }).isConfigured()).toBe(false);
     expect(new PymthouseAdapter().isConfigured()).toBe(true);
+  });
+});
+
+describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer)', () => {
+  const TOKEN = { accessToken: 'pmth_abc123', tokenType: 'Bearer', expiresIn: 3600, scope: 'sign:job' };
+
+  it('returns the directDmz signer API url + Bearer session header', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: {
+        directDmz: { description: '', signerApiUrl: 'https://signer-dmz.pymthouse.com', webhookUrl: 'https://hook' },
+        deprecatedHostedFacade: { description: '', signerApiUrl: null },
+      },
+    });
+
+    const ep = await adapter.resolveSignerEndpoint(TOKEN);
+    expect(getSignerRouting).toHaveBeenCalledTimes(1);
+    expect(ep).toEqual({
+      url: 'https://signer-dmz.pymthouse.com',
+      headers: { Authorization: 'Bearer pmth_abc123' },
+    });
+  });
+
+  it('falls back to routing.remoteDmzUrl when directDmz is absent', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+
+    const ep = await adapter.resolveSignerEndpoint(TOKEN);
+    expect(ep.url).toBe('https://dmz.pymthouse.com');
+  });
+
+  it('throws when the provider exposes no DMZ url (front door fails safe)', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: '', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+
+    await expect(adapter.resolveSignerEndpoint(TOKEN)).rejects.toThrow(/no remote signer DMZ url/);
   });
 });
 

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -33,6 +33,7 @@ import {
   type ProviderSpendRecord,
   type ProviderSpendResult,
   type ProviderSpendScope,
+  type SignerSessionEndpoint,
   type SignerSessionToken,
   type UsageForExternalUserInput,
   type ValidateResult,
@@ -240,6 +241,37 @@ export class PymthouseAdapter implements BillingProviderAdapter {
       tokenType: session.tokenType,
       expiresIn: session.expiresIn,
       scope: session.scope,
+    };
+  }
+
+  /**
+   * Per-key remote signer (endpoint form). Resolve the app's remote signer DMZ
+   * via the Builder API `GET /api/v1/apps/{clientId}/signer/routing`
+   * (`getSignerRouting()`), then return the {@link SignerSessionEndpoint} form:
+   * the DMZ `url` + an `Authorization: Bearer <pmth_…>` header carrying the
+   * minted opaque session. go-livepeer's remote signer verifies that bearer via
+   * its `POST /webhooks/remote-signer` hook and meters usage to THIS pymthouse
+   * app's account — so signing + payment route to the funded per-key wallet
+   * instead of a static shared signer.
+   *
+   * The DMZ URL is the direct-DMZ signer API (`patterns.directDmz.signerApiUrl`),
+   * falling back to `routing.remoteDmzUrl`/`routing.signerApiUrl`. Throws when
+   * the provider exposes no DMZ URL so the front door can fail safe (it keeps
+   * the token-bundle form rather than emit a half-formed endpoint).
+   */
+  async resolveSignerEndpoint(session: SignerSessionToken): Promise<SignerSessionEndpoint> {
+    const routing = await this.client().getSignerRouting();
+    const url =
+      routing.patterns?.directDmz?.signerApiUrl ||
+      routing.routing?.remoteDmzUrl ||
+      routing.routing?.signerApiUrl ||
+      '';
+    if (!url) {
+      throw new Error('pymthouse signer routing returned no remote signer DMZ url');
+    }
+    return {
+      url,
+      headers: { Authorization: `Bearer ${session.accessToken}` },
     };
   }
 

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -66,6 +66,23 @@ export const MULTI_SUBSCRIPTION_FLAG = 'multi_subscription';
  */
 export const PLAN_SPEC_SYNC_FLAG = 'plan_spec_sync';
 
+/**
+ * Canonical key for per-key remote-signer wiring (default OFF). When OFF the
+ * validation front door returns the signer session EXACTLY as today — the
+ * provider token-bundle form (`SignerSessionToken`, `pmth_…`) — and no extra
+ * provider I/O happens (zero regression). When ON, and the resolved adapter
+ * implements `resolveSignerEndpoint`, the front door instead returns the
+ * `SignerSession` ENDPOINT form `{ url, headers }` pointing at the provider's
+ * per-key remote signer DMZ (pymthouse: `getSignerRouting()` DMZ URL + the
+ * minted `pmth_…` session as the `Authorization` header), so the SDK service
+ * signs + pays through the funded per-key wallet instead of a static shared
+ * signer. Mirrors the `DISCOVERY_FROM_VALIDATE` pattern: additive, flag-gated,
+ * canary-only. Shared by KNOWN_FLAGS and the front door so the name cannot
+ * drift. Pairs with simple-infra `SIGNER_FROM_VALIDATE` (the SDK service only
+ * consumes the endpoint form when ITS flag is on).
+ */
+export const PER_KEY_REMOTE_SIGNER_FLAG = 'per_key_remote_signer';
+
 export const KNOWN_FLAGS: KnownFlag[] = [
   {
     key: 'enableTeams',
@@ -155,6 +172,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
     enabled: false,
     description:
       'Plan-spec → per-app discovery sync (P4): pull each ProviderInstance\'s published plans into ProviderPlan rows and auto-generate per-app DiscoveryPlans; the validate front door may expose the per-key discovery URL (key → subscription → ProviderPlan → DiscoveryPlan). OFF = no sync runs, ProviderPlan is never read/written, the catalog exposes no plans, and discovery is exactly today\'s static storyboard-default behavior (golden-set parity, zero regression).',
+  },
+  {
+    key: PER_KEY_REMOTE_SIGNER_FLAG,
+    enabled: false,
+    description:
+      'Per-key remote signer: the validation front door returns the signerSession ENDPOINT form { url, headers } pointing at the provider\'s per-key remote signer DMZ (pymthouse getSignerRouting DMZ URL + the minted pmth_ session), so the SDK service signs + pays through the funded per-key wallet. OFF = the front door returns the provider token-bundle form (pmth_ accessToken) exactly as today and performs no extra provider I/O (zero regression). Canary-only; pairs with simple-infra SIGNER_FROM_VALIDATE (the SDK service consumes the endpoint form only when its own flag is on).',
   },
 ];
 


### PR DESCRIPTION
## Summary

Behind a new **`per_key_remote_signer`** feature flag (**default OFF**), the key-validation front door (`POST /api/v1/keys/validate`) returns the `SignerSession` **endpoint** form `{ url, headers }` pointing at the provider's per-key remote signer DMZ, instead of the provider token-bundle form. For pymthouse this resolves the DMZ via `getSignerRouting()` and carries the minted `pmth_` session as the `Authorization` header — so the downstream SDK service signs **and pays** through the caller's own funded per-key wallet (metered to the pymthouse account) rather than a static shared signer.

- New **optional** SPI method `BillingProviderAdapter.resolveSignerEndpoint` (uses the existing `SignerSession` discriminated union's endpoint form). Providers without a remote signer DMZ omit it.
- `PymthouseAdapter.resolveSignerEndpoint` resolves the DMZ URL (`patterns.directDmz.signerApiUrl`, falling back to `routing.remoteDmzUrl`/`signerApiUrl`) and returns `{ url, headers: { Authorization: "Bearer pmth_…" } }`.
- The front door swaps to the endpoint form **only** when the flag is ON **and** the resolved adapter implements `resolveSignerEndpoint`; it **fails SAFE** to the token-bundle form on any resolution error (never 500s).

## Flags & defaults

| Flag | Default | Effect when OFF |
| --- | --- | --- |
| `per_key_remote_signer` | **OFF** | Front door returns the provider token-bundle form (`pmth_` accessToken) and performs **no extra provider I/O** — byte-for-byte today's response (zero regression). |

Pairs with simple-infra `SIGNER_FROM_VALIDATE` (the SDK service consumes the endpoint form only when its own flag is on). Mirrors the existing `DISCOVERY_FROM_VALIDATE` pattern exactly: additive, flag-gated, canary-only.

## Zero-regression evidence

- New test `flag OFF → returns the provider token-bundle form (byte-for-byte today, INV)` asserts the resolver is **never called** and the response `signerSession` is unchanged when the flag is OFF.
- `flag ON + adapter without resolveSignerEndpoint → keeps token form (no-op)` and `flag ON + resolver throws → fails SAFE to the token form (never 500)`.
- All pre-existing validate front-door / adapter tests unchanged and green.

## Test plan

- [x] `vitest run keys/validate/route.test.ts` (route: flag ON/OFF, no-op, fail-safe) — green
- [x] `vitest run pymthouse-adapter.test.ts` (resolveSignerEndpoint: directDmz, remoteDmzUrl fallback, no-DMZ throw) — green
- [x] `tsc --noEmit` introduces no new type errors
- [ ] Canary/preview validation with both flags ON proving the signer used is the pymthouse DMZ and usage attributes to the pymthouse account (do not flip prod flags)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-key remote signer routing during key validation, allowing eligible requests to return a direct signer endpoint when enabled.
  * Introduced a new feature flag to control this behavior, with a safe default that keeps existing behavior unchanged.

* **Bug Fixes**
  * Improved fallback handling so key validation continues to return the standard signer session if endpoint resolution is unavailable or fails.
  * Added coverage to ensure signer session data is formatted consistently across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->