### PR TITLE
feat(flags): per-team feature-flag scoping with admin UI

### DIFF
--- a/apps/web-next/src/app/(dashboard)/admin/feature-flags/page.tsx
+++ b/apps/web-next/src/app/(dashboard)/admin/feature-flags/page.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+/**
+ * Admin — Per-Team Feature Flag Overrides
+ *
+ * Enable/disable a feature flag for a SINGLE team without changing the
+ * platform-wide default. Pick a team (searchable), then for each flag set a
+ * per-team override ON / OFF, or clear it to inherit the global value. Shows the
+ * effective value and provenance (inherited vs overridden) for every flag.
+ *
+ * Guarded by `system:admin`. Purely additive: a team with no overrides behaves
+ * exactly as the global flags dictate.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Flag,
+  Loader2,
+  Search,
+  CheckCircle2,
+  AlertTriangle,
+  Users as UsersIcon,
+} from 'lucide-react';
+import { Input } from '@naap/ui';
+import { useAuth } from '@/contexts/auth-context';
+import { AdminNav } from '@/components/admin/AdminNav';
+import { getCsrfToken } from '@/lib/api/csrf-client';
+import { invalidateFeatureFlags } from '@/hooks/use-feature-flags';
+
+interface TeamRow {
+  id: string;
+  name: string;
+  slug: string;
+  overrideCount: number;
+}
+
+interface FlagRow {
+  key: string;
+  description: string | null;
+  globalEnabled: boolean;
+  override: boolean | null;
+  effective: boolean;
+  source: 'override' | 'inherited';
+  updatedBy: string | null;
+  updatedAt: string | null;
+}
+
+type OverrideState = 'on' | 'off' | 'inherit';
+
+function humanizeKey(key: string): string {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function AdminFeatureFlagsPage() {
+  const router = useRouter();
+  const { hasRole } = useAuth();
+  const isAdmin = hasRole('system:admin');
+
+  const [teams, setTeams] = useState<TeamRow[]>([]);
+  const [teamSearch, setTeamSearch] = useState('');
+  const [selectedTeam, setSelectedTeam] = useState<TeamRow | null>(null);
+  const [flags, setFlags] = useState<FlagRow[]>([]);
+  const [loadingTeams, setLoadingTeams] = useState(true);
+  const [loadingFlags, setLoadingFlags] = useState(false);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!isAdmin) router.push('/dashboard');
+  }, [isAdmin, router]);
+
+  const loadTeams = useCallback(async (q: string) => {
+    try {
+      setLoadingTeams(true);
+      const url = q
+        ? `/api/v1/admin/feature-flag-overrides/teams?q=${encodeURIComponent(q)}`
+        : '/api/v1/admin/feature-flag-overrides/teams';
+      const res = await fetch(url, { credentials: 'include' });
+      const data = await res.json();
+      if (data.success) setTeams(data.data.teams);
+      else setFeedback({ type: 'error', message: data.error?.message || 'Failed to load teams' });
+    } catch {
+      setFeedback({ type: 'error', message: 'Failed to load teams' });
+    } finally {
+      setLoadingTeams(false);
+    }
+  }, []);
+
+  const loadFlags = useCallback(async (teamId: string) => {
+    try {
+      setLoadingFlags(true);
+      const res = await fetch(
+        `/api/v1/admin/feature-flag-overrides?teamId=${encodeURIComponent(teamId)}`,
+        { credentials: 'include' },
+      );
+      const data = await res.json();
+      if (data.success) setFlags(data.data.flags);
+      else setFeedback({ type: 'error', message: data.error?.message || 'Failed to load flags' });
+    } catch {
+      setFeedback({ type: 'error', message: 'Failed to load flags' });
+    } finally {
+      setLoadingFlags(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) loadTeams('');
+  }, [isAdmin, loadTeams]);
+
+  // Debounced team search.
+  useEffect(() => {
+    if (!isAdmin) return;
+    const t = setTimeout(() => loadTeams(teamSearch.trim()), 250);
+    return () => clearTimeout(t);
+  }, [teamSearch, isAdmin, loadTeams]);
+
+  function selectTeam(team: TeamRow) {
+    setSelectedTeam(team);
+    setFeedback(null);
+    loadFlags(team.id);
+  }
+
+  async function applyOverride(flag: FlagRow, next: OverrideState) {
+    if (!selectedTeam) return;
+    setSavingKey(flag.key);
+    setFeedback(null);
+    try {
+      const csrfToken = await getCsrfToken();
+      const headers = { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken };
+      let res: Response;
+      if (next === 'inherit') {
+        res = await fetch('/api/v1/admin/feature-flag-overrides', {
+          method: 'DELETE',
+          credentials: 'include',
+          headers,
+          body: JSON.stringify({ teamId: selectedTeam.id, key: flag.key }),
+        });
+      } else {
+        res = await fetch('/api/v1/admin/feature-flag-overrides', {
+          method: 'PUT',
+          credentials: 'include',
+          headers,
+          body: JSON.stringify({ teamId: selectedTeam.id, key: flag.key, enabled: next === 'on' }),
+        });
+      }
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error?.message || 'Update failed');
+
+      await loadFlags(selectedTeam.id);
+      // Reflect the new override count in the team list.
+      loadTeams(teamSearch.trim());
+      invalidateFeatureFlags();
+      setFeedback({
+        type: 'success',
+        message:
+          next === 'inherit'
+            ? `Cleared override for "${flag.key}" — now inherits global`
+            : `Set "${flag.key}" ${next.toUpperCase()} for ${selectedTeam.name}`,
+      });
+    } catch (err) {
+      setFeedback({ type: 'error', message: err instanceof Error ? err.message : 'Update failed' });
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  if (!isAdmin) return null;
+
+  return (
+    <div className="p-4 max-w-6xl mx-auto">
+      <AdminNav />
+
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold flex items-center gap-2">
+          <Flag size={20} />
+          Per-Team Feature Flags
+        </h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">
+          Enable or disable a flag for a single team without changing the platform-wide default.
+          Clear an override to inherit the global value.
+        </p>
+      </div>
+
+      {feedback && (
+        <div
+          className={`flex items-center gap-2 px-4 py-3 rounded-lg mb-4 ${
+            feedback.type === 'success'
+              ? 'bg-emerald-500/10 text-emerald-500'
+              : 'bg-destructive/10 text-destructive'
+          }`}
+        >
+          {feedback.type === 'success' ? (
+            <CheckCircle2 size={16} />
+          ) : (
+            <AlertTriangle size={16} />
+          )}
+          <span className="text-sm">{feedback.message}</span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Team picker */}
+        <div className="md:col-span-1">
+          <div className="mb-3">
+            <Input
+              icon={<Search className="w-4 h-4" />}
+              value={teamSearch}
+              onChange={(e) => setTeamSearch(e.target.value)}
+              placeholder="Search teams..."
+            />
+          </div>
+          <div className="bg-card border border-border rounded-lg overflow-hidden">
+            {loadingTeams ? (
+              <div className="flex items-center justify-center h-40">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : teams.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">
+                <UsersIcon className="w-7 h-7 mx-auto mb-2 opacity-50" />
+                <p className="text-sm">No teams found</p>
+              </div>
+            ) : (
+              <ul className="divide-y divide-border max-h-[60vh] overflow-y-auto">
+                {teams.map((team) => (
+                  <li key={team.id}>
+                    <button
+                      onClick={() => selectTeam(team)}
+                      className={`w-full text-left px-3 py-2.5 hover:bg-muted/40 transition-colors ${
+                        selectedTeam?.id === team.id ? 'bg-muted/60' : ''
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium truncate">{team.name}</div>
+                          <div className="text-[11px] text-muted-foreground font-mono truncate">
+                            {team.slug}
+                          </div>
+                        </div>
+                        {team.overrideCount > 0 && (
+                          <span className="shrink-0 text-[11px] px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+                            {team.overrideCount}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {/* Flags for the selected team */}
+        <div className="md:col-span-2">
+          {!selectedTeam ? (
+            <div className="flex flex-col items-center justify-center h-64 bg-muted/30 rounded-lg text-muted-foreground">
+              <Flag className="w-8 h-8 mb-3 opacity-50" />
+              <p className="text-sm">Select a team to manage its feature flag overrides</p>
+            </div>
+          ) : loadingFlags ? (
+            <div className="flex items-center justify-center h-64">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <div className="text-sm text-muted-foreground mb-1">
+                Managing <span className="font-medium text-foreground">{selectedTeam.name}</span>
+              </div>
+              {flags.map((flag) => {
+                const state: OverrideState =
+                  flag.override === null ? 'inherit' : flag.override ? 'on' : 'off';
+                return (
+                  <div
+                    key={flag.key}
+                    className="p-4 bg-card border border-border rounded-lg"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <p className="text-sm font-medium">{humanizeKey(flag.key)}</p>
+                          {flag.source === 'override' ? (
+                            <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400">
+                              Overridden
+                            </span>
+                          ) : (
+                            <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                              Inherited
+                            </span>
+                          )}
+                          <span
+                            className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${
+                              flag.effective
+                                ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+                                : 'bg-muted text-muted-foreground'
+                            }`}
+                          >
+                            {flag.effective ? 'Effective: ON' : 'Effective: OFF'}
+                          </span>
+                        </div>
+                        {flag.description && (
+                          <p className="text-[13px] text-muted-foreground mt-1">{flag.description}</p>
+                        )}
+                        <p className="text-[11px] text-muted-foreground/70 mt-1 font-mono">
+                          {flag.key} · global default: {flag.globalEnabled ? 'ON' : 'OFF'}
+                        </p>
+                      </div>
+                      <SegmentedControl
+                        value={state}
+                        disabled={savingKey === flag.key}
+                        onChange={(next) => applyOverride(flag, next)}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SegmentedControl({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: OverrideState;
+  disabled: boolean;
+  onChange: (next: OverrideState) => void;
+}) {
+  const options: { id: OverrideState; label: string }[] = [
+    { id: 'on', label: 'On' },
+    { id: 'off', label: 'Off' },
+    { id: 'inherit', label: 'Inherit' },
+  ];
+  return (
+    <div className="shrink-0 inline-flex rounded-md border border-border overflow-hidden">
+      {options.map((opt) => {
+        const active = value === opt.id;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            disabled={disabled || active}
+            onClick={() => onChange(opt.id)}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-default ${
+              active
+                ? opt.id === 'on'
+                  ? 'bg-emerald-500 text-white'
+                  : opt.id === 'off'
+                    ? 'bg-destructive text-white'
+                    : 'bg-muted text-foreground'
+                : 'bg-transparent text-muted-foreground hover:bg-muted/50'
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web-next/src/app/(dashboard)/admin/feature-flags/page.tsx
+++ b/apps/web-next/src/app/(dashboard)/admin/feature-flags/page.tsx
@@ -12,7 +12,7 @@
  * exactly as the global flags dictate.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Flag,
@@ -67,6 +67,9 @@ export default function AdminFeatureFlagsPage() {
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(
     null,
   );
+  // Identifies the latest flag load so a slow response for a previously selected
+  // team can never overwrite the flags shown for the team the admin is now on.
+  const flagsRequestRef = useRef(0);
 
   useEffect(() => {
     if (!isAdmin) router.push('/dashboard');
@@ -90,6 +93,8 @@ export default function AdminFeatureFlagsPage() {
   }, []);
 
   const loadFlags = useCallback(async (teamId: string) => {
+    const requestId = ++flagsRequestRef.current;
+    const isStale = () => requestId !== flagsRequestRef.current;
     try {
       setLoadingFlags(true);
       const res = await fetch(
@@ -97,12 +102,16 @@ export default function AdminFeatureFlagsPage() {
         { credentials: 'include' },
       );
       const data = await res.json();
+      // A newer team selection superseded this request — drop its result so it
+      // can't clobber the active team's flags or feedback.
+      if (isStale()) return;
       if (data.success) setFlags(data.data.flags);
       else setFeedback({ type: 'error', message: data.error?.message || 'Failed to load flags' });
     } catch {
+      if (isStale()) return;
       setFeedback({ type: 'error', message: 'Failed to load flags' });
     } finally {
-      setLoadingFlags(false);
+      if (!isStale()) setLoadingFlags(false);
     }
   }, []);
 

--- a/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.test.ts
+++ b/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.test.ts
@@ -1,11 +1,11 @@
 /** @vitest-environment node */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 const prisma = vi.hoisted(() => ({
   team: { findUnique: vi.fn() },
-  featureFlag: { findMany: vi.fn(), upsert: vi.fn() },
+  featureFlag: { findMany: vi.fn(), findUnique: vi.fn(), upsert: vi.fn() },
   featureFlagOverride: { findMany: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
   auditLog: { create: vi.fn() },
 }));
@@ -14,8 +14,12 @@ vi.mock('@/lib/db', () => ({ prisma }));
 const validateSession = vi.fn();
 vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
 
-// CSRF is enforced separately; treat it as passing here.
-vi.mock('@/lib/api/csrf', () => ({ validateCSRF: () => null }));
+// Spy on CSRF so we can assert the mutations actually invoke it (regression
+// guard: the check must never be silently dropped) and exercise its failure
+// path. Default: passes (returns null), matching the repo-wide shadow-mode
+// posture where a present token is accepted.
+const validateCSRF = vi.fn<(...a: unknown[]) => NextResponse | null>(() => null);
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: (...a: unknown[]) => validateCSRF(...a) }));
 
 import { GET, PUT, DELETE } from './route';
 
@@ -39,9 +43,11 @@ function req(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  validateCSRF.mockReturnValue(null);
   validateSession.mockResolvedValue(ADMIN);
   prisma.featureFlag.upsert.mockResolvedValue({});
   prisma.featureFlag.findMany.mockResolvedValue([]);
+  prisma.featureFlag.findUnique.mockResolvedValue(null);
   prisma.featureFlagOverride.findMany.mockResolvedValue([]);
   prisma.team.findUnique.mockResolvedValue({ id: 'team-1', name: 'Acme', slug: 'acme' });
 });
@@ -137,6 +143,49 @@ describe('PUT — set an override', () => {
       }),
     );
     expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('400 for an unknown flag key (no orphan override row is written)', async () => {
+    // Not in KNOWN_FLAGS and absent from the FeatureFlag table.
+    prisma.featureFlag.findUnique.mockResolvedValue(null);
+    const res = await PUT(req('PUT', { body: { teamId: 'team-1', key: 'totally_made_up_flag', enabled: true } }));
+    expect(res.status).toBe(400);
+    expect(prisma.featureFlagOverride.upsert).not.toHaveBeenCalled();
+  });
+
+  it('accepts a flag that exists in the DB but is not in KNOWN_FLAGS', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ key: 'db_only_flag' });
+    prisma.featureFlagOverride.upsert.mockResolvedValue({ id: 'o2', teamId: 'team-1', flagKey: 'db_only_flag', enabled: false });
+    const res = await PUT(req('PUT', { body: { teamId: 'team-1', key: 'db_only_flag', enabled: false } }));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('CSRF — mutations enforce the check (never silently dropped)', () => {
+  it('PUT invokes validateCSRF before mutating', async () => {
+    prisma.featureFlagOverride.upsert.mockResolvedValue({ id: 'o1' });
+    await PUT(req('PUT', { body: { teamId: 'team-1', key: 'capability_gate', enabled: true } }));
+    expect(validateCSRF).toHaveBeenCalledTimes(1);
+  });
+
+  it('DELETE invokes validateCSRF before mutating', async () => {
+    prisma.featureFlagOverride.deleteMany.mockResolvedValue({ count: 0 });
+    await DELETE(req('DELETE', { body: { teamId: 'team-1', key: 'capability_gate' } }));
+    expect(validateCSRF).toHaveBeenCalledTimes(1);
+  });
+
+  it('PUT returns the CSRF error and does NOT upsert when the check fails closed', async () => {
+    validateCSRF.mockReturnValue(NextResponse.json({ error: 'CSRF' }, { status: 403 }));
+    const res = await PUT(req('PUT', { body: { teamId: 'team-1', key: 'capability_gate', enabled: true } }));
+    expect(res.status).toBe(403);
+    expect(prisma.featureFlagOverride.upsert).not.toHaveBeenCalled();
+  });
+
+  it('DELETE returns the CSRF error and does NOT delete when the check fails closed', async () => {
+    validateCSRF.mockReturnValue(NextResponse.json({ error: 'CSRF' }, { status: 403 }));
+    const res = await DELETE(req('DELETE', { body: { teamId: 'team-1', key: 'capability_gate' } }));
+    expect(res.status).toBe(403);
+    expect(prisma.featureFlagOverride.deleteMany).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.test.ts
+++ b/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.test.ts
@@ -1,0 +1,158 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const prisma = vi.hoisted(() => ({
+  team: { findUnique: vi.fn() },
+  featureFlag: { findMany: vi.fn(), upsert: vi.fn() },
+  featureFlagOverride: { findMany: vi.fn(), upsert: vi.fn(), deleteMany: vi.fn() },
+  auditLog: { create: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+// CSRF is enforced separately; treat it as passing here.
+vi.mock('@/lib/api/csrf', () => ({ validateCSRF: () => null }));
+
+import { GET, PUT, DELETE } from './route';
+
+const ADMIN = { id: 'admin-1', roles: ['system:admin'] };
+const NON_ADMIN = { id: 'user-2', roles: ['user'] };
+
+function req(
+  method: string,
+  opts: { url?: string; token?: string | null; body?: unknown } = {},
+): NextRequest {
+  const url = opts.url ?? 'http://localhost/api/v1/admin/feature-flag-overrides';
+  return new NextRequest(url, {
+    method,
+    headers: {
+      ...(opts.token !== null ? { authorization: `Bearer ${opts.token ?? 'tok'}` } : {}),
+      'content-type': 'application/json',
+    },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSession.mockResolvedValue(ADMIN);
+  prisma.featureFlag.upsert.mockResolvedValue({});
+  prisma.featureFlag.findMany.mockResolvedValue([]);
+  prisma.featureFlagOverride.findMany.mockResolvedValue([]);
+  prisma.team.findUnique.mockResolvedValue({ id: 'team-1', name: 'Acme', slug: 'acme' });
+});
+
+describe('authz (all verbs require system:admin)', () => {
+  it('GET 401 without a token', async () => {
+    expect((await GET(req('GET', { url: 'http://localhost/api/v1/admin/feature-flag-overrides?teamId=team-1', token: null }))).status).toBe(401);
+  });
+  it('GET 401 for an invalid session', async () => {
+    validateSession.mockResolvedValue(null);
+    expect((await GET(req('GET', { url: 'http://localhost/api/v1/admin/feature-flag-overrides?teamId=team-1' }))).status).toBe(401);
+  });
+  it('GET 403 for a non-admin', async () => {
+    validateSession.mockResolvedValue(NON_ADMIN);
+    expect((await GET(req('GET', { url: 'http://localhost/api/v1/admin/feature-flag-overrides?teamId=team-1' }))).status).toBe(403);
+  });
+  it('PUT 403 for a non-admin', async () => {
+    validateSession.mockResolvedValue(NON_ADMIN);
+    const res = await PUT(req('PUT', { body: { teamId: 'team-1', key: 'capability_gate', enabled: true } }));
+    expect(res.status).toBe(403);
+    expect(prisma.featureFlagOverride.upsert).not.toHaveBeenCalled();
+  });
+  it('DELETE 403 for a non-admin', async () => {
+    validateSession.mockResolvedValue(NON_ADMIN);
+    const res = await DELETE(req('DELETE', { body: { teamId: 'team-1', key: 'capability_gate' } }));
+    expect(res.status).toBe(403);
+    expect(prisma.featureFlagOverride.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET — effective values + provenance', () => {
+  it('400 without teamId', async () => {
+    expect((await GET(req('GET'))).status).toBe(400);
+  });
+
+  it('404 for an unknown team', async () => {
+    prisma.team.findUnique.mockResolvedValue(null);
+    expect((await GET(req('GET', { url: 'http://localhost/api/v1/admin/feature-flag-overrides?teamId=nope' }))).status).toBe(404);
+  });
+
+  it('merges global defaults with the team override and marks provenance', async () => {
+    prisma.featureFlag.findMany.mockResolvedValue([
+      { key: 'capability_gate', enabled: false, description: 'gate' },
+      { key: 'usage_pull', enabled: false, description: 'pull' },
+    ]);
+    prisma.featureFlagOverride.findMany.mockResolvedValue([
+      { flagKey: 'capability_gate', enabled: true, updatedBy: 'admin-1', updatedAt: new Date() },
+    ]);
+
+    const res = await GET(req('GET', { url: 'http://localhost/api/v1/admin/feature-flag-overrides?teamId=team-1' }));
+    expect(res.status).toBe(200);
+    const { data } = await res.json();
+
+    const gate = data.flags.find((f: { key: string }) => f.key === 'capability_gate');
+    expect(gate).toMatchObject({
+      globalEnabled: false,
+      override: true,
+      effective: true,
+      source: 'override',
+    });
+
+    const pull = data.flags.find((f: { key: string }) => f.key === 'usage_pull');
+    expect(pull).toMatchObject({
+      globalEnabled: false,
+      override: null,
+      effective: false,
+      source: 'inherited',
+    });
+  });
+});
+
+describe('PUT — set an override', () => {
+  it('400 on missing/invalid fields', async () => {
+    expect((await PUT(req('PUT', { body: { key: 'x', enabled: true } }))).status).toBe(400); // no teamId
+    expect((await PUT(req('PUT', { body: { teamId: 't', enabled: true } }))).status).toBe(400); // no key
+    expect((await PUT(req('PUT', { body: { teamId: 't', key: 'x' } }))).status).toBe(400); // enabled not bool
+  });
+
+  it('404 for an unknown team', async () => {
+    prisma.team.findUnique.mockResolvedValue(null);
+    expect((await PUT(req('PUT', { body: { teamId: 'nope', key: 'capability_gate', enabled: true } }))).status).toBe(404);
+  });
+
+  it('200 upserts the override, audits, and records updatedBy', async () => {
+    prisma.featureFlagOverride.upsert.mockResolvedValue({ id: 'o1', teamId: 'team-1', flagKey: 'capability_gate', enabled: true });
+    const res = await PUT(req('PUT', { body: { teamId: 'team-1', key: 'capability_gate', enabled: true } }));
+    expect(res.status).toBe(200);
+    expect(prisma.featureFlagOverride.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { teamId_flagKey: { teamId: 'team-1', flagKey: 'capability_gate' } },
+        update: { enabled: true, updatedBy: 'admin-1' },
+        create: { teamId: 'team-1', flagKey: 'capability_gate', enabled: true, updatedBy: 'admin-1' },
+      }),
+    );
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DELETE — clear an override (inherit)', () => {
+  it('400 on missing fields', async () => {
+    expect((await DELETE(req('DELETE', { body: { teamId: 't' } }))).status).toBe(400);
+    expect((await DELETE(req('DELETE', { body: { key: 'x' } }))).status).toBe(400);
+  });
+
+  it('200 idempotent clear, audits', async () => {
+    prisma.featureFlagOverride.deleteMany.mockResolvedValue({ count: 1 });
+    const res = await DELETE(req('DELETE', { body: { teamId: 'team-1', key: 'capability_gate' } }));
+    expect(res.status).toBe(200);
+    expect(prisma.featureFlagOverride.deleteMany).toHaveBeenCalledWith({
+      where: { teamId: 'team-1', flagKey: 'capability_gate' },
+    });
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.ts
+++ b/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.ts
@@ -154,6 +154,14 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
     if (!key || typeof key !== 'string') return errors.badRequest('key is required');
     if (typeof enabled !== 'boolean') return errors.badRequest('enabled must be a boolean');
 
+    // Reject unknown flag keys. The GET response lists KNOWN_FLAGS ∪ FeatureFlag
+    // rows, so persisting an override for any other key would create a row the
+    // admin UI never shows (an invisible orphan that can't be cleared from here).
+    const isKnownFlag =
+      KNOWN_FLAGS.some((f) => f.key === key) ||
+      (await prisma.featureFlag.findUnique({ where: { key }, select: { key: true } })) !== null;
+    if (!isKnownFlag) return errors.badRequest(`Unknown feature flag key: ${key}`);
+
     const team = await prisma.team.findUnique({ where: { id: teamId }, select: { id: true } });
     if (!team) return errors.notFound('Team');
 

--- a/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.ts
+++ b/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/route.ts
@@ -1,0 +1,210 @@
+/**
+ * Admin Per-Team Feature Flag Overrides API (admin only).
+ *
+ *   GET    /api/v1/admin/feature-flag-overrides?teamId=…
+ *     → every known flag with its GLOBAL default, this team's override (if any),
+ *       the EFFECTIVE value, and provenance (inherited | overridden).
+ *   PUT    /api/v1/admin/feature-flag-overrides   { teamId, key, enabled }
+ *     → set a per-team override ON/OFF (upsert).
+ *   DELETE /api/v1/admin/feature-flag-overrides   { teamId, key }
+ *     → clear a per-team override (the team re-inherits the global value).
+ *
+ * Per-team overrides scope a flag for ONE team without touching the platform-wide
+ * `FeatureFlag` default — so a flag can be enabled for a single test team with
+ * zero blast radius. Guarded by the existing `system:admin` authz; mutations are
+ * CSRF-checked and audited. PURELY ADDITIVE: with no overrides, flag evaluation
+ * is byte-identical to today.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { validateCSRF } from '@/lib/api/csrf';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import {
+  KNOWN_FLAGS,
+  ensureKnownFlags,
+  resetFeatureFlagOverrideCache,
+} from '@/lib/feature-flags';
+
+interface SessionUser {
+  id: string;
+  roles: string[];
+}
+
+/** Resolve the admin session or return the error response to send. */
+async function requireAdmin(
+  request: NextRequest,
+): Promise<{ user: SessionUser } | { error: NextResponse }> {
+  const token = getAuthToken(request);
+  if (!token) return { error: errors.unauthorized('No auth token provided') };
+
+  const sessionUser = await validateSession(token);
+  if (!sessionUser) return { error: errors.unauthorized('Invalid or expired session') };
+  if (!sessionUser.roles.includes('system:admin')) {
+    return { error: errors.forbidden('Admin permission required') };
+  }
+  return { user: { id: sessionUser.id, roles: sessionUser.roles } };
+}
+
+/** Best-effort audit row; never blocks (or fails) the mutation. */
+async function audit(
+  request: NextRequest,
+  user: SessionUser,
+  action: 'feature_flag_override.set' | 'feature_flag_override.clear',
+  details: Record<string, string | number | boolean | null>,
+): Promise<void> {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        action,
+        resource: 'feature-flag-override',
+        resourceId: typeof details.teamId === 'string' ? details.teamId : null,
+        userId: user.id,
+        ipAddress:
+          request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || null,
+        userAgent: request.headers.get('user-agent') || null,
+        details,
+        status: 'success',
+      },
+    });
+  } catch (err) {
+    console.error('[feature-flag-override] audit write failed:', err);
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
+    const teamId = request.nextUrl.searchParams.get('teamId')?.trim();
+    if (!teamId) return errors.badRequest('teamId query parameter is required');
+
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { id: true, name: true, slug: true },
+    });
+    if (!team) return errors.notFound('Team');
+
+    await ensureKnownFlags();
+
+    const [globalFlags, overrides] = await Promise.all([
+      prisma.featureFlag.findMany({ select: { key: true, enabled: true, description: true } }),
+      prisma.featureFlagOverride.findMany({
+        where: { teamId },
+        select: { flagKey: true, enabled: true, updatedBy: true, updatedAt: true },
+      }),
+    ]);
+
+    const globalByKey = new Map(globalFlags.map((f) => [f.key, f]));
+    const overrideByKey = new Map(overrides.map((o) => [o.flagKey, o]));
+
+    // Union of known + DB flag keys so nothing is hidden from the admin.
+    const keys = new Set<string>([
+      ...KNOWN_FLAGS.map((f) => f.key),
+      ...globalFlags.map((f) => f.key),
+    ]);
+
+    const flags = [...keys]
+      .sort()
+      .map((key) => {
+        const known = KNOWN_FLAGS.find((f) => f.key === key);
+        const globalRow = globalByKey.get(key);
+        const globalEnabled = globalRow?.enabled ?? known?.enabled ?? false;
+        const description = globalRow?.description ?? known?.description ?? null;
+        const ov = overrideByKey.get(key);
+        const hasOverride = ov !== undefined;
+        return {
+          key,
+          description,
+          globalEnabled,
+          override: hasOverride ? ov!.enabled : null,
+          effective: hasOverride ? ov!.enabled : globalEnabled,
+          source: hasOverride ? ('override' as const) : ('inherited' as const),
+          updatedBy: hasOverride ? ov!.updatedBy : null,
+          updatedAt: hasOverride ? ov!.updatedAt : null,
+        };
+      });
+
+    return success({ team, flags });
+  } catch (err) {
+    console.error('Error fetching feature flag overrides:', err);
+    return errors.internal('Failed to fetch feature flag overrides');
+  }
+}
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  try {
+    const csrfErr = validateCSRF(request, { shadowMode: true });
+    if (csrfErr) return csrfErr;
+
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return errors.badRequest('Malformed JSON body');
+    }
+
+    const { teamId, key, enabled } = body;
+    if (!teamId || typeof teamId !== 'string') return errors.badRequest('teamId is required');
+    if (!key || typeof key !== 'string') return errors.badRequest('key is required');
+    if (typeof enabled !== 'boolean') return errors.badRequest('enabled must be a boolean');
+
+    const team = await prisma.team.findUnique({ where: { id: teamId }, select: { id: true } });
+    if (!team) return errors.notFound('Team');
+
+    const override = await prisma.featureFlagOverride.upsert({
+      where: { teamId_flagKey: { teamId, flagKey: key } },
+      update: { enabled, updatedBy: auth.user.id },
+      create: { teamId, flagKey: key, enabled, updatedBy: auth.user.id },
+    });
+
+    // Drop the short-TTL resolver cache so the override takes effect immediately.
+    resetFeatureFlagOverrideCache();
+    await audit(request, auth.user, 'feature_flag_override.set', { teamId, key, enabled });
+
+    return success({ override });
+  } catch (err) {
+    console.error('Error setting feature flag override:', err);
+    return errors.internal('Failed to set feature flag override');
+  }
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  try {
+    const csrfErr = validateCSRF(request, { shadowMode: true });
+    if (csrfErr) return csrfErr;
+
+    const auth = await requireAdmin(request);
+    if ('error' in auth) return auth.error;
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return errors.badRequest('Malformed JSON body');
+    }
+
+    const { teamId, key } = body;
+    if (!teamId || typeof teamId !== 'string') return errors.badRequest('teamId is required');
+    if (!key || typeof key !== 'string') return errors.badRequest('key is required');
+
+    // Idempotent clear: deleteMany so removing an absent override is a no-op
+    // success (the team already inherits the global value).
+    const { count } = await prisma.featureFlagOverride.deleteMany({
+      where: { teamId, flagKey: key },
+    });
+
+    resetFeatureFlagOverrideCache();
+    await audit(request, auth.user, 'feature_flag_override.clear', { teamId, key, removed: count });
+
+    return success({ cleared: count });
+  } catch (err) {
+    console.error('Error clearing feature flag override:', err);
+    return errors.internal('Failed to clear feature flag override');
+  }
+}

--- a/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/teams/route.test.ts
+++ b/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/teams/route.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const prisma = vi.hoisted(() => ({
+  team: { findMany: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+const validateSession = vi.fn();
+vi.mock('@/lib/api/auth', () => ({ validateSession: (...a: unknown[]) => validateSession(...a) }));
+
+import { GET } from './route';
+
+const ADMIN = { id: 'admin-1', roles: ['system:admin'] };
+
+function req(url: string, token: string | null = 'tok'): NextRequest {
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: token !== null ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+const BASE = 'http://localhost/api/v1/admin/feature-flag-overrides/teams';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSession.mockResolvedValue(ADMIN);
+  prisma.team.findMany.mockResolvedValue([
+    { id: 't1', name: 'Acme', slug: 'acme', _count: { featureFlagOverrides: 2 } },
+    { id: 't2', name: 'Globex', slug: 'globex', _count: { featureFlagOverrides: 0 } },
+  ]);
+});
+
+describe('GET teams list', () => {
+  it('401 without a token', async () => {
+    expect((await GET(req(BASE, null))).status).toBe(401);
+  });
+
+  it('403 for a non-admin', async () => {
+    validateSession.mockResolvedValue({ id: 'u', roles: ['user'] });
+    expect((await GET(req(BASE))).status).toBe(403);
+  });
+
+  it('200 returns teams with override counts', async () => {
+    const res = await GET(req(BASE));
+    expect(res.status).toBe(200);
+    const { data } = await res.json();
+    expect(data.teams).toEqual([
+      { id: 't1', name: 'Acme', slug: 'acme', overrideCount: 2 },
+      { id: 't2', name: 'Globex', slug: 'globex', overrideCount: 0 },
+    ]);
+  });
+
+  it('passes a case-insensitive name/slug search filter', async () => {
+    await GET(req(`${BASE}?q=acme`));
+    expect(prisma.team.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [
+            { name: { contains: 'acme', mode: 'insensitive' } },
+            { slug: { contains: 'acme', mode: 'insensitive' } },
+          ],
+        },
+      }),
+    );
+  });
+});

--- a/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/teams/route.ts
+++ b/apps/web-next/src/app/api/v1/admin/feature-flag-overrides/teams/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Admin teams list for the per-team feature-flag override UI (admin only).
+ *
+ *   GET /api/v1/admin/feature-flag-overrides/teams[?q=search]
+ *     → teams (id, name, slug) with a count of active overrides, so the admin can
+ *       pick a team to manage. Search is a case-insensitive name/slug contains.
+ *
+ * Read-only; guarded by the existing `system:admin` authz.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { validateSession } from '@/lib/api/auth';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+
+const MAX_TEAMS = 200;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const token = getAuthToken(request);
+    if (!token) return errors.unauthorized('No auth token provided');
+
+    const sessionUser = await validateSession(token);
+    if (!sessionUser) return errors.unauthorized('Invalid or expired session');
+    if (!sessionUser.roles.includes('system:admin')) {
+      return errors.forbidden('Admin permission required');
+    }
+
+    const q = request.nextUrl.searchParams.get('q')?.trim();
+    const where = q
+      ? {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { slug: { contains: q, mode: 'insensitive' as const } },
+          ],
+        }
+      : {};
+
+    const teams = await prisma.team.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        _count: { select: { featureFlagOverrides: true } },
+      },
+      orderBy: { name: 'asc' },
+      take: MAX_TEAMS,
+    });
+
+    return success({
+      teams: teams.map((t) => ({
+        id: t.id,
+        name: t.name,
+        slug: t.slug,
+        overrideCount: t._count.featureFlagOverrides,
+      })),
+    });
+  } catch (err) {
+    console.error('Error listing teams for feature flag overrides:', err);
+    return errors.internal('Failed to list teams');
+  }
+}

--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -9,8 +9,10 @@ import { generateNativeApiKey } from '@/lib/dev-api/native-key';
 import { hashApiKey } from '@naap/database';
 
 const isFeatureEnabled = vi.fn();
+const anyTeamFlagOverrideEnabled = vi.fn();
 vi.mock('@/lib/feature-flags', () => ({
   isFeatureEnabled: (...a: unknown[]) => isFeatureEnabled(...a),
+  anyTeamFlagOverrideEnabled: (...a: unknown[]) => anyTeamFlagOverrideEnabled(...a),
   PER_KEY_REMOTE_SIGNER_FLAG: 'per_key_remote_signer',
 }));
 
@@ -59,6 +61,9 @@ function req(token: string | null, headers: Record<string, string> = {}): NextRe
 beforeEach(() => {
   vi.clearAllMocks();
   isFeatureEnabled.mockResolvedValue(true);
+  // No team opted in via override unless a test says otherwise (keeps the
+  // globally-OFF front-door path returning 404 exactly as today).
+  anyTeamFlagOverrideEnabled.mockResolvedValue(false);
   prisma.devApiKey.findUnique.mockResolvedValue({
     id: 'key-1',
     userId: 'user-1',
@@ -220,7 +225,7 @@ describe('P2 per-key subscription resolution (multi_subscription)', () => {
     expect(d.quota).toEqual({ remaining: 3 });
     expect(d.signerSession.accessToken).toBe('instance-tok');
     // Per-account scoping: validate + mint keyed off the subscription account.
-    expect(instanceAdapter.validate).toHaveBeenCalledWith('acct_sub_99');
+    expect(instanceAdapter.validate).toHaveBeenCalledWith('acct_sub_99', { teamId: 'team-1' });
     expect(instanceAdapter.mintSignerSession).toHaveBeenCalledWith(
       expect.objectContaining({ externalUserId: 'acct_sub_99' }),
     );
@@ -298,6 +303,42 @@ describe('per-key remote signer (per_key_remote_signer)', () => {
     const res = await POST(req(rawKey));
     expect(res.status).toBe(200);
     expect((await res.json()).data.signerSession.accessToken).toBe('signer-tok');
+  });
+});
+
+describe('per-team front-door scoping (zero-blast-radius)', () => {
+  // Front door is GLOBALLY OFF in every test here; only a per-team override opens it.
+  const frontDoorEnabledForTeam = (enabledTeamId: string | null) =>
+    isFeatureEnabled.mockImplementation(async (key: string, teamId?: string | null) =>
+      key === 'key_validation_front_door' ? teamId != null && teamId === enabledTeamId : false,
+    );
+
+  it('ZERO REGRESSION: globally OFF + no team opted in → 404, never touches the key DB', async () => {
+    isFeatureEnabled.mockResolvedValue(false);
+    anyTeamFlagOverrideEnabled.mockResolvedValue(false);
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(404);
+    expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('opted-in team → 200 even though the front door is globally OFF', async () => {
+    frontDoorEnabledForTeam('team-1');
+    anyTeamFlagOverrideEnabled.mockResolvedValue(true); // some team has an override
+    prisma.devApiKey.findUnique.mockResolvedValue({
+      id: 'key-1', userId: 'user-1', keyHash, status: 'ACTIVE', seatId: 'seat-1', teamId: 'team-1',
+    });
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(200);
+  });
+
+  it('a DIFFERENT team is masked back to 404 (override for team-1 never leaks to team-2)', async () => {
+    frontDoorEnabledForTeam('team-1');
+    anyTeamFlagOverrideEnabled.mockResolvedValue(true);
+    prisma.devApiKey.findUnique.mockResolvedValue({
+      id: 'key-2', userId: 'user-2', keyHash, status: 'ACTIVE', seatId: 'seat-2', teamId: 'team-2',
+    });
+    const res = await POST(req(rawKey));
+    expect(res.status).toBe(404);
   });
 });
 

--- a/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.test.ts
@@ -340,6 +340,48 @@ describe('per-team front-door scoping (zero-blast-radius)', () => {
     const res = await POST(req(rawKey));
     expect(res.status).toBe(404);
   });
+
+  // Pre-team failure masking: while the front door is globally OFF and merely
+  // canaried per-team, the endpoint's existence must not be probable. EVERY
+  // failure that occurs BEFORE the owning team is resolved returns the same 404
+  // as the disabled state (not 401/400), so an attacker can't distinguish
+  // "front door exists" from "not found".
+  describe('globally OFF + some team opted in → pre-team failures stay masked (404)', () => {
+    beforeEach(() => {
+      isFeatureEnabled.mockResolvedValue(false); // globally OFF for every flag
+      anyTeamFlagOverrideEnabled.mockResolvedValue(true); // ≥1 team has an override
+    });
+
+    it('no bearer → 404 (not 401), key DB untouched', async () => {
+      const res = await POST(req(null));
+      expect(res.status).toBe(404);
+      expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('provider token (passthrough disabled) → 404 (not 401)', async () => {
+      const res = await POST(req('pmth_sometoken'));
+      expect(res.status).toBe(404);
+      expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('malformed naap_ key → 404 (not 401), key DB untouched', async () => {
+      const res = await POST(req('naap_short'));
+      expect(res.status).toBe(404);
+      expect(prisma.devApiKey.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('unknown key → 404 (not 401)', async () => {
+      prisma.devApiKey.findUnique.mockResolvedValue(null);
+      expect((await POST(req(rawKey))).status).toBe(404);
+    });
+
+    it('revoked key → 404 (not 401)', async () => {
+      prisma.devApiKey.findUnique.mockResolvedValue({
+        id: 'key-1', userId: 'user-1', keyHash, status: 'REVOKED', seatId: 'seat-1', teamId: 'team-1',
+      });
+      expect((await POST(req(rawKey))).status).toBe(404);
+    });
+  });
 });
 
 describe('NAAP-E capability gate', () => {

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -26,7 +26,7 @@ import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/db';
 import { error, errors, success } from '@/lib/api/response';
 import { enforceRateLimit } from '@/lib/api/rate-limit';
-import { isFeatureEnabled, PER_KEY_REMOTE_SIGNER_FLAG } from '@/lib/feature-flags';
+import { isFeatureEnabled, anyTeamFlagOverrideEnabled, PER_KEY_REMOTE_SIGNER_FLAG } from '@/lib/feature-flags';
 import { parseApiKey } from '@naap/database';
 import { AdapterNotImplementedError, type SignerSession } from '@/lib/billing/adapter';
 import { getBillingProviderAdapter } from '@/lib/billing/registry';
@@ -74,8 +74,13 @@ function invalid(correlationId: string, reason: string): NextResponse {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    // Flag OFF → 404; callers fall back to their existing direct path.
-    if (!(await isFeatureEnabled(FRONT_DOOR_FLAG))) {
+    // Front-door visibility gate (team-scoped). Globally ON → today's exact path
+    // (short-circuits, no extra query). Globally OFF + NO team opted in → 404
+    // immediately, byte-identical to today. Globally OFF but some team has an
+    // override ON → continue so we can resolve the key's team and re-evaluate in
+    // that team's scope below (a non-enabled team is masked back to 404).
+    const globalFrontDoor = await isFeatureEnabled(FRONT_DOOR_FLAG);
+    if (!globalFrontDoor && !(await anyTeamFlagOverrideEnabled(FRONT_DOOR_FLAG))) {
       return noStore(errors.notFound('Resource'));
     }
 
@@ -121,6 +126,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
     if (key.status !== 'ACTIVE') {
       return invalid(correlationId, 'revoked');
+    }
+
+    // Per-team front-door re-check, now that we know the key's owning team.
+    // Resolves the flag in THIS team's scope: a per-team override (ON or OFF)
+    // wins, else the team inherits the global value — so a non-opted-in team is
+    // masked back to 404 (endpoint stays hidden for it, exactly as today). The
+    // override fetch is cached and reused by every team-scoped flag check below,
+    // so this adds no extra DB round-trip on the hot path. With NO override the
+    // result equals the global value (zero regression).
+    const teamId = key.teamId;
+    if (!(await isFeatureEnabled(FRONT_DOOR_FLAG, teamId))) {
+      return noStore(errors.notFound('Resource'));
     }
 
     // Resolve the seat's team binding.
@@ -178,7 +195,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let signerSession: SignerSession = resolved.signerSession;
     if (
       adapter?.resolveSignerEndpoint &&
-      (await isFeatureEnabled(PER_KEY_REMOTE_SIGNER_FLAG))
+      (await isFeatureEnabled(PER_KEY_REMOTE_SIGNER_FLAG, teamId))
     ) {
       try {
         signerSession = await adapter.resolveSignerEndpoint(resolved.signerSession, {
@@ -203,7 +220,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     let quota: { remaining: number; resetAt?: string } | null = null;
     if (adapter) {
       try {
-        const v = await adapter.validate(ref.accountId);
+        const v = await adapter.validate(ref.accountId, { teamId });
         if (Array.isArray(v.capabilities)) capabilities = v.capabilities;
         quota = v.quota ?? null;
       } catch (e) {
@@ -220,7 +237,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // exactly as before). ON → an optional `X-Requested-Capability` the resolved
     // plan does not grant is denied (fail closed; an empty grant set denies all).
     const gate = enforceCapabilityGate({
-      enabled: await isFeatureEnabled(CAPABILITY_GATE_FLAG),
+      enabled: await isFeatureEnabled(CAPABILITY_GATE_FLAG, teamId),
       granted: capabilities,
       requested: request.headers.get('x-requested-capability'),
     });
@@ -239,7 +256,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // otherwise null ⇒ no `discovery` field ⇒ byte-for-byte today's response.
     const resolvedDiscovery =
       binding.mode === 'subscription'
-        ? await resolveKeyDiscovery(binding.subscription)
+        ? await resolveKeyDiscovery(binding.subscription, teamId)
         : null;
     const discovery = resolvedDiscovery
       ? { planId: resolvedDiscovery.discoveryPlanId, url: resolvedDiscovery.url }

--- a/apps/web-next/src/app/api/v1/keys/validate/route.ts
+++ b/apps/web-next/src/app/api/v1/keys/validate/route.ts
@@ -84,6 +84,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return noStore(errors.notFound('Resource'));
     }
 
+    // Canary mode: the front door is globally OFF and opened only per-team. Keep
+    // the endpoint FULLY masked — every pre-team-resolution failure returns the
+    // same 404 as the disabled state — so its existence/rollout can't be probed
+    // (no_bearer, malformed/unknown key, revoked, bad app id all look identical
+    // to "endpoint not found") until we resolve the key's owning team and
+    // confirm THAT team opted in below. When the front door is globally ON,
+    // `masked` is false and these are the usual 401/400s (byte-identical to
+    // today — zero regression for the rolled-out state).
+    const masked = !globalFrontDoor;
+    const reject = (reason: string): NextResponse => {
+      if (masked) {
+        log('warn', 'keys.validate.invalid', { correlationId, reason, masked: true });
+        return noStore(errors.notFound('Resource'));
+      }
+      return invalid(correlationId, reason);
+    };
+
     const rateLimited = enforceRateLimit(request, {
       keyPrefix: 'keys-validate',
       windowMs: RATE_LIMIT_WINDOW_MS,
@@ -92,20 +109,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (rateLimited) return rateLimited;
 
     const token = parseBearer(request.headers.get('authorization'));
-    if (!token) return invalid(correlationId, 'no_bearer');
+    if (!token) return reject('no_bearer');
 
     // D1: native naap_ keys ONLY — provider-token passthrough is disabled.
     if (!isNativeKeyToken(token)) {
-      return invalid(correlationId, 'provider_token_passthrough_disabled');
+      return reject('provider_token_passthrough_disabled');
     }
 
     const appId = extractAppId(request.headers.get('x-app-id'));
     if (appId === INVALID_APP_ID) {
-      return noStore(errors.badRequest('Invalid X-App-Id'));
+      return masked ? noStore(errors.notFound('Resource')) : noStore(errors.badRequest('Invalid X-App-Id'));
     }
 
     const parsed = parseApiKey(token);
-    if (!parsed) return invalid(correlationId, 'malformed');
+    if (!parsed) return reject('malformed');
 
     const key = await prisma.devApiKey.findUnique({
       where: { keyLookupId: parsed.lookupId },
@@ -122,10 +139,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Constant-time hash check; uniform failure whether the row is missing or
     // the secret mismatches (no key enumeration).
     if (!key || !verifyNativeKeyHash(token, key.keyHash)) {
-      return invalid(correlationId, 'not_found_or_mismatch');
+      return reject('not_found_or_mismatch');
     }
     if (key.status !== 'ACTIVE') {
-      return invalid(correlationId, 'revoked');
+      return reject('revoked');
     }
 
     // Per-team front-door re-check, now that we know the key's owning team.

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/billing-account/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/billing-account/route.ts
@@ -60,7 +60,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId } = await params;
     const token = getAuthToken(request);
@@ -93,7 +93,7 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
 export async function PUT(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/[keyId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/[keyId]/route.ts
@@ -53,7 +53,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, seatId, keyId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/keys/route.ts
@@ -104,7 +104,7 @@ async function authorizeSeatAction(
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, seatId } = await params;
     const token = getAuthToken(request);
@@ -133,7 +133,7 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
 export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(NATIVE_KEYS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, seatId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/[seatId]/route.ts
@@ -65,7 +65,7 @@ const SEAT_SELECT = {
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, seatId } = await params;
     const token = getAuthToken(request);
@@ -95,7 +95,7 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
 export async function PATCH(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, seatId } = await params;
     const token = getAuthToken(request);
@@ -156,7 +156,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams): Prom
 export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, seatId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/seats/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/seats/route.ts
@@ -66,7 +66,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) {
       return noStore(errors.notFound('Resource'));
     }
 
@@ -114,7 +114,7 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
 export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG))) {
+    if (!(await isFeatureEnabled(TEAM_SEATS_FLAG, (await params).teamId))) {
       return noStore(errors.notFound('Resource'));
     }
 

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/route.ts
@@ -52,7 +52,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, subId, keyId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/usage/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/[keyId]/usage/route.ts
@@ -56,7 +56,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, subId, keyId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/keys/route.ts
@@ -84,7 +84,7 @@ async function loadTeamSubscription(teamId: string, subId: string) {
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, subId } = await params;
     const token = getAuthToken(request);
@@ -119,7 +119,7 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
 export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, subId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/[subId]/route.ts
@@ -58,7 +58,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function DELETE(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId, subId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/route.ts
+++ b/apps/web-next/src/app/api/v1/teams/[teamId]/subscriptions/route.ts
@@ -73,7 +73,7 @@ function mapAccessError(err: unknown): NextResponse {
 export async function GET(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId } = await params;
     const token = getAuthToken(request);
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
 export async function POST(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
   const correlationId = correlationIdOf(request);
   try {
-    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG))) return noStore(errors.notFound('Resource'));
+    if (!(await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, (await params).teamId))) return noStore(errors.notFound('Resource'));
 
     const { teamId } = await params;
     const token = getAuthToken(request);

--- a/apps/web-next/src/components/admin/AdminNav.tsx
+++ b/apps/web-next/src/components/admin/AdminNav.tsx
@@ -2,13 +2,14 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Users, MessageSquare, Key, Blocks, Settings } from 'lucide-react';
+import { Users, MessageSquare, Key, Blocks, Settings, Flag } from 'lucide-react';
 
 const adminTabs = [
   { name: 'Users', href: '/admin/users', icon: Users },
   { name: 'Plugins', href: '/admin/plugins', icon: Blocks },
   { name: 'Feedback', href: '/admin/feedback', icon: MessageSquare },
   { name: 'Secrets', href: '/admin/secrets', icon: Key },
+  { name: 'Flags', href: '/admin/feature-flags', icon: Flag },
   { name: 'Settings', href: '/admin/settings', icon: Settings },
 ];
 

--- a/apps/web-next/src/lib/billing/adapter.ts
+++ b/apps/web-next/src/lib/billing/adapter.ts
@@ -10,6 +10,16 @@
  * `AdapterNotImplementedError` (HTTP 501-equivalent) rather than guessing.
  */
 
+/**
+ * Optional context for a {@link BillingProviderAdapter.validate} call. Carries
+ * the NaaP `teamId` that owns the key being validated so an adapter can evaluate
+ * its own flag gates (e.g. pymthouse's `pymthouse_bpp_validate`) in that team's
+ * scope. Omitted ⇒ global flag evaluation (today's behavior).
+ */
+export interface ValidateContext {
+  teamId?: string | null;
+}
+
 /** BPP ② validate result (provider-neutral; mirrors validate.schema.json). */
 export interface ValidateResult {
   valid: boolean;
@@ -152,7 +162,7 @@ export interface BillingProviderAdapter {
   isConfigured(): boolean;
 
   /** BPP ② — resolve an opaque key into identity + capabilities + signer session. */
-  validate(key: string): Promise<ValidateResult>;
+  validate(key: string, context?: ValidateContext): Promise<ValidateResult>;
 
   /** BPP ④ — plan catalogue. */
   getPlans(): Promise<Plan[]>;

--- a/apps/web-next/src/lib/billing/key-discovery.ts
+++ b/apps/web-next/src/lib/billing/key-discovery.ts
@@ -51,6 +51,7 @@ export function buildDiscoveryUrl(discoveryPlanId: string): string {
  */
 export async function resolveKeyDiscovery(
   subscription: Pick<SubscriptionRecord, 'providerInstanceId' | 'providerPlanId'>,
+  teamId?: string | null,
 ): Promise<KeyDiscoveryResolution | null> {
   if (!subscription.providerPlanId) {
     return null;
@@ -58,7 +59,9 @@ export async function resolveKeyDiscovery(
 
   let flagOn = false;
   try {
-    flagOn = await isFeatureEnabled(PLAN_SPEC_SYNC_FLAG);
+    // Team-scoped when a `teamId` is supplied (the key's owning team); else the
+    // global value (today's behavior — byte-identical when no override exists).
+    flagOn = await isFeatureEnabled(PLAN_SPEC_SYNC_FLAG, teamId);
   } catch {
     flagOn = false;
   }

--- a/apps/web-next/src/lib/billing/key-provider-binding.test.ts
+++ b/apps/web-next/src/lib/billing/key-provider-binding.test.ts
@@ -89,7 +89,8 @@ describe('resolveKeyProviderBinding — per-instance/per-account resolution', ()
 
     const r = await resolveKeyProviderBinding({ subscriptionId: 'sub-1', teamId: 'team-1' });
 
-    expect(resolveAdapterForProviderInstanceById).toHaveBeenCalledWith('inst-1');
+    // Instance resolution is scoped to the key's team (provider_instances flag).
+    expect(resolveAdapterForProviderInstanceById).toHaveBeenCalledWith('inst-1', undefined, 'team-1');
     expect(r.mode).toBe('subscription');
     if (r.mode !== 'subscription') throw new Error('expected subscription');
     expect(r.adapter).toBe(adapter);

--- a/apps/web-next/src/lib/billing/key-provider-binding.ts
+++ b/apps/web-next/src/lib/billing/key-provider-binding.ts
@@ -57,7 +57,10 @@ export async function resolveKeyProviderBinding(key: {
   subscriptionId: string | null;
   teamId: string | null;
 }): Promise<KeyProviderBinding> {
-  const sub = await resolveSubscriptionForKey({ subscriptionId: key.subscriptionId });
+  // Flag evaluation (multi_subscription, provider_instances) resolves in the
+  // key's OWN team scope so a per-team override enables the subscription hop for
+  // that team only; a team with no override inherits today's global value.
+  const sub = await resolveSubscriptionForKey({ subscriptionId: key.subscriptionId }, key.teamId);
   if (sub.mode === 'legacy') {
     return { mode: 'legacy', reason: sub.reason };
   }
@@ -67,7 +70,11 @@ export async function resolveKeyProviderBinding(key: {
     return { mode: 'legacy', reason: 'team_mismatch' };
   }
 
-  const adapterRes = await resolveAdapterForProviderInstanceById(sub.subscription.providerInstanceId);
+  const adapterRes = await resolveAdapterForProviderInstanceById(
+    sub.subscription.providerInstanceId,
+    undefined,
+    key.teamId,
+  );
   if (!adapterRes.adapter) {
     // Unresolved instance → fall back to legacy (never hard-fail an existing key).
     return { mode: 'legacy', reason: 'instance_unresolved' };

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -38,6 +38,7 @@ import {
   type SignerSessionEndpoint,
   type SignerSessionToken,
   type UsageForExternalUserInput,
+  type ValidateContext,
   type ValidateResult,
 } from './adapter';
 
@@ -100,8 +101,11 @@ export class PymthouseAdapter implements BillingProviderAdapter {
    * falls back to an empty capability set (zero regression). Provider errors
    * propagate so the front door fails CLOSED.
    */
-  async validate(externalUserId: string): Promise<ValidateResult> {
-    if (!(await isFeatureEnabled(PYMTHOUSE_BPP_VALIDATE_FLAG))) {
+  async validate(externalUserId: string, context?: ValidateContext): Promise<ValidateResult> {
+    // Team-scoped flag when the front door supplies the key's owning team; else
+    // global (today's behavior). A per-team override lets ONE team resolve live
+    // capabilities without flipping `pymthouse_bpp_validate` for everyone.
+    if (!(await isFeatureEnabled(PYMTHOUSE_BPP_VALIDATE_FLAG, context?.teamId))) {
       throw new AdapterNotImplementedError(this.slug, 'validate');
     }
     const resolved = await resolvePymthouseCapabilities(externalUserId);

--- a/apps/web-next/src/lib/billing/registry-db.ts
+++ b/apps/web-next/src/lib/billing/registry-db.ts
@@ -187,6 +187,7 @@ export async function resolveAdapterForProviderInstance(
 export async function resolveAdapterForProviderInstanceById(
   providerInstanceId: string,
   fallbackAdapterType: string = PYMTHOUSE_ADAPTER_SLUG,
+  teamId?: string | null,
 ): Promise<InstanceAdapterResolution> {
   return resolveInstanceAdapter(
     () =>
@@ -195,6 +196,7 @@ export async function resolveAdapterForProviderInstanceById(
         select: PROVIDER_INSTANCE_SELECT,
       }),
     fallbackAdapterType,
+    teamId,
   );
 }
 
@@ -218,10 +220,14 @@ async function resolveInstanceAdapter(
     enabled: boolean;
   } | null>,
   fallbackAdapterType: string,
+  teamId?: string | null,
 ): Promise<InstanceAdapterResolution> {
   let flagOn = false;
   try {
-    flagOn = await isFeatureEnabled(PROVIDER_INSTANCES_FLAG);
+    // Team-scoped when a `teamId` is supplied (the key's owning team); else the
+    // global value (today's behavior). The by-slug entry point passes no teamId
+    // and stays global by design.
+    flagOn = await isFeatureEnabled(PROVIDER_INSTANCES_FLAG, teamId);
   } catch {
     flagOn = false;
   }

--- a/apps/web-next/src/lib/billing/subscription.ts
+++ b/apps/web-next/src/lib/billing/subscription.ts
@@ -60,12 +60,17 @@ export type SubscriptionResolution =
  * resolution", so existing keys (null subscriptionId) are byte-for-byte
  * unchanged. Never throws — DB errors degrade to `legacy`.
  */
-export async function resolveSubscriptionForKey(key: {
-  subscriptionId: string | null;
-}): Promise<SubscriptionResolution> {
+export async function resolveSubscriptionForKey(
+  key: {
+    subscriptionId: string | null;
+  },
+  teamId?: string | null,
+): Promise<SubscriptionResolution> {
   let flagOn = false;
   try {
-    flagOn = await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG);
+    // Team-scoped when a `teamId` is supplied (the key's owning team); falls back
+    // to the global value otherwise — byte-identical to today for existing keys.
+    flagOn = await isFeatureEnabled(MULTI_SUBSCRIPTION_FLAG, teamId);
   } catch {
     flagOn = false;
   }

--- a/apps/web-next/src/lib/feature-flags.test.ts
+++ b/apps/web-next/src/lib/feature-flags.test.ts
@@ -1,0 +1,141 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const prisma = vi.hoisted(() => ({
+  featureFlag: { findUnique: vi.fn() },
+  featureFlagOverride: { findMany: vi.fn(), findFirst: vi.fn() },
+}));
+vi.mock('@/lib/db', () => ({ prisma }));
+
+import {
+  isFeatureEnabled,
+  isFeatureEnabledForTeam,
+  anyTeamFlagOverrideEnabled,
+  resetFeatureFlagOverrideCache,
+} from './feature-flags';
+
+const FLAG = 'capability_gate'; // KNOWN_FLAGS default: false
+const TEAM = 'team-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetFeatureFlagOverrideCache();
+  // Default: no overrides anywhere.
+  prisma.featureFlagOverride.findMany.mockResolvedValue([]);
+  prisma.featureFlagOverride.findFirst.mockResolvedValue(null);
+  prisma.featureFlag.findUnique.mockResolvedValue(null);
+});
+
+describe('isFeatureEnabled — global (no team context) is unchanged', () => {
+  it('returns the global DB value when the flag row exists', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: true });
+    expect(await isFeatureEnabled(FLAG)).toBe(true);
+    // No override lookup happens without a team context.
+    expect(prisma.featureFlagOverride.findMany).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the KNOWN_FLAGS default when the row is absent', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue(null);
+    expect(await isFeatureEnabled(FLAG)).toBe(false); // capability_gate default OFF
+    expect(await isFeatureEnabled('enableTeams')).toBe(true); // default ON
+  });
+
+  it('unknown flag with no row → false', async () => {
+    expect(await isFeatureEnabled('does_not_exist')).toBe(false);
+  });
+
+  it('DB error → static default (safe no-op)', async () => {
+    prisma.featureFlag.findUnique.mockRejectedValue(new Error('db down'));
+    expect(await isFeatureEnabled(FLAG)).toBe(false);
+  });
+});
+
+describe('isFeatureEnabled — per-team override precedence', () => {
+  it('override ON wins over a global OFF', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: false });
+    prisma.featureFlagOverride.findMany.mockResolvedValue([{ flagKey: FLAG, enabled: true }]);
+    expect(await isFeatureEnabled(FLAG, TEAM)).toBe(true);
+  });
+
+  it('override OFF wins over a global ON', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: true });
+    prisma.featureFlagOverride.findMany.mockResolvedValue([{ flagKey: FLAG, enabled: false }]);
+    expect(await isFeatureEnabled(FLAG, TEAM)).toBe(false);
+  });
+
+  it('no override for the key → inherits the global value (cleared = inherit)', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: true });
+    prisma.featureFlagOverride.findMany.mockResolvedValue([
+      { flagKey: 'some_other_flag', enabled: true },
+    ]);
+    expect(await isFeatureEnabled(FLAG, TEAM)).toBe(true);
+  });
+
+  it('ZERO REGRESSION: no override rows → byte-identical to the global value', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: false });
+    prisma.featureFlagOverride.findMany.mockResolvedValue([]);
+    const globalValue = await isFeatureEnabled(FLAG);
+    const teamValue = await isFeatureEnabled(FLAG, TEAM);
+    expect(teamValue).toBe(globalValue);
+    expect(teamValue).toBe(false);
+  });
+
+  it('override lookup failure degrades to the global value (fail-safe)', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: true });
+    prisma.featureFlagOverride.findMany.mockRejectedValue(new Error('db down'));
+    expect(await isFeatureEnabled(FLAG, TEAM)).toBe(true);
+  });
+
+  it('cross-team isolation: team B is unaffected by team A\'s override', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: false });
+    prisma.featureFlagOverride.findMany.mockImplementation(async ({ where }: { where: { teamId: string } }) =>
+      where.teamId === 'team-A' ? [{ flagKey: FLAG, enabled: true }] : [],
+    );
+    expect(await isFeatureEnabled(FLAG, 'team-A')).toBe(true);
+    expect(await isFeatureEnabled(FLAG, 'team-B')).toBe(false);
+  });
+
+  it('isFeatureEnabledForTeam is an alias for the team-scoped path', async () => {
+    prisma.featureFlag.findUnique.mockResolvedValue({ enabled: false });
+    prisma.featureFlagOverride.findMany.mockResolvedValue([{ flagKey: FLAG, enabled: true }]);
+    expect(await isFeatureEnabledForTeam(FLAG, TEAM)).toBe(true);
+  });
+});
+
+describe('per-request cache (no N+1 on the hot path)', () => {
+  it('loads a team\'s overrides with ONE findMany for multiple flag checks', async () => {
+    prisma.featureFlagOverride.findMany.mockResolvedValue([
+      { flagKey: 'capability_gate', enabled: true },
+      { flagKey: 'key_validation_front_door', enabled: true },
+    ]);
+    await isFeatureEnabled('capability_gate', TEAM);
+    await isFeatureEnabled('key_validation_front_door', TEAM);
+    await isFeatureEnabled('per_key_remote_signer', TEAM);
+    expect(prisma.featureFlagOverride.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetFeatureFlagOverrideCache forces a fresh load', async () => {
+    await isFeatureEnabled(FLAG, TEAM);
+    resetFeatureFlagOverrideCache();
+    await isFeatureEnabled(FLAG, TEAM);
+    expect(prisma.featureFlagOverride.findMany).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('anyTeamFlagOverrideEnabled — front-door visibility helper', () => {
+  it('true when at least one team has the flag overridden ON', async () => {
+    prisma.featureFlagOverride.findFirst.mockResolvedValue({ id: 'o1' });
+    expect(await anyTeamFlagOverrideEnabled('key_validation_front_door')).toBe(true);
+  });
+
+  it('false when no team has it overridden ON', async () => {
+    prisma.featureFlagOverride.findFirst.mockResolvedValue(null);
+    expect(await anyTeamFlagOverrideEnabled('key_validation_front_door')).toBe(false);
+  });
+
+  it('DB error → false (stay hidden, exactly as today)', async () => {
+    prisma.featureFlagOverride.findFirst.mockRejectedValue(new Error('db down'));
+    expect(await anyTeamFlagOverrideEnabled('key_validation_front_door')).toBe(false);
+  });
+});

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -182,11 +182,12 @@ export const KNOWN_FLAGS: KnownFlag[] = [
 ];
 
 /**
- * Read a single feature flag's effective state without writing to the DB.
- * Falls back to the KNOWN_FLAGS default (or `false`) when the flag row does not
- * exist yet, so a flag defaulting OFF is a no-op until an admin enables it.
+ * Read a single feature flag's GLOBAL (platform-wide) effective state without
+ * writing to the DB. Falls back to the KNOWN_FLAGS default (or `false`) when the
+ * flag row does not exist yet, so a flag defaulting OFF is a no-op until an admin
+ * enables it.
  */
-export async function isFeatureEnabled(key: string): Promise<boolean> {
+async function readGlobalFlag(key: string): Promise<boolean> {
   try {
     const flag = await prisma.featureFlag.findUnique({
       where: { key },
@@ -198,6 +199,109 @@ export async function isFeatureEnabled(key: string): Promise<boolean> {
     // static KNOWN_FLAGS default so a flag defaulting OFF stays a safe no-op.
   }
   return KNOWN_FLAGS.find((f) => f.key === key)?.enabled ?? false;
+}
+
+// ── Per-team override resolution (zero-blast-radius flag scoping) ──
+
+/**
+ * Short-TTL per-team override cache. A team's overrides are loaded with a SINGLE
+ * `findMany` and reused for the TTL window, so threading team-scoped resolution
+ * onto the hot validate path — which evaluates several flags per request —
+ * resolves every team-scoped flag from ONE query instead of an N+1. The TTL is
+ * intentionally short so an admin toggling an override takes effect promptly.
+ */
+const TEAM_OVERRIDE_TTL_MS = 5_000;
+const teamOverrideCache = new Map<string, { overrides: Record<string, boolean>; expiresAt: number }>();
+
+/**
+ * Load (and briefly cache) ALL of a team's flag overrides as `flagKey → enabled`.
+ * Returns `{}` when the team has no overrides or the lookup fails — either way
+ * the caller then inherits the global value (fail-safe, zero regression).
+ */
+async function loadTeamOverrides(teamId: string): Promise<Record<string, boolean>> {
+  const now = Date.now();
+  const cached = teamOverrideCache.get(teamId);
+  if (cached && cached.expiresAt > now) return cached.overrides;
+
+  let overrides: Record<string, boolean> = {};
+  try {
+    const rows = await prisma.featureFlagOverride.findMany({
+      where: { teamId },
+      select: { flagKey: true, enabled: true },
+    });
+    overrides = Object.fromEntries(rows.map((r) => [r.flagKey, r.enabled]));
+  } catch {
+    // DB unavailable / lagging → no overrides → inherit global (never hard-fail).
+    overrides = {};
+  }
+  teamOverrideCache.set(teamId, { overrides, expiresAt: now + TEAM_OVERRIDE_TTL_MS });
+  return overrides;
+}
+
+/**
+ * Read a single feature flag's effective state for an OPTIONAL team context.
+ *
+ * Precedence: a per-team `FeatureFlagOverride` row (ON or OFF) wins for that
+ * team; otherwise the team inherits the GLOBAL value (today's exact behavior).
+ * With no `teamId` — or no override row for that flag — this is byte-identical to
+ * the global path, so default behavior is unchanged (zero regression).
+ *
+ * Backward compatible: every existing `isFeatureEnabled(key)` call keeps the
+ * global semantics; passing a `teamId` opts into team-scoped resolution.
+ */
+export async function isFeatureEnabled(key: string, teamId?: string | null): Promise<boolean> {
+  if (teamId) {
+    const overrides = await loadTeamOverrides(teamId);
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      return overrides[key];
+    }
+  }
+  return readGlobalFlag(key);
+}
+
+/**
+ * Explicit team-scoped alias of {@link isFeatureEnabled} for call sites that
+ * always have a team context (reads better than a positional second arg).
+ */
+export async function isFeatureEnabledForTeam(key: string, teamId: string | null | undefined): Promise<boolean> {
+  return isFeatureEnabled(key, teamId);
+}
+
+/**
+ * Does ANY team currently have `flagKey` overridden to ENABLED?
+ *
+ * Used only to keep flag-gated "endpoint hidden" surfaces (e.g. the
+ * `/api/v1/keys/validate` front door) byte-identical to today when the flag is
+ * globally OFF and NO team has opted in: a single cheap existence check lets the
+ * endpoint return its usual 404 immediately without resolving a team. Cached
+ * briefly to avoid a per-request query on the globally-OFF hot path. Fail-safe:
+ * any error reports `false` (stay hidden, exactly as today).
+ */
+const anyOverrideCache = new Map<string, { value: boolean; expiresAt: number }>();
+
+export async function anyTeamFlagOverrideEnabled(flagKey: string): Promise<boolean> {
+  const now = Date.now();
+  const cached = anyOverrideCache.get(flagKey);
+  if (cached && cached.expiresAt > now) return cached.value;
+
+  let value = false;
+  try {
+    const row = await prisma.featureFlagOverride.findFirst({
+      where: { flagKey, enabled: true },
+      select: { id: true },
+    });
+    value = Boolean(row);
+  } catch {
+    value = false;
+  }
+  anyOverrideCache.set(flagKey, { value, expiresAt: now + TEAM_OVERRIDE_TTL_MS });
+  return value;
+}
+
+/** Clear the in-memory override caches (test isolation / after a mutation). */
+export function resetFeatureFlagOverrideCache(): void {
+  teamOverrideCache.clear();
+  anyOverrideCache.clear();
 }
 
 /**

--- a/apps/web-next/src/lib/feature-flags.ts
+++ b/apps/web-next/src/lib/feature-flags.ts
@@ -211,7 +211,39 @@ async function readGlobalFlag(key: string): Promise<boolean> {
  * intentionally short so an admin toggling an override takes effect promptly.
  */
 const TEAM_OVERRIDE_TTL_MS = 5_000;
+/**
+ * Hard ceiling on cached teams. The TTL is short, so this is only ever
+ * approached under a burst across many distinct teams; the bounded set below
+ * prunes expired entries and then evicts oldest-first so the cache can never
+ * grow without limit (memory stays tied to the active working set).
+ */
+const TEAM_OVERRIDE_CACHE_MAX = 1_000;
 const teamOverrideCache = new Map<string, { overrides: Record<string, boolean>; expiresAt: number }>();
+
+/**
+ * Insert into a short-TTL cache while keeping it bounded: once at capacity,
+ * first drop any expired entries, then evict oldest-inserted until under the
+ * limit. Prevents unbounded `Map` growth across many distinct keys.
+ */
+function setBounded<V extends { expiresAt: number }>(
+  cache: Map<string, V>,
+  key: string,
+  value: V,
+  max: number,
+): void {
+  if (cache.size >= max && !cache.has(key)) {
+    const now = Date.now();
+    for (const [k, v] of cache) {
+      if (v.expiresAt <= now) cache.delete(k);
+    }
+    while (cache.size >= max) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
+  }
+  cache.set(key, value);
+}
 
 /**
  * Load (and briefly cache) ALL of a team's flag overrides as `flagKey → enabled`.
@@ -234,7 +266,7 @@ async function loadTeamOverrides(teamId: string): Promise<Record<string, boolean
     // DB unavailable / lagging → no overrides → inherit global (never hard-fail).
     overrides = {};
   }
-  teamOverrideCache.set(teamId, { overrides, expiresAt: now + TEAM_OVERRIDE_TTL_MS });
+  setBounded(teamOverrideCache, teamId, { overrides, expiresAt: now + TEAM_OVERRIDE_TTL_MS }, TEAM_OVERRIDE_CACHE_MAX);
   return overrides;
 }
 
@@ -294,7 +326,7 @@ export async function anyTeamFlagOverrideEnabled(flagKey: string): Promise<boole
   } catch {
     value = false;
   }
-  anyOverrideCache.set(flagKey, { value, expiresAt: now + TEAM_OVERRIDE_TTL_MS });
+  setBounded(anyOverrideCache, flagKey, { value, expiresAt: now + TEAM_OVERRIDE_TTL_MS }, TEAM_OVERRIDE_CACHE_MAX);
   return value;
 }
 

--- a/packages/database/prisma/migrations/20260629150000_add_feature_flag_override/migration.sql
+++ b/packages/database/prisma/migrations/20260629150000_add_feature_flag_override/migration.sql
@@ -1,0 +1,33 @@
+-- Per-team feature-flag override (zero-blast-radius flag scoping). EXPAND-ONLY,
+-- additive. Adds the `public.FeatureFlagOverride` table keyed by
+-- (teamId, flagKey). When a row exists its `enabled` wins for that team; with NO
+-- rows, flag evaluation is byte-identical to today (the global `FeatureFlag`
+-- value). No existing table/column/constraint is dropped or rewritten and no
+-- data is backfilled. Idempotent (IF NOT EXISTS) for safe re-apply.
+
+-- CreateTable: FeatureFlagOverride (public)
+CREATE TABLE IF NOT EXISTS "public"."FeatureFlagOverride" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "flagKey" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "updatedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeatureFlagOverride_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "FeatureFlagOverride_teamId_flagKey_key"
+    ON "public"."FeatureFlagOverride"("teamId", "flagKey");
+CREATE INDEX IF NOT EXISTS "FeatureFlagOverride_flagKey_enabled_idx"
+    ON "public"."FeatureFlagOverride"("flagKey", "enabled");
+CREATE INDEX IF NOT EXISTS "FeatureFlagOverride_teamId_idx"
+    ON "public"."FeatureFlagOverride"("teamId");
+
+-- FK to Team (cascade) — references an existing public table. A team's overrides
+-- are removed with the team.
+ALTER TABLE "public"."FeatureFlagOverride"
+    ADD CONSTRAINT "FeatureFlagOverride_teamId_fkey" FOREIGN KEY ("teamId")
+    REFERENCES "public"."Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260629150000_add_feature_flag_override/migration.sql
+++ b/packages/database/prisma/migrations/20260629150000_add_feature_flag_override/migration.sql
@@ -27,7 +27,15 @@ CREATE INDEX IF NOT EXISTS "FeatureFlagOverride_teamId_idx"
     ON "public"."FeatureFlagOverride"("teamId");
 
 -- FK to Team (cascade) — references an existing public table. A team's overrides
--- are removed with the team.
-ALTER TABLE "public"."FeatureFlagOverride"
-    ADD CONSTRAINT "FeatureFlagOverride_teamId_fkey" FOREIGN KEY ("teamId")
-    REFERENCES "public"."Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- are removed with the team. Guarded so re-applying the migration is a no-op
+-- once the constraint already exists (idempotent, matching the table/index above).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'FeatureFlagOverride_teamId_fkey'
+    ) THEN
+        ALTER TABLE "public"."FeatureFlagOverride"
+            ADD CONSTRAINT "FeatureFlagOverride_teamId_fkey" FOREIGN KEY ("teamId")
+            REFERENCES "public"."Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -338,6 +338,7 @@ model Team {
   members        TeamMember[]
   pluginInstalls TeamPluginInstall[]
   seats          Seat[]
+  featureFlagOverrides FeatureFlagOverride[]
 
   @@index([ownerId])
   @@index([billingAccountProviderSlug])
@@ -541,6 +542,30 @@ model FeatureFlag {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  @@schema("public")
+}
+
+// Per-team feature-flag override. Scopes a single flag ON/OFF for ONE team
+// without changing the platform-wide `FeatureFlag` default. Keyed by
+// (teamId, flagKey); when a row exists its `enabled` wins for that team, else
+// the team inherits the global `FeatureFlag` value. PURELY ADDITIVE: with no
+// override rows, flag evaluation is byte-identical to today (global value).
+// `flagKey` is the same string used in `FeatureFlag.key` / `KNOWN_FLAGS` (no FK
+// so a flag defaulting OFF in code needs no `FeatureFlag` row to be overridden).
+// Audit fields record who set the override and when.
+model FeatureFlagOverride {
+  id        String   @id @default(uuid())
+  teamId    String
+  team      Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  flagKey   String
+  enabled   Boolean
+  updatedBy String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([teamId, flagKey])
+  @@index([flagKey, enabled])
+  @@index([teamId])
   @@schema("public")
 }
 


### PR DESCRIPTION
## Why

NaaP feature flags are currently **global** — one `FeatureFlag` row per flag, no per-team scoping. Enabling the billing-chain flags (`key_validation_front_door`, `per_key_remote_signer`, `provider_instances`, `multi_subscription`, `plan_spec_sync`, `pymthouse_bpp_validate`, `capability_gate`, …) in prod flips behavior for the **entire** live platform. This PR makes flags **context-aware** so a flag can be enabled for **one team** with zero blast radius — unblocking a true-prod e2e on a single test team.

**Additive + zero-regression.** With no override rows, flag evaluation is byte-identical to today.

## Per-team scoping model

New `public.FeatureFlagOverride` table keyed by `(teamId, flagKey)` → `enabled` (+ `updatedBy`/`updatedAt` audit, `Team` FK, cascade delete). Precedence: a per-team override (ON **or** OFF) wins for that team; otherwise the team inherits the **global** `FeatureFlag` value. The global table remains the default/fallback. Migration is expand-only / idempotent (`IF NOT EXISTS`); no existing table/column is altered and nothing is backfilled.

## Resolver

`apps/web-next/src/lib/feature-flags.ts`:
- `isFeatureEnabled(key, teamId?)` — backward compatible; existing `isFeatureEnabled(key)` calls keep global semantics. With a `teamId`, returns the team override if present, else global.
- A **short-TTL per-team cache** loads *all* of a team's overrides in a single `findMany`, so threading team scope onto the hot validate path (which evaluates several flags per request) introduces **no N+1**.
- `isFeatureEnabledForTeam(key, teamId)` (explicit alias), `anyTeamFlagOverrideEnabled(flagKey)` (front-door visibility helper), `resetFeatureFlagOverrideCache()`.
- Fail-safe: any DB error degrades to the global value.

## Consumers threaded to team scope (file:line)

Team context = the key's owning `teamId` (validate) or the `[teamId]` route param.

- `app/api/v1/keys/validate/route.ts` — front-door gate (`key_validation_front_door`, ~L82-85 + L131-134), `per_key_remote_signer` (~L189), `capability_gate` (~L233), and passes `{ teamId }` to `adapter.validate()` (~L216).
- `lib/billing/pymthouse-adapter.ts:validate(externalUserId, context?)` — `pymthouse_bpp_validate` resolved in the key's team scope.
- `lib/billing/adapter.ts` — added optional `ValidateContext` to the `validate` SPI (backward compatible; other adapters ignore it).
- `lib/billing/key-provider-binding.ts` → `lib/billing/subscription.ts` (`multi_subscription`) + `lib/billing/registry-db.ts` (`provider_instances`) — resolved in `key.teamId` scope.
- `lib/billing/key-discovery.ts` (`plan_spec_sync`) — resolved in the subscription's team scope.
- `app/api/v1/teams/[teamId]/**` — `team_seats`, `native_keys`, `multi_subscription` CRUD routes resolved in the `[teamId]` scope.

**Global-by-design (no single team context):** `app/api/v1/metrics/ingest` (`usage_ingest`, provider→NaaP service token) and `app/api/v1/metrics/usage` (`usage_pull`/`usage_ingest`, a user-session dashboard aggregating many teams) keep global evaluation. The by-slug adapter registry path and the plan-spec sync job also stay global. These still **read** overrides nowhere, so they remain unchanged.

## Admin UI + API

- **Page:** `/admin/feature-flags` (new "Flags" admin tab). Searchable team list → pick a team → every flag with its **global default**, **effective** value, and **provenance** (Inherited vs Overridden), with a per-flag **On / Off / Inherit** control. Guarded by `system:admin`.
- **API:** `/api/v1/admin/feature-flag-overrides` — `GET ?teamId=` (effective values + provenance), `PUT {teamId,key,enabled}` (set), `DELETE {teamId,key}` (clear→inherit). `/api/v1/admin/feature-flag-overrides/teams` lists teams with override counts. All `system:admin`-guarded, CSRF-checked on mutations, and audited to `AuditLog`.

## Zero-regression guarantees

- `isFeatureEnabled(key)` with no `teamId` is unchanged.
- With **no override rows**, `isFeatureEnabled(key, teamId)` == global value (unit test asserts byte-identical).
- `/keys/validate` globally-OFF + nobody opted in → 404 **without touching the key DB** (test asserts).
- `capability_gate` stays **fail-closed only for the team that opts in**; other teams inherit global OFF → no enforcement.

## Test plan

All green (`vitest` 1240 passed / 1 skipped; lint + typecheck clean on changed files):
- Resolver unit (`lib/feature-flags.test.ts`): override ON/OFF/clear→inherit, no-override==global, precedence, cross-team isolation, fail-safe, single-`findMany` cache, `anyTeamFlagOverrideEnabled`.
- Integration (`keys/validate/route.test.ts`): opted-in team → 200 while globally OFF; a different team masked → 404; zero-regression (globally OFF + no opt-in → 404, no DB).
- Admin CRUD + authz (`feature-flag-overrides/**.test.ts`): 401/403 gating, GET provenance, PUT upsert + audit + `updatedBy`, DELETE idempotent clear, teams search.

## How to enable the billing chain for ONE test team

In **Admin → Flags**, pick the test team and set **On** (per-team override) for:
`key_validation_front_door`, `pymthouse_bpp_validate`, `provider_instances`, `multi_subscription`, `plan_spec_sync`, `per_key_remote_signer`, and (optionally, fail-closed) `capability_gate` — plus `team_seats` + `native_keys` to mint the team's keys. Leave all global defaults OFF. Every other team and the global platform stay byte-identical to today.

> Not merged; nothing enabled in prod. After this merges + the migration is applied, overrides are set per-team via the admin UI.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin “Flags” page to view and manage per-team feature flags.
  * Team lists now include search, flag override counts, and effective flag status details.
  * Feature flags can now be set to On, Off, or Inherit at the team level.

* **Bug Fixes**
  * Feature-gated areas now respect team-specific settings more consistently across billing, seats, subscriptions, and key workflows.
  * Flag changes refresh related data immediately so updates take effect across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->