### PR TITLE
feat(billing): mint user-scoped signer JWT for per-key remote signer (P7)

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.4.3",
+    "@pymthouse/builder-sdk": "0.4.6",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -272,9 +272,11 @@ describe('per-key remote signer (per_key_remote_signer)', () => {
     expect(res.status).toBe(200);
     const d = (await res.json()).data;
     expect(d.signerSession).toEqual(endpoint);
-    // The minted token-bundle session is handed to the resolver.
+    // The minted token-bundle session is handed to the resolver, along with the
+    // key's billing account id as the externalUserId for the user-scoped JWT.
     expect(resolveSignerEndpoint).toHaveBeenCalledWith(
       expect.objectContaining({ accessToken: 'signer-tok' }),
+      { externalUserId: 'acct_om_1' },
     );
   });
 

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -181,7 +181,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       (await isFeatureEnabled(PER_KEY_REMOTE_SIGNER_FLAG))
     ) {
       try {
-        signerSession = await adapter.resolveSignerEndpoint(resolved.signerSession);
+        signerSession = await adapter.resolveSignerEndpoint(resolved.signerSession, {
+          externalUserId: ref.accountId,
+        });
         log('info', 'keys.validate.signer_endpoint', {
           correlationId,
           providerSlug: ref.providerSlug,

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -182,13 +182,19 @@ export interface BillingProviderAdapter {
    * BPP per-key remote signer (endpoint form) — OPTIONAL. Resolve a minted
    * token-bundle session into the {@link SignerSessionEndpoint} form: the
    * provider's per-key remote signer DMZ `url` plus opaque-to-apps `headers`
-   * carrying that session (so a downstream SDK/gateway can sign + pay directly
-   * against the per-key funded wallet). Providers that cannot expose a remote
-   * signer DMZ omit this; the front door then keeps the token-bundle form.
-   * Gated at the front door by `PER_KEY_REMOTE_SIGNER_FLAG` (default OFF), so a
-   * provider implementing this is still a no-op until the flag is enabled.
+   * carrying a per-user bearer (so a downstream SDK/gateway can sign + pay
+   * directly against the per-key funded wallet). The optional `context`
+   * carries the provider `externalUserId` (the front door's
+   * `billingAccountRef.accountId`) so the provider can mint a user-scoped
+   * credential for the bearer. Providers that cannot expose a remote signer DMZ
+   * omit this; the front door then keeps the token-bundle form. Gated at the
+   * front door by `PER_KEY_REMOTE_SIGNER_FLAG` (default OFF), so a provider
+   * implementing this is still a no-op until the flag is enabled.
    */
-  resolveSignerEndpoint?(session: SignerSessionToken): Promise<SignerSessionEndpoint>;
+  resolveSignerEndpoint?(
+    session: SignerSessionToken,
+    context?: { externalUserId: string },
+  ): Promise<SignerSessionEndpoint>;
 
   /** BPP ⑧ — receive a curated orchestrator list for a plan. */
   receiveCuratedOrchestrators(plan: string, list: CuratedOrchestrator[]): Promise<void>;

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -7,6 +7,8 @@ const getUsage = vi.fn();
 const getUserSubscription = vi.fn();
 const listBillingProducts = vi.fn();
 const getSignerRouting = vi.fn();
+const mintUserSignerJwtForExternalUser = vi.fn();
+const globalSignerExchangeConfig = vi.fn();
 
 vi.mock('@/lib/pymthouse-client', () => ({
   getPmtHouseServerClient: () => ({
@@ -16,6 +18,8 @@ vi.mock('@/lib/pymthouse-client', () => ({
     listBillingProducts,
     getSignerRouting,
   }),
+  globalSignerExchangeConfig: () => globalSignerExchangeConfig(),
+  mintUserSignerJwtForExternalUser: (input: unknown) => mintUserSignerJwtForExternalUser(input),
 }));
 
 vi.mock('@pymthouse/builder-sdk/config', () => ({
@@ -40,6 +44,17 @@ beforeEach(() => {
   vi.clearAllMocks();
   resetPymthouseCapabilityCacheForTests();
   isFeatureEnabled.mockResolvedValue(false);
+  globalSignerExchangeConfig.mockReturnValue({
+    issuerUrl: 'https://pymthouse.com/api/v1/oidc',
+    m2mClientId: 'm2m_test',
+    m2mClientSecret: 'secret_test',
+  });
+  mintUserSignerJwtForExternalUser.mockResolvedValue({
+    jwt: 'eyJhbGciOiJSUzI1NiJ9.user-signer-jwt.sig',
+    expiresIn: 900,
+    scope: 'sign:job',
+    balanceUsdMicros: '5000000',
+  });
   adapter = new PymthouseAdapter();
 });
 
@@ -123,10 +138,13 @@ describe('PymthouseAdapter per-instance client (P0, zero regression)', () => {
   });
 });
 
-describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer)', () => {
+describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JWT)', () => {
+  // The opaque session is intentionally IGNORED for the bearer now — the DMZ
+  // webhook is OIDC/JWT-only, so we mint + forward a user-scoped signer JWT.
   const TOKEN = { accessToken: 'pmth_abc123', tokenType: 'Bearer', expiresIn: 3600, scope: 'sign:job' };
+  const CTX = { externalUserId: 'acct_user_42' };
 
-  it('returns the directDmz signer API url + Bearer session header', async () => {
+  it('mints a user signer JWT and forwards it as the Bearer (NOT the opaque pmth_)', async () => {
     getSignerRouting.mockResolvedValue({
       clientId: 'app_x',
       routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
@@ -136,12 +154,50 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer)', () =>
       },
     });
 
-    const ep = await adapter.resolveSignerEndpoint(TOKEN);
+    const ep = await adapter.resolveSignerEndpoint(TOKEN, CTX);
     expect(getSignerRouting).toHaveBeenCalledTimes(1);
+    // The JWT is minted with the resolved exchange config + the key's account id.
+    expect(mintUserSignerJwtForExternalUser).toHaveBeenCalledWith({
+      exchange: {
+        issuerUrl: 'https://pymthouse.com/api/v1/oidc',
+        m2mClientId: 'm2m_test',
+        m2mClientSecret: 'secret_test',
+      },
+      externalUserId: 'acct_user_42',
+    });
     expect(ep).toEqual({
       url: 'https://signer-dmz.pymthouse.com',
-      headers: { Authorization: 'Bearer pmth_abc123' },
+      headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.user-signer-jwt.sig' },
     });
+    // The opaque session token must never leak into the forwarded header.
+    expect(ep.headers.Authorization).not.toContain('pmth_');
+  });
+
+  it('uses the per-instance signer exchange config when one is injected', async () => {
+    const instanceClient = { getSignerRouting } as never;
+    const instanceExchange = {
+      issuerUrl: 'https://tenant.pymthouse.com/api/v1/oidc',
+      m2mClientId: 'm2m_tenant',
+      m2mClientSecret: 'secret_tenant',
+    };
+    const a = new PymthouseAdapter({
+      client: instanceClient,
+      isConfigured: () => true,
+      signerExchange: instanceExchange,
+    });
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_tenant',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+
+    await a.resolveSignerEndpoint(TOKEN, CTX);
+    expect(mintUserSignerJwtForExternalUser).toHaveBeenCalledWith({
+      exchange: instanceExchange,
+      externalUserId: 'acct_user_42',
+    });
+    // The global env exchange config is NOT consulted for a per-instance adapter.
+    expect(globalSignerExchangeConfig).not.toHaveBeenCalled();
   });
 
   it('falls back to routing.remoteDmzUrl when directDmz is absent', async () => {
@@ -151,7 +207,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer)', () =>
       patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
     });
 
-    const ep = await adapter.resolveSignerEndpoint(TOKEN);
+    const ep = await adapter.resolveSignerEndpoint(TOKEN, CTX);
     expect(ep.url).toBe('https://dmz.pymthouse.com');
   });
 
@@ -162,7 +218,41 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer)', () =>
       patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
     });
 
-    await expect(adapter.resolveSignerEndpoint(TOKEN)).rejects.toThrow(/no remote signer DMZ url/);
+    await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow(/no remote signer DMZ url/);
+    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dashboard /api/signer proxy base (must target the DMZ directly)', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://dashboard.pymthouse.com/api/signer', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: 'https://dashboard.pymthouse.com/api/signer', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+
+    await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow();
+    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+  });
+
+  it('throws when no externalUserId is provided (cannot mint a user-scoped JWT)', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+
+    await expect(adapter.resolveSignerEndpoint(TOKEN)).rejects.toThrow(/externalUserId/);
+    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+  });
+
+  it('propagates a mint error so the front door fails safe to the token bundle', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+    mintUserSignerJwtForExternalUser.mockRejectedValue(new Error('mint failed'));
+
+    await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow('mint failed');
   });
 });
 

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -11,13 +11,16 @@
 import 'server-only';
 
 import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
+import { assertDirectSignerBaseUrl } from '@pymthouse/builder-sdk/signer/server';
 
 import type { MeScopeUsagePayload, PmtHouseClient, UsageApiResponse } from '@pymthouse/builder-sdk';
 
 import {
   getPmtHouseServerClient,
+  globalSignerExchangeConfig,
   mintOpaqueSignerSessionForExternalUser,
   mintSignerSessionForExternalUser,
+  mintUserSignerJwtForExternalUser,
   type PymthouseSignerExchangeConfig,
 } from '@/lib/pymthouse-client';
 import { isFeatureEnabled, PYMTHOUSE_BPP_VALIDATE_FLAG } from '@/lib/feature-flags';
@@ -248,18 +251,30 @@ export class PymthouseAdapter implements BillingProviderAdapter {
    * Per-key remote signer (endpoint form). Resolve the app's remote signer DMZ
    * via the Builder API `GET /api/v1/apps/{clientId}/signer/routing`
    * (`getSignerRouting()`), then return the {@link SignerSessionEndpoint} form:
-   * the DMZ `url` + an `Authorization: Bearer <pmth_…>` header carrying the
-   * minted opaque session. go-livepeer's remote signer verifies that bearer via
-   * its `POST /webhooks/remote-signer` hook and meters usage to THIS pymthouse
-   * app's account — so signing + payment route to the funded per-key wallet
-   * instead of a static shared signer.
+   * the DMZ `url` + an `Authorization: Bearer <jwt>` header carrying a freshly
+   * minted USER-SCOPED SIGNER JWT (token-exchange "Option A" via
+   * {@link mintUserSignerJwtForExternalUser}).
+   *
+   * The DMZ identity webhook is OIDC/JWT-only: it verifies the bearer as a JWT
+   * (JWKS, `aud` = issuer, `client_id`, `external_user_id`) to attribute the
+   * billable `/generate-live-payment` ticket to the funded per-key wallet — an
+   * opaque `pmth_…` session is rejected with `Invalid JWT` (502). So we forward
+   * the JWT here, NOT the opaque `session.accessToken`. `mintSignerSession`
+   * (the flag-OFF default/Daydream path) still mints the opaque bundle
+   * byte-for-byte; the JWT is produced ONLY inside this already-flag-gated
+   * method (front-door `PER_KEY_REMOTE_SIGNER_FLAG`, fail-safe on error).
    *
    * The DMZ URL is the direct-DMZ signer API (`patterns.directDmz.signerApiUrl`),
-   * falling back to `routing.remoteDmzUrl`/`routing.signerApiUrl`. Throws when
-   * the provider exposes no DMZ URL so the front door can fail safe (it keeps
-   * the token-bundle form rather than emit a half-formed endpoint).
+   * falling back to `routing.remoteDmzUrl`/`routing.signerApiUrl`, validated by
+   * `assertDirectSignerBaseUrl` (rejects dashboard `/api/signer` proxy URLs).
+   * Throws when the provider exposes no DMZ URL or no `externalUserId` so the
+   * front door can fail safe (it keeps the token-bundle form rather than emit a
+   * half-formed endpoint).
    */
-  async resolveSignerEndpoint(session: SignerSessionToken): Promise<SignerSessionEndpoint> {
+  async resolveSignerEndpoint(
+    _session: SignerSessionToken,
+    context?: { externalUserId: string },
+  ): Promise<SignerSessionEndpoint> {
     const routing = await this.client().getSignerRouting();
     const url =
       routing.patterns?.directDmz?.signerApiUrl ||
@@ -269,9 +284,23 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     if (!url) {
       throw new Error('pymthouse signer routing returned no remote signer DMZ url');
     }
+    // Reject dashboard `/api/signer/*` proxy bases — signing RPCs must target
+    // the remote-signer DMZ origin directly (builder-sdk 0.4.6).
+    assertDirectSignerBaseUrl(url);
+
+    const externalUserId = context?.externalUserId;
+    if (!externalUserId) {
+      throw new Error('resolveSignerEndpoint requires externalUserId to mint the user signer JWT');
+    }
+
+    // Per-instance exchange config (this app's issuer + M2M creds) when the
+    // registry injected one, else the global `PYMTHOUSE_*` env config.
+    const exchange = this.signerExchange ?? globalSignerExchangeConfig();
+    const { jwt } = await mintUserSignerJwtForExternalUser({ exchange, externalUserId });
+
     return {
       url,
-      headers: { Authorization: `Bearer ${session.accessToken}` },
+      headers: { Authorization: `Bearer ${jwt}` },
     };
   }
 

--- a/apps/web-next/src/lib/pymthouse-client.test.ts
+++ b/apps/web-next/src/lib/pymthouse-client.test.ts
@@ -1,0 +1,116 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mintUserSignerToken = vi.fn();
+
+vi.mock('@pymthouse/builder-sdk/signer/server', () => ({
+  mintUserSignerToken: (...a: unknown[]) => mintUserSignerToken(...a),
+}));
+
+import { mintUserSignerJwtForExternalUser } from './pymthouse-client';
+
+const EXCHANGE = {
+  issuerUrl: 'https://pymthouse.com/api/v1/oidc',
+  m2mClientId: 'm2m_5ad45661715c8bb7eb30d18f',
+  m2mClientSecret: 'pmth_cs_secret',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-25T00:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('mintUserSignerJwtForExternalUser (Option A user-scoped signer JWT)', () => {
+  it('mints via builder-sdk with issuer + M2M creds + externalUserId, returns the JWT', async () => {
+    mintUserSignerToken.mockResolvedValue({
+      jwt: 'eyJhbGciOiJSUzI1NiJ9.payload.sig',
+      expiresAt: Date.now() + 900_000, // +15 min
+      refreshAt: Date.now() + 720_000,
+      balanceUsdMicros: '5000000',
+      lifetimeGrantedUsdMicros: '10000000',
+    });
+
+    const out = await mintUserSignerJwtForExternalUser({
+      exchange: EXCHANGE,
+      externalUserId: 'acct_user_42',
+    });
+
+    // The SDK is the single audience authority: aud = issuer URL (no override).
+    expect(mintUserSignerToken).toHaveBeenCalledWith({
+      issuerUrl: EXCHANGE.issuerUrl,
+      m2mClientId: EXCHANGE.m2mClientId,
+      m2mClientSecret: EXCHANGE.m2mClientSecret,
+      externalUserId: 'acct_user_42',
+      allowInsecureHttp: false,
+    });
+    expect(out.jwt).toBe('eyJhbGciOiJSUzI1NiJ9.payload.sig');
+    expect(out.expiresIn).toBe(900);
+    expect(out.scope).toBe('sign:job');
+    expect(out.balanceUsdMicros).toBe('5000000');
+  });
+
+  it('clamps a near-expiry mint to a >= 1s TTL', async () => {
+    mintUserSignerToken.mockResolvedValue({
+      jwt: 'eyJ.x.y',
+      expiresAt: Date.now() - 5_000, // already expired
+      refreshAt: Date.now(),
+      balanceUsdMicros: '0',
+      lifetimeGrantedUsdMicros: '0',
+    });
+
+    const out = await mintUserSignerJwtForExternalUser({
+      exchange: EXCHANGE,
+      externalUserId: 'acct_user_42',
+    });
+    expect(out.expiresIn).toBe(1);
+  });
+
+  it('honors an explicit scope override', async () => {
+    mintUserSignerToken.mockResolvedValue({
+      jwt: 'eyJ.x.y',
+      expiresAt: Date.now() + 60_000,
+      refreshAt: Date.now() + 48_000,
+      balanceUsdMicros: '0',
+      lifetimeGrantedUsdMicros: '0',
+    });
+
+    const out = await mintUserSignerJwtForExternalUser({
+      exchange: EXCHANGE,
+      externalUserId: 'acct_user_42',
+      scope: 'sign:job extra:scope',
+    });
+    expect(out.scope).toBe('sign:job extra:scope');
+  });
+
+  it('passes allowInsecureHttp=true for an http issuer (local/dev)', async () => {
+    mintUserSignerToken.mockResolvedValue({
+      jwt: 'eyJ.x.y',
+      expiresAt: Date.now() + 60_000,
+      refreshAt: Date.now() + 48_000,
+      balanceUsdMicros: '0',
+      lifetimeGrantedUsdMicros: '0',
+    });
+
+    await mintUserSignerJwtForExternalUser({
+      exchange: { ...EXCHANGE, issuerUrl: 'http://localhost:4000/api/v1/oidc' },
+      externalUserId: 'acct_user_42',
+    });
+    expect(mintUserSignerToken).toHaveBeenCalledWith(
+      expect.objectContaining({ allowInsecureHttp: true }),
+    );
+  });
+
+  it('propagates a mint failure (front door fails safe on this)', async () => {
+    mintUserSignerToken.mockRejectedValue(new Error('invalid_target'));
+    await expect(
+      mintUserSignerJwtForExternalUser({ exchange: EXCHANGE, externalUserId: 'acct_user_42' }),
+    ).rejects.toThrow('invalid_target');
+  });
+});

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -16,6 +16,7 @@ import {
 } from '@pymthouse/builder-sdk';
 import { createPmtHouseClientFromEnv } from '@pymthouse/builder-sdk/env';
 import { PmtHouseClient } from '@pymthouse/builder-sdk';
+import { mintUserSignerToken } from '@pymthouse/builder-sdk/signer/server';
 
 const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
 const SUBJECT_ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
@@ -91,7 +92,7 @@ export interface PymthouseSignerExchangeConfig {
 }
 
 /** Resolve the global `PYMTHOUSE_*` env into a signer-exchange config (or throw). */
-function globalSignerExchangeConfig(): PymthouseSignerExchangeConfig {
+export function globalSignerExchangeConfig(): PymthouseSignerExchangeConfig {
   const env = readPymthouseEnv();
   if (!env) {
     throw new PmtHouseError(PYMTHOUSE_NOT_CONFIGURED_MESSAGE, {
@@ -247,4 +248,58 @@ export async function mintSignerSessionForExternalUser(input: {
     ...(input.email != null ? { email: input.email } : {}),
     ...(input.scope != null ? { scope: input.scope } : {}),
   });
+}
+
+/** Result of minting a user-scoped signer JWT (the JWT plus its derived TTL). */
+export interface UserSignerJwt {
+  /** The user-scoped signer JWT (`eyJ…`) to forward as `Authorization: Bearer`. */
+  jwt: string;
+  /** Seconds until the JWT expires (>= 1), derived from the SDK's `expiresAt`. */
+  expiresIn: number;
+  /** Scope the token carries (always `sign:job` for the signed-job path). */
+  scope: string;
+  /** Funded balance (USD-micros) returned alongside the mint, for diagnostics. */
+  balanceUsdMicros: string;
+}
+
+/**
+ * Mint a USER-SCOPED SIGNER JWT for a NaaP user via builder-sdk
+ * `mintUserSignerToken` (token-exchange doc "Option A" clearinghouse mint:
+ * `grant_type=client_credentials`, `scope=sign:mint_user_token`,
+ * `external_user_id` baked in). Unlike {@link mintOpaqueSignerSessionForExternalUser}
+ * this returns a JWKS-verifiable JWT (`iss`/`client_id`/`external_user_id`
+ * cryptographically embedded) — the form the remote-signer DMZ identity webhook
+ * accepts on `/generate-live-payment` with no DB lookup.
+ *
+ * `aud` is set automatically by the SDK to the OIDC issuer URL
+ * (`signerJwtAudience(issuerUrl)`), which is exactly what the prod DMZ webhook
+ * validates — so there is no `aud` knob here (do NOT hardcode
+ * `livepeer-remote-signer`; current issuers reject it with `invalid_target`).
+ */
+export async function mintUserSignerJwtForExternalUser(input: {
+  exchange: PymthouseSignerExchangeConfig;
+  externalUserId: string;
+  scope?: string;
+}): Promise<UserSignerJwt> {
+  const allowInsecureHttp =
+    input.exchange.allowInsecureHttp ??
+    (process.env.PYMTHOUSE_ALLOW_INSECURE_HTTP === '1' ||
+      input.exchange.issuerUrl.startsWith('http:'));
+
+  const minted = await mintUserSignerToken({
+    issuerUrl: input.exchange.issuerUrl,
+    m2mClientId: input.exchange.m2mClientId,
+    m2mClientSecret: input.exchange.m2mClientSecret,
+    externalUserId: input.externalUserId,
+    allowInsecureHttp,
+  });
+
+  return {
+    jwt: minted.jwt,
+    // `expiresAt` is an absolute epoch-ms; clamp to >= 1s so a near-expiry mint
+    // never serializes a non-positive TTL.
+    expiresIn: Math.max(1, Math.floor((minted.expiresAt - Date.now()) / 1000)),
+    scope: input.scope?.trim() || SIGN_JOB_SCOPE,
+    balanceUsdMicros: minted.balanceUsdMicros,
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.4.3",
+        "@pymthouse/builder-sdk": "0.4.6",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -131,6 +131,18 @@
       "version": "7.4.2",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "apps/web-next/node_modules/@pymthouse/builder-sdk": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
+      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "apps/web-next/node_modules/@types/mime-types": {
       "version": "3.0.1",
@@ -8706,18 +8718,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.3.tgz",
-      "integrity": "sha512-1cwK78PDekyd2BYC59OJeSorT8XT+laNp7dQj+JC9FNcO4TmJs32Yz4EzhWZohUXszIpejas3J+KXWh9HR8hrw==",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@remix-run/router": {
@@ -25303,6 +25303,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -31919,7 +31920,7 @@
         "@naap/database": "*",
         "@naap/plugin-server-sdk": "*",
         "@naap/types": "*",
-        "@pymthouse/builder-sdk": "0.4.3",
+        "@pymthouse/builder-sdk": "0.4.6",
         "cors": "^2.8.6",
         "dotenv": "^16.6.1",
         "express": "^4.21.0",
@@ -31932,6 +31933,18 @@
         "@types/uuid": "^10.0.0",
         "tsx": "^4.19.0",
         "typescript": "~5.9.3"
+      }
+    },
+    "plugins/developer-api/backend/node_modules/@pymthouse/builder-sdk": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
+      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "plugins/developer-api/backend/node_modules/dotenv": {
@@ -31966,7 +31979,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.4.3",
+        "@pymthouse/builder-sdk": "0.4.6",
         "framer-motion": "^12.0.0",
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",
@@ -31986,6 +31999,18 @@
       },
       "engines": {
         "node": ">=20.19.0 || >=22.12.0"
+      }
+    },
+    "plugins/developer-api/frontend/node_modules/@pymthouse/builder-sdk": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
+      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "plugins/lightning-client/backend": {

--- a/plugins/developer-api/backend/package.json
+++ b/plugins/developer-api/backend/package.json
@@ -12,7 +12,7 @@
     "@naap/database": "*",
     "@naap/plugin-server-sdk": "*",
     "@naap/types": "*",
-    "@pymthouse/builder-sdk": "0.4.3",
+    "@pymthouse/builder-sdk": "0.4.6",
     "cors": "^2.8.6",
     "dotenv": "^16.6.1",
     "express": "^4.21.0",

--- a/plugins/developer-api/frontend/package.json
+++ b/plugins/developer-api/frontend/package.json
@@ -17,7 +17,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.4.3",
+    "@pymthouse/builder-sdk": "0.4.6",
     "framer-motion": "^12.0.0",
     "lucide-react": "^0.575.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

Fixes the per-key remote-signer path so it mints and forwards a **user-scoped signer JWT** (not the opaque `pmth_` session) to the pymthouse signer DMZ, per the [token-exchange doc](https://docs.pymthouse.com/integration/token-exchange) (Option A) and the dashboard #3 / builder-sdk 0.4.6 pattern.

**Root cause:** the remote-signer DMZ identity webhook is OIDC/JWT-only — it verifies the bearer as a JWT (JWKS, `aud`=issuer, `client_id`, `external_user_id`) to attribute the billable `/generate-live-payment` ticket to the funded per-key wallet. Forwarding the opaque `pmth_` session was rejected with `Invalid JWT` (502). (`/sign-orchestrator-info` is unauthenticated, which masked the asymmetry.)

**Fix (additive, flag-gated `per_key_remote_signer`, default OFF):**
- Bump `@pymthouse/builder-sdk` `0.4.3 → 0.4.6` across the monorepo (web-next + developer-api fe/be), matching dashboard #3.
- Add `mintUserSignerJwtForExternalUser()` wrapping builder-sdk `mintUserSignerToken` (`grant_type=client_credentials`, `scope=sign:mint_user_token`, `external_user_id` baked in). `aud` defaults to the OIDC issuer URL — set automatically by the SDK (`signerJwtAudience(issuer)`); no `aud` knob (current issuers reject `livepeer-remote-signer` with `invalid_target`).
- `resolveSignerEndpoint()` now mints a fresh user signer JWT, validates the DMZ base via `assertDirectSignerBaseUrl` (rejects dashboard `/api/signer` proxy URLs), and forwards `Authorization: Bearer <jwt>`. The `externalUserId` (= the key's `billingAccountRef.accountId`) is threaded from the validate front door.

## Zero-regression

- The JWT is minted **only** inside the already-flag-gated `resolveSignerEndpoint`. `mintSignerSession` (the flag-OFF default / Daydream path) still mints the opaque bundle **byte-for-byte**.
- Front door keeps its fail-safe try/catch: any mint/routing error keeps the token-bundle form (never 500s).
- No `simple-infra` change: the `SIGNER_FROM_VALIDATE` leg forwards `signerSession.headers` verbatim, so swapping `pmth_` → JWT in the header is transparent.

## Test plan

- [x] Unit: JWT minted + forwarded as `Bearer eyJ…` when flag ON; opaque `pmth_` never leaks into the header.
- [x] Unit: per-instance vs global exchange config selection.
- [x] Unit (INV): flag OFF → token-bundle form byte-for-byte; resolver never called.
- [x] Unit: fail-safe — mint error / missing `externalUserId` / dashboard proxy URL → throws (front door keeps token bundle).
- [x] `mintUserSignerJwtForExternalUser` unit tests (issuer/creds/TTL/scope/insecure-http/error).
- [x] Full web-next suite green (1203 passed / 1 skipped); no new typecheck errors vs `main` baseline.
- [ ] E2E on isolated preview: `naap_` key → `/keys/validate` returns endpoint form with a real JWT (`aud`=issuer, `external_user_id` present) → canary SDK `/inference` → `/generate-live-payment` 200 + OpenMeter increment.

Closes the NaaP side of the work tracked in pymthouse/pymthouse#164 (closed as wrong-layer; this is the correct caller-side JWT mint).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote signer requests now include account-aware context, enabling more reliable user-scoped signing behavior.
  * Added support for minting and using user-scoped signer credentials, improving per-key remote signing flows.

* **Bug Fixes**
  * Strengthened validation around signer endpoints to avoid using unsupported routing paths.
  * Improved fallback handling so signing continues to work when remote signer resolution fails.

* **Chores**
  * Updated the builder SDK to a newer version across web and developer API packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->