### PR TITLE
fix(billing): forward Builder user-token JWT to the remote signer DMZ (P7)

### DIFF
--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -53,7 +53,6 @@ beforeEach(() => {
     jwt: 'eyJhbGciOiJSUzI1NiJ9.user-signer-jwt.sig',
     expiresIn: 900,
     scope: 'sign:job',
-    balanceUsdMicros: '5000000',
   });
   adapter = new PymthouseAdapter();
 });
@@ -156,13 +155,10 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
 
     const ep = await adapter.resolveSignerEndpoint(TOKEN, CTX);
     expect(getSignerRouting).toHaveBeenCalledTimes(1);
-    // The JWT is minted with the resolved exchange config + the key's account id.
+    // The JWT is minted against this adapter's client (the global-env singleton
+    // here) + the key's account id as the externalUserId.
     expect(mintUserSignerJwtForExternalUser).toHaveBeenCalledWith({
-      exchange: {
-        issuerUrl: 'https://pymthouse.com/api/v1/oidc',
-        m2mClientId: 'm2m_test',
-        m2mClientSecret: 'secret_test',
-      },
+      client: expect.objectContaining({ getSignerRouting }),
       externalUserId: 'acct_user_42',
     });
     expect(ep).toEqual({
@@ -192,8 +188,10 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
     });
 
     await a.resolveSignerEndpoint(TOKEN, CTX);
+    // The mint binds to the injected per-instance client (whose app the DMZ
+    // routing was resolved against), never the global-env singleton.
     expect(mintUserSignerJwtForExternalUser).toHaveBeenCalledWith({
-      exchange: instanceExchange,
+      client: instanceClient,
       externalUserId: 'acct_user_42',
     });
     // The global env exchange config is NOT consulted for a per-instance adapter.

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -17,7 +17,6 @@ import type { MeScopeUsagePayload, PmtHouseClient, UsageApiResponse } from '@pym
 
 import {
   getPmtHouseServerClient,
-  globalSignerExchangeConfig,
   mintOpaqueSignerSessionForExternalUser,
   mintSignerSessionForExternalUser,
   mintUserSignerJwtForExternalUser,
@@ -252,17 +251,21 @@ export class PymthouseAdapter implements BillingProviderAdapter {
    * via the Builder API `GET /api/v1/apps/{clientId}/signer/routing`
    * (`getSignerRouting()`), then return the {@link SignerSessionEndpoint} form:
    * the DMZ `url` + an `Authorization: Bearer <jwt>` header carrying a freshly
-   * minted USER-SCOPED SIGNER JWT (token-exchange "Option A" via
-   * {@link mintUserSignerJwtForExternalUser}).
+   * minted Builder USER-TOKEN JWT (via {@link mintUserSignerJwtForExternalUser}).
    *
-   * The DMZ identity webhook is OIDC/JWT-only: it verifies the bearer as a JWT
-   * (JWKS, `aud` = issuer, `client_id`, `external_user_id`) to attribute the
-   * billable `/generate-live-payment` ticket to the funded per-key wallet — an
+   * Per the pymthouse "User-scoped JWTs" doc ("Passing the token to downstream
+   * services") and the signer-routing `directDmz` pattern, the token the remote
+   * signer DMZ validates is the Builder user-token (`/users/{id}/token`,
+   * `sign:job`) — NOT the token-exchange "Option A" `sign:mint_user_token`
+   * clearinghouse mint, which currently `500`s upstream. The DMZ identity
+   * webhook is OIDC/JWT-only: it verifies the bearer as a JWT (JWKS, `aud` =
+   * issuer, `client_id`/`azp`, `scope` ⊇ `sign:job`, `sub` = app-user) — an
    * opaque `pmth_…` session is rejected with `Invalid JWT` (502). So we forward
-   * the JWT here, NOT the opaque `session.accessToken`. `mintSignerSession`
-   * (the flag-OFF default/Daydream path) still mints the opaque bundle
-   * byte-for-byte; the JWT is produced ONLY inside this already-flag-gated
-   * method (front-door `PER_KEY_REMOTE_SIGNER_FLAG`, fail-safe on error).
+   * the user-token JWT here, NOT the opaque `session.accessToken`.
+   * `mintSignerSession` (the flag-OFF default/Daydream path) still mints the
+   * opaque bundle byte-for-byte; the JWT is produced ONLY inside this
+   * already-flag-gated method (front-door `PER_KEY_REMOTE_SIGNER_FLAG`,
+   * fail-safe on error).
    *
    * The DMZ URL is the direct-DMZ signer API (`patterns.directDmz.signerApiUrl`),
    * falling back to `routing.remoteDmzUrl`/`routing.signerApiUrl`, validated by
@@ -293,10 +296,13 @@ export class PymthouseAdapter implements BillingProviderAdapter {
       throw new Error('resolveSignerEndpoint requires externalUserId to mint the user signer JWT');
     }
 
-    // Per-instance exchange config (this app's issuer + M2M creds) when the
-    // registry injected one, else the global `PYMTHOUSE_*` env config.
-    const exchange = this.signerExchange ?? globalSignerExchangeConfig();
-    const { jwt } = await mintUserSignerJwtForExternalUser({ exchange, externalUserId });
+    // Mint the Builder user-token JWT against THIS adapter's client (the
+    // per-instance client in subscription mode, else the global-env singleton),
+    // so the JWT's `client_id` matches the app whose DMZ we resolved above.
+    const { jwt } = await mintUserSignerJwtForExternalUser({
+      client: this.client(),
+      externalUserId,
+    });
 
     return {
       url,

--- a/apps/web-next/src/lib/pymthouse-client.test.ts
+++ b/apps/web-next/src/lib/pymthouse-client.test.ts
@@ -2,115 +2,133 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mintUserSignerToken = vi.fn();
-
-vi.mock('@pymthouse/builder-sdk/signer/server', () => ({
-  mintUserSignerToken: (...a: unknown[]) => mintUserSignerToken(...a),
-}));
-
 import { mintUserSignerJwtForExternalUser } from './pymthouse-client';
 
-const EXCHANGE = {
-  issuerUrl: 'https://pymthouse.com/api/v1/oidc',
-  m2mClientId: 'm2m_5ad45661715c8bb7eb30d18f',
-  m2mClientSecret: 'pmth_cs_secret',
-};
+/** Minimal `PmtHouseClient` stub exposing only what the mint helper touches. */
+function makeClient(
+  overrides: Partial<{
+    upsertAppUser: ReturnType<typeof vi.fn>;
+    mintUserAccessToken: ReturnType<typeof vi.fn>;
+  }> = {},
+) {
+  return {
+    upsertAppUser: vi.fn().mockResolvedValue({ id: 'app-user-1' }),
+    mintUserAccessToken: vi.fn().mockResolvedValue({
+      access_token: 'eyJhbGciOiJSUzI1NiJ9.payload.sig',
+      refresh_token: 'r',
+      token_type: 'Bearer',
+      expires_in: 900,
+      scope: 'sign:job',
+      subject_type: 'app_user',
+    }),
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.useFakeTimers();
-  vi.setSystemTime(new Date('2026-06-25T00:00:00.000Z'));
 });
 
 afterEach(() => {
-  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
-describe('mintUserSignerJwtForExternalUser (Option A user-scoped signer JWT)', () => {
-  it('mints via builder-sdk with issuer + M2M creds + externalUserId, returns the JWT', async () => {
-    mintUserSignerToken.mockResolvedValue({
-      jwt: 'eyJhbGciOiJSUzI1NiJ9.payload.sig',
-      expiresAt: Date.now() + 900_000, // +15 min
-      refreshAt: Date.now() + 720_000,
-      balanceUsdMicros: '5000000',
-      lifetimeGrantedUsdMicros: '10000000',
-    });
+describe('mintUserSignerJwtForExternalUser (Builder user-token JWT for the remote signer DMZ)', () => {
+  it('upserts the user then mints the Builder user-token, returning the JWT', async () => {
+    const client = makeClient();
 
     const out = await mintUserSignerJwtForExternalUser({
-      exchange: EXCHANGE,
+      client: client as never,
       externalUserId: 'acct_user_42',
     });
 
-    // The SDK is the single audience authority: aud = issuer URL (no override).
-    expect(mintUserSignerToken).toHaveBeenCalledWith({
-      issuerUrl: EXCHANGE.issuerUrl,
-      m2mClientId: EXCHANGE.m2mClientId,
-      m2mClientSecret: EXCHANGE.m2mClientSecret,
+    // Idempotent provision first so the mint never 404s on an unprovisioned user.
+    expect(client.upsertAppUser).toHaveBeenCalledWith({
       externalUserId: 'acct_user_42',
-      allowInsecureHttp: false,
+      status: 'active',
+    });
+    // Builder user-token mint: POST /users/{id}/token with scope sign:job.
+    expect(client.mintUserAccessToken).toHaveBeenCalledWith({
+      externalUserId: 'acct_user_42',
+      scope: 'sign:job',
     });
     expect(out.jwt).toBe('eyJhbGciOiJSUzI1NiJ9.payload.sig');
     expect(out.expiresIn).toBe(900);
     expect(out.scope).toBe('sign:job');
-    expect(out.balanceUsdMicros).toBe('5000000');
   });
 
-  it('clamps a near-expiry mint to a >= 1s TTL', async () => {
-    mintUserSignerToken.mockResolvedValue({
-      jwt: 'eyJ.x.y',
-      expiresAt: Date.now() - 5_000, // already expired
-      refreshAt: Date.now(),
-      balanceUsdMicros: '0',
-      lifetimeGrantedUsdMicros: '0',
-    });
+  it('passes an email through to the upsert when provided', async () => {
+    const client = makeClient();
 
-    const out = await mintUserSignerJwtForExternalUser({
-      exchange: EXCHANGE,
+    await mintUserSignerJwtForExternalUser({
+      client: client as never,
       externalUserId: 'acct_user_42',
+      email: 'user@example.com',
     });
-    expect(out.expiresIn).toBe(1);
+
+    expect(client.upsertAppUser).toHaveBeenCalledWith({
+      externalUserId: 'acct_user_42',
+      email: 'user@example.com',
+      status: 'active',
+    });
   });
 
-  it('honors an explicit scope override', async () => {
-    mintUserSignerToken.mockResolvedValue({
-      jwt: 'eyJ.x.y',
-      expiresAt: Date.now() + 60_000,
-      refreshAt: Date.now() + 48_000,
-      balanceUsdMicros: '0',
-      lifetimeGrantedUsdMicros: '0',
+  it('honors an explicit scope override (and falls back to it when the response omits scope)', async () => {
+    const client = makeClient({
+      mintUserAccessToken: vi.fn().mockResolvedValue({
+        access_token: 'eyJ.x.y',
+        expires_in: 60,
+        scope: '',
+      }),
     });
 
     const out = await mintUserSignerJwtForExternalUser({
-      exchange: EXCHANGE,
+      client: client as never,
+      externalUserId: 'acct_user_42',
+      scope: 'sign:job extra:scope',
+    });
+
+    expect(client.mintUserAccessToken).toHaveBeenCalledWith({
       externalUserId: 'acct_user_42',
       scope: 'sign:job extra:scope',
     });
     expect(out.scope).toBe('sign:job extra:scope');
   });
 
-  it('passes allowInsecureHttp=true for an http issuer (local/dev)', async () => {
-    mintUserSignerToken.mockResolvedValue({
-      jwt: 'eyJ.x.y',
-      expiresAt: Date.now() + 60_000,
-      refreshAt: Date.now() + 48_000,
-      balanceUsdMicros: '0',
-      lifetimeGrantedUsdMicros: '0',
+  it('clamps a non-positive / invalid expires_in to a safe default TTL', async () => {
+    const client = makeClient({
+      mintUserAccessToken: vi.fn().mockResolvedValue({
+        access_token: 'eyJ.x.y',
+        expires_in: 0,
+        scope: 'sign:job',
+      }),
     });
 
-    await mintUserSignerJwtForExternalUser({
-      exchange: { ...EXCHANGE, issuerUrl: 'http://localhost:4000/api/v1/oidc' },
+    const out = await mintUserSignerJwtForExternalUser({
+      client: client as never,
       externalUserId: 'acct_user_42',
     });
-    expect(mintUserSignerToken).toHaveBeenCalledWith(
-      expect.objectContaining({ allowInsecureHttp: true }),
-    );
+    expect(out.expiresIn).toBe(300);
   });
 
   it('propagates a mint failure (front door fails safe on this)', async () => {
-    mintUserSignerToken.mockRejectedValue(new Error('invalid_target'));
+    const client = makeClient({
+      mintUserAccessToken: vi.fn().mockRejectedValue(new Error('mint boom')),
+    });
+
     await expect(
-      mintUserSignerJwtForExternalUser({ exchange: EXCHANGE, externalUserId: 'acct_user_42' }),
-    ).rejects.toThrow('invalid_target');
+      mintUserSignerJwtForExternalUser({ client: client as never, externalUserId: 'acct_user_42' }),
+    ).rejects.toThrow('mint boom');
+  });
+
+  it('propagates an upsert failure (no mint attempted)', async () => {
+    const client = makeClient({
+      upsertAppUser: vi.fn().mockRejectedValue(new Error('upsert boom')),
+    });
+
+    await expect(
+      mintUserSignerJwtForExternalUser({ client: client as never, externalUserId: 'acct_user_42' }),
+    ).rejects.toThrow('upsert boom');
+    expect(client.mintUserAccessToken).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -16,7 +16,6 @@ import {
 } from '@pymthouse/builder-sdk';
 import { createPmtHouseClientFromEnv } from '@pymthouse/builder-sdk/env';
 import { PmtHouseClient } from '@pymthouse/builder-sdk';
-import { mintUserSignerToken } from '@pymthouse/builder-sdk/signer/server';
 
 const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
 const SUBJECT_ACCESS_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:access_token';
@@ -250,56 +249,67 @@ export async function mintSignerSessionForExternalUser(input: {
   });
 }
 
-/** Result of minting a user-scoped signer JWT (the JWT plus its derived TTL). */
+/** Result of minting the user-token JWT forwarded to the remote signer DMZ. */
 export interface UserSignerJwt {
-  /** The user-scoped signer JWT (`eyJ…`) to forward as `Authorization: Bearer`. */
+  /** The user-scoped JWT (`eyJ…`) to forward as `Authorization: Bearer`. */
   jwt: string;
-  /** Seconds until the JWT expires (>= 1), derived from the SDK's `expiresAt`. */
+  /** Seconds until the JWT expires (>= 1), derived from the mint response. */
   expiresIn: number;
   /** Scope the token carries (always `sign:job` for the signed-job path). */
   scope: string;
-  /** Funded balance (USD-micros) returned alongside the mint, for diagnostics. */
-  balanceUsdMicros: string;
 }
 
 /**
- * Mint a USER-SCOPED SIGNER JWT for a NaaP user via builder-sdk
- * `mintUserSignerToken` (token-exchange doc "Option A" clearinghouse mint:
- * `grant_type=client_credentials`, `scope=sign:mint_user_token`,
- * `external_user_id` baked in). Unlike {@link mintOpaqueSignerSessionForExternalUser}
- * this returns a JWKS-verifiable JWT (`iss`/`client_id`/`external_user_id`
- * cryptographically embedded) — the form the remote-signer DMZ identity webhook
- * accepts on `/generate-live-payment` with no DB lookup.
+ * Mint the Builder USER-TOKEN JWT for a NaaP user and return it for forwarding
+ * to the remote signer DMZ as `Authorization: Bearer <jwt>`.
  *
- * `aud` is set automatically by the SDK to the OIDC issuer URL
- * (`signerJwtAudience(issuerUrl)`), which is exactly what the prod DMZ webhook
- * validates — so there is no `aud` knob here (do NOT hardcode
- * `livepeer-remote-signer`; current issuers reject it with `invalid_target`).
+ * This is the downstream token the pymthouse "User-scoped JWTs" doc prescribes
+ * under "Passing the token to downstream services" (mint at
+ * `POST /api/v1/apps/{clientId}/users/{externalUserId}/token`, then pass the JWT
+ * to any PymtHouse service that validates it), and the same token the
+ * signer-routing `directDmz` pattern calls for ("Mint a user JWT via Builder API
+ * OIDC, sign against the remote signer DMZ directly").
+ *
+ * The minted JWT carries exactly the claims the DMZ OIDC identity webhook
+ * validates: `aud` = the issuer URL (matches the webhook's default
+ * `JWT_AUDIENCE`), `iss` = issuer, `client_id`/`azp` = the public app, and
+ * `scope` includes `sign:job` (usage is attributed via the `sub` app-user id).
+ * It mints successfully against the live issuer — unlike the token-exchange
+ * "Option A" clearinghouse mint (`grant_type=client_credentials`,
+ * `scope=sign:mint_user_token`), which currently returns
+ * `500 "Internal error during token mint"` upstream.
+ *
+ * The user is upserted first (idempotent) so the mint never 404s on a not-yet
+ * provisioned `externalUserId`.
  */
 export async function mintUserSignerJwtForExternalUser(input: {
-  exchange: PymthouseSignerExchangeConfig;
+  client: PmtHouseClient;
   externalUserId: string;
+  email?: string;
   scope?: string;
 }): Promise<UserSignerJwt> {
-  const allowInsecureHttp =
-    input.exchange.allowInsecureHttp ??
-    (process.env.PYMTHOUSE_ALLOW_INSECURE_HTTP === '1' ||
-      input.exchange.issuerUrl.startsWith('http:'));
+  const scope = input.scope?.trim() || SIGN_JOB_SCOPE;
 
-  const minted = await mintUserSignerToken({
-    issuerUrl: input.exchange.issuerUrl,
-    m2mClientId: input.exchange.m2mClientId,
-    m2mClientSecret: input.exchange.m2mClientSecret,
+  await input.client.upsertAppUser({
     externalUserId: input.externalUserId,
-    allowInsecureHttp,
+    ...(input.email != null ? { email: input.email } : {}),
+    status: 'active',
   });
 
+  const token = await input.client.mintUserAccessToken({
+    externalUserId: input.externalUserId,
+    scope,
+  });
+
+  const expiresIn =
+    Number.isFinite(token.expires_in) && token.expires_in > 0
+      ? Math.floor(token.expires_in)
+      : 300;
+
   return {
-    jwt: minted.jwt,
-    // `expiresAt` is an absolute epoch-ms; clamp to >= 1s so a near-expiry mint
-    // never serializes a non-positive TTL.
-    expiresIn: Math.max(1, Math.floor((minted.expiresAt - Date.now()) / 1000)),
-    scope: input.scope?.trim() || SIGN_JOB_SCOPE,
-    balanceUsdMicros: minted.balanceUsdMicros,
+    jwt: token.access_token,
+    // Clamp to >= 1s so a near-expiry mint never serializes a non-positive TTL.
+    expiresIn: Math.max(1, expiresIn),
+    scope: token.scope?.trim() || scope,
   };
 }


### PR DESCRIPTION
## Summary

The per-key remote signer endpoint (`PymthouseAdapter.resolveSignerEndpoint`, gated by `per_key_remote_signer`, default **OFF**) was forwarding the token-exchange **"Option A" clearinghouse mint** (`grant_type=client_credentials`, `scope=sign:mint_user_token`) to the remote signer DMZ. That mint currently returns **`500 "Internal error during token mint"`** upstream for our app, so the per-key signer path can never produce a usable JWT.

Per the pymthouse **["User-scoped JWTs" doc → "Passing the token to downstream services"](https://docs.pymthouse.com/integration/user-tokens#passing-the-token-to-downstream-services)** and the **[signer-routing `directDmz` pattern](https://docs.pymthouse.com/integration/signer-routing)** ("Mint a user JWT via Builder API OIDC, sign against the remote signer DMZ directly"), the token the remote signer DMZ validates is the **Builder user-token** (`POST /api/v1/apps/{clientId}/users/{externalUserId}/token`, scope `sign:job`).

This PR switches `resolveSignerEndpoint` to mint + forward the Builder user-token JWT (via `mintUserSignerJwtForExternalUser`, reimplemented over `client.upsertAppUser` + `client.mintUserAccessToken`).

## Why this is correct (verified live against the test app `app_98575870…`)

- **Builder user-token mints 200** with claims: `aud` = issuer URL (`https://pymthouse.com/api/v1/oidc`) — exactly the DMZ OIDC webhook's default `JWT_AUDIENCE` — `iss` = issuer, `client_id`/`azp` = public app, `scope` = `sign:job`, `sub` = app-user id.
- **The DMZ accepts it**: `POST /sign-orchestrator-info` → `200` (real signer signature `0x6CAE…7260`); `POST /generate-live-payment` gets **past identity auth** (`400 missing orchestrator`, i.e. a payload error, **not** an auth/"Invalid JWT" error).
- **Option A still `500`s** on the same app (re-confirmed).

## Zero-regression / safety

- Additive; entirely inside the already-flag-gated `resolveSignerEndpoint` (fail-safe on error → keeps the token-bundle form).
- The default / Daydream **opaque `pmth_…` session path** (`mintSignerSession`) is **untouched** (byte-for-byte when the flag is OFF).

## Test plan

- [x] `pymthouse-client.test.ts` + `pymthouse-adapter.test.ts` + `keys/validate/route.test.ts` — **49 passing**.
- [x] `tsc --noEmit` — **no new errors** in touched files (13 pre-existing repo-wide errors unchanged).
- [ ] **Full billed-generation E2E** (canary SDK service → preview, real orchestrator, OpenMeter `requestCount` increment) — verified up to the DMZ auth boundary; the final orchestrated generation needs the canary SDK service to construct a valid `/generate-live-payment` payload.

Made with [Cursor](https://cursor.com)