### PR TITLE
feat(pymthouse): adopt new api-key signer-session exchange contract

### DIFF
--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -321,6 +321,28 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
     expect(getSignerRouting).not.toHaveBeenCalled();
   });
 
+  it('per-instance adapter (injected client) does NOT fall back to the global PYMTHOUSE_API_KEY env', async () => {
+    // A per-instance adapter must stay bound to ITS app: the global env key is
+    // never even consulted (short-circuited by the injected client), so it uses
+    // the legacy per-instance mint instead of the global app's api key.
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_tenant',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.tenant.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+    const a = new PymthouseAdapter({ client: { getSignerRouting } as never, isConfigured: () => true });
+
+    const ep = await a.resolveSignerEndpoint(TOKEN, CTX);
+
+    // The global env key is never read, the api-key exchange never runs, and the
+    // legacy per-instance mint is used instead (tenant isolation preserved).
+    expect(readApiKeySignerSessionConfig).not.toHaveBeenCalled();
+    expect(exchangeApiKeyForSignerSession).not.toHaveBeenCalled();
+    expect(getSignerRouting).toHaveBeenCalledTimes(1);
+    expect(mintUserSignerJwtForExternalUser).toHaveBeenCalled();
+    expect(ep.url).toBe('https://dmz.tenant.com');
+  });
+
   it('throws when the exchange returns no signerUrl (front door fails safe)', async () => {
     exchangeApiKeyForSignerSession.mockResolvedValue({
       accessToken: 'jwt', signerUrl: null, expiresIn: 900, scope: 'sign:job', tokenType: 'Bearer',

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -9,6 +9,7 @@ const listBillingProducts = vi.fn();
 const getSignerRouting = vi.fn();
 const mintUserSignerJwtForExternalUser = vi.fn();
 const globalSignerExchangeConfig = vi.fn();
+const exchangeApiKeyForSignerSession = vi.fn();
 
 vi.mock('@/lib/pymthouse-client', () => ({
   getPmtHouseServerClient: () => ({
@@ -20,6 +21,15 @@ vi.mock('@/lib/pymthouse-client', () => ({
   }),
   globalSignerExchangeConfig: () => globalSignerExchangeConfig(),
   mintUserSignerJwtForExternalUser: (input: unknown) => mintUserSignerJwtForExternalUser(input),
+  exchangeApiKeyForSignerSession: (input: unknown) => exchangeApiKeyForSignerSession(input),
+}));
+
+// Default: no global PYMTHOUSE_API_KEY → legacy per-user mint path (zero
+// regression). Tests that exercise the new endpoint pass `apiKeyExchange`
+// explicitly via the adapter options instead.
+const readApiKeySignerSessionConfig = vi.fn(() => null);
+vi.mock('@/lib/pymthouse-signer-exchange-config', () => ({
+  readApiKeySignerSessionConfig: () => readApiKeySignerSessionConfig(),
 }));
 
 vi.mock('@pymthouse/builder-sdk/config', () => ({
@@ -251,6 +261,88 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
     mintUserSignerJwtForExternalUser.mockRejectedValue(new Error('mint failed'));
 
     await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow('mint failed');
+  });
+});
+
+describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exchange)', () => {
+  const TOKEN = { accessToken: 'pmth_abc123', tokenType: 'Bearer', expiresIn: 3600, scope: 'sign:job' };
+  const CTX = { externalUserId: 'acct_user_42' };
+
+  it('explicit apiKeyExchange option → single-call exchange supplies url + bearer (no routing/mint)', async () => {
+    exchangeApiKeyForSignerSession.mockResolvedValue({
+      accessToken: 'eyJhbGciOiJSUzI1NiJ9.signer.sig',
+      signerUrl: 'https://signer-dmz.pymthouse.com',
+      expiresIn: 900,
+      scope: 'sign:job',
+      tokenType: 'Bearer',
+    });
+    const a = new PymthouseAdapter({
+      apiKeyExchange: { billingUrl: 'https://pymthouse.com', clientId: 'app_x', apiKey: 'pmth_key' },
+    });
+
+    const ep = await a.resolveSignerEndpoint(TOKEN, CTX);
+
+    expect(exchangeApiKeyForSignerSession).toHaveBeenCalledWith({
+      billingUrl: 'https://pymthouse.com',
+      clientId: 'app_x',
+      apiKey: 'pmth_key',
+    });
+    expect(ep).toEqual({
+      url: 'https://signer-dmz.pymthouse.com',
+      headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.signer.sig' },
+    });
+    // The legacy routing + user-JWT mint path is bypassed entirely.
+    expect(getSignerRouting).not.toHaveBeenCalled();
+    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+  });
+
+  it('global PYMTHOUSE_API_KEY env config is used when no explicit option is injected', async () => {
+    readApiKeySignerSessionConfig.mockReturnValueOnce({
+      billingUrl: 'https://pymthouse.com',
+      clientId: 'app_env',
+      apiKey: 'pmth_env_key',
+    } as never);
+    exchangeApiKeyForSignerSession.mockResolvedValue({
+      accessToken: 'env.signer.jwt',
+      signerUrl: 'https://signer-dmz.pymthouse.com',
+      expiresIn: 900,
+      scope: 'sign:job',
+      tokenType: 'Bearer',
+    });
+
+    const ep = await adapter.resolveSignerEndpoint(TOKEN, CTX);
+
+    expect(exchangeApiKeyForSignerSession).toHaveBeenCalledWith({
+      billingUrl: 'https://pymthouse.com',
+      clientId: 'app_env',
+      apiKey: 'pmth_env_key',
+    });
+    expect(ep.url).toBe('https://signer-dmz.pymthouse.com');
+    expect(getSignerRouting).not.toHaveBeenCalled();
+  });
+
+  it('throws when the exchange returns no signerUrl (front door fails safe)', async () => {
+    exchangeApiKeyForSignerSession.mockResolvedValue({
+      accessToken: 'jwt', signerUrl: null, expiresIn: 900, scope: 'sign:job', tokenType: 'Bearer',
+    });
+    const a = new PymthouseAdapter({
+      apiKeyExchange: { billingUrl: 'https://pymthouse.com', clientId: 'app_x', apiKey: 'pmth_key' },
+    });
+    await expect(a.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow(/no signerUrl/);
+  });
+
+  it('rejects a dashboard /api/signer proxy base returned by the exchange', async () => {
+    exchangeApiKeyForSignerSession.mockResolvedValue({
+      accessToken: 'jwt',
+      signerUrl: 'https://dashboard.pymthouse.com/api/signer',
+      expiresIn: 900,
+      scope: 'sign:job',
+      tokenType: 'Bearer',
+    });
+    const a = new PymthouseAdapter({
+      apiKeyExchange: { billingUrl: 'https://pymthouse.com', clientId: 'app_x', apiKey: 'pmth_key' },
+    });
+    await expect(a.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow();
   });
 });
 

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -16,12 +16,15 @@ import { assertDirectSignerBaseUrl } from '@pymthouse/builder-sdk/signer/server'
 import type { MeScopeUsagePayload, PmtHouseClient, UsageApiResponse } from '@pymthouse/builder-sdk';
 
 import {
+  exchangeApiKeyForSignerSession,
   getPmtHouseServerClient,
   mintOpaqueSignerSessionForExternalUser,
   mintSignerSessionForExternalUser,
   mintUserSignerJwtForExternalUser,
+  type PymthouseApiKeyExchangeConfig,
   type PymthouseSignerExchangeConfig,
 } from '@/lib/pymthouse-client';
+import { readApiKeySignerSessionConfig } from '@/lib/pymthouse-signer-exchange-config';
 import { isFeatureEnabled, PYMTHOUSE_BPP_VALIDATE_FLAG } from '@/lib/feature-flags';
 import { resolvePymthouseCapabilities } from './pymthouse-capabilities';
 import {
@@ -63,6 +66,14 @@ export interface PymthouseAdapterOptions {
    * adapter, which uses the `PYMTHOUSE_*` env exchange.
    */
   signerExchange?: PymthouseSignerExchangeConfig;
+  /**
+   * Optional config for the NEW single-call signer-session exchange
+   * (`POST /api/v1/apps/{clientId}/auth/api-key/signer-session`). When present,
+   * {@link PymthouseAdapter.resolveSignerEndpoint} prefers it over the legacy
+   * `getSignerRouting()` + user-JWT mint. Omitted by default; the global-env
+   * adapter resolves it lazily from `PYMTHOUSE_API_KEY` (unset ⇒ legacy path).
+   */
+  apiKeyExchange?: PymthouseApiKeyExchangeConfig;
 }
 
 export class PymthouseAdapter implements BillingProviderAdapter {
@@ -71,11 +82,13 @@ export class PymthouseAdapter implements BillingProviderAdapter {
   private readonly clientOverride?: PmtHouseClient;
   private readonly isConfiguredOverride?: () => boolean;
   private readonly signerExchange?: PymthouseSignerExchangeConfig;
+  private readonly apiKeyExchange?: PymthouseApiKeyExchangeConfig;
 
   constructor(options: PymthouseAdapterOptions = {}) {
     this.clientOverride = options.client;
     this.isConfiguredOverride = options.isConfigured;
     this.signerExchange = options.signerExchange;
+    this.apiKeyExchange = options.apiKeyExchange;
   }
 
   /**
@@ -282,6 +295,31 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     _session: SignerSessionToken,
     context?: { externalUserId: string },
   ): Promise<SignerSessionEndpoint> {
+    // NEW contract: a single authenticated POST to
+    // `/api/v1/apps/{clientId}/auth/api-key/signer-session` returns BOTH the
+    // remote signer DMZ url AND the bearer in one call (replacing the legacy
+    // `getSignerRouting()` + user-JWT mint below). Preferred when an explicit
+    // `apiKeyExchange` was injected (per-instance) OR `PYMTHOUSE_API_KEY` is set
+    // (global env). Unset by default ⇒ this branch is skipped and the legacy
+    // path runs byte-for-byte (zero regression). NOTE: this endpoint is
+    // authenticated by the `pmth_…` key itself and takes no `externalUserId`, so
+    // identity/usage attribution is at the KEY level, not per NaaP user.
+    const apiKeyCfg = this.apiKeyExchange ?? readApiKeySignerSessionConfig();
+    if (apiKeyCfg) {
+      const session = await exchangeApiKeyForSignerSession(apiKeyCfg);
+      const url = session.signerUrl;
+      if (!url) {
+        throw new Error('pymthouse api-key signer-session returned no signerUrl');
+      }
+      // Reject dashboard `/api/signer/*` proxy bases — signing RPCs must target
+      // the remote-signer DMZ origin directly (builder-sdk 0.4.6).
+      assertDirectSignerBaseUrl(url);
+      return {
+        url,
+        headers: { Authorization: `Bearer ${session.accessToken}` },
+      };
+    }
+
     const routing = await this.client().getSignerRouting();
     const url =
       routing.patterns?.directDmz?.signerApiUrl ||

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -299,12 +299,22 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     // `/api/v1/apps/{clientId}/auth/api-key/signer-session` returns BOTH the
     // remote signer DMZ url AND the bearer in one call (replacing the legacy
     // `getSignerRouting()` + user-JWT mint below). Preferred when an explicit
-    // `apiKeyExchange` was injected (per-instance) OR `PYMTHOUSE_API_KEY` is set
-    // (global env). Unset by default ⇒ this branch is skipped and the legacy
-    // path runs byte-for-byte (zero regression). NOTE: this endpoint is
-    // authenticated by the `pmth_…` key itself and takes no `externalUserId`, so
-    // identity/usage attribution is at the KEY level, not per NaaP user.
-    const apiKeyCfg = this.apiKeyExchange ?? readApiKeySignerSessionConfig();
+    // `apiKeyExchange` was injected (per-instance) OR — for the GLOBAL-env
+    // adapter only — `PYMTHOUSE_API_KEY` is set. Unset by default ⇒ this branch
+    // is skipped and the legacy path runs byte-for-byte (zero regression).
+    //
+    // The global `PYMTHOUSE_API_KEY` env is NOT consulted for a per-instance
+    // adapter (one with an injected `clientOverride`): that key belongs to the
+    // global `PYMTHOUSE_*` app, so falling back to it would silently exchange a
+    // tenant's signer session against the WRONG app and break per-instance
+    // isolation. A per-instance adapter therefore uses the new path only when
+    // its own `apiKeyExchange` is injected, else the legacy per-instance mint.
+    //
+    // NOTE: this endpoint is authenticated by the `pmth_…` key itself and takes
+    // no `externalUserId`, so identity/usage attribution is at the KEY level,
+    // not per NaaP user.
+    const apiKeyCfg =
+      this.apiKeyExchange ?? (this.clientOverride ? undefined : readApiKeySignerSessionConfig());
     if (apiKeyCfg) {
       const session = await exchangeApiKeyForSignerSession(apiKeyCfg);
       const url = session.signerUrl;

--- a/apps/web-next/src/lib/pymthouse-client.test.ts
+++ b/apps/web-next/src/lib/pymthouse-client.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mintUserSignerJwtForExternalUser } from './pymthouse-client';
+import { exchangeApiKeyForSignerSession, mintUserSignerJwtForExternalUser } from './pymthouse-client';
 
 /** Minimal `PmtHouseClient` stub exposing only what the mint helper touches. */
 function makeClient(
@@ -130,5 +130,139 @@ describe('mintUserSignerJwtForExternalUser (Builder user-token JWT for the remot
       mintUserSignerJwtForExternalUser({ client: client as never, externalUserId: 'acct_user_42' }),
     ).rejects.toThrow('upsert boom');
     expect(client.mintUserAccessToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/auth/api-key/signer-session)', () => {
+  function mockFetch(
+    response: { ok?: boolean; status?: number; json: () => Promise<unknown> },
+  ): ReturnType<typeof vi.fn> {
+    const fn = vi.fn().mockResolvedValue({
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      json: response.json,
+    });
+    vi.stubGlobal('fetch', fn);
+    return fn;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the api key as Bearer with scope body and parses the nested token envelope', async () => {
+    // Canonical example-client envelope: { token: { accessToken }, signerUrl }.
+    const fetchMock = mockFetch({
+      json: async () => ({
+        token: { accessToken: 'eyJhbGciOiJSUzI1NiJ9.signer.sig' },
+        signerUrl: 'https://signer-dmz.pymthouse.com',
+        expires_in: 900,
+        scope: 'sign:job',
+      }),
+    });
+
+    const out = await exchangeApiKeyForSignerSession({
+      billingUrl: 'https://pymthouse.com',
+      clientId: 'app_973064',
+      apiKey: 'pmth_test_key',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://pymthouse.com/api/v1/apps/app_973064/auth/api-key/signer-session');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer pmth_test_key',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+    expect(JSON.parse(init.body as string)).toEqual({ scope: 'sign:job' });
+
+    expect(out).toEqual({
+      accessToken: 'eyJhbGciOiJSUzI1NiJ9.signer.sig',
+      signerUrl: 'https://signer-dmz.pymthouse.com',
+      expiresIn: 900,
+      scope: 'sign:job',
+      tokenType: 'Bearer',
+    });
+  });
+
+  it('accepts a flat top-level accessToken + signer_url and honors a custom scope', async () => {
+    const fetchMock = mockFetch({
+      json: async () => ({ accessToken: 'flat.jwt.sig', signer_url: 'https://dmz.example' }),
+    });
+
+    const out = await exchangeApiKeyForSignerSession({
+      billingUrl: 'https://pymthouse.com/',
+      clientId: 'app_x',
+      apiKey: 'pmth_x',
+      scope: 'sign:job extra',
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ scope: 'sign:job extra' });
+    expect(out.accessToken).toBe('flat.jwt.sig');
+    expect(out.signerUrl).toBe('https://dmz.example');
+    // No expires_in in the response → conservative default TTL.
+    expect(out.expiresIn).toBe(300);
+    expect(out.scope).toBe('sign:job extra');
+  });
+
+  it('url-encodes the clientId into the path', async () => {
+    const fetchMock = mockFetch({ json: async () => ({ accessToken: 't' }) });
+    await exchangeApiKeyForSignerSession({
+      billingUrl: 'https://pymthouse.com',
+      clientId: 'app/with space',
+      apiKey: 'pmth_x',
+    });
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(
+      'https://pymthouse.com/api/v1/apps/app%2Fwith%20space/auth/api-key/signer-session',
+    );
+  });
+
+  it('rejects an empty api key before any network call', async () => {
+    const fetchMock = mockFetch({ json: async () => ({}) });
+    await expect(
+      exchangeApiKeyForSignerSession({ billingUrl: 'https://p.com', clientId: 'app_x', apiKey: '  ' }),
+    ).rejects.toThrow(/non-empty API key/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty clientId before any network call', async () => {
+    const fetchMock = mockFetch({ json: async () => ({}) });
+    await expect(
+      exchangeApiKeyForSignerSession({ billingUrl: 'https://p.com', clientId: ' ', apiKey: 'pmth_x' }),
+    ).rejects.toThrow(/non-empty clientId/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when the response carries no signer access token', async () => {
+    mockFetch({ json: async () => ({ signerUrl: 'https://dmz.example' }) });
+    await expect(
+      exchangeApiKeyForSignerSession({ billingUrl: 'https://p.com', clientId: 'app_x', apiKey: 'pmth_x' }),
+    ).rejects.toThrow(/missing signer access token/);
+  });
+
+  it('surfaces a non-2xx error_description from the provider', async () => {
+    mockFetch({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'unauthorized', error_description: 'invalid api key' }),
+    });
+    await expect(
+      exchangeApiKeyForSignerSession({ billingUrl: 'https://p.com', clientId: 'app_x', apiKey: 'pmth_bad' }),
+    ).rejects.toThrow(/invalid api key/);
+  });
+
+  it('throws on invalid JSON in the response body', async () => {
+    mockFetch({
+      json: async () => {
+        throw new Error('not json');
+      },
+    });
+    await expect(
+      exchangeApiKeyForSignerSession({ billingUrl: 'https://p.com', clientId: 'app_x', apiKey: 'pmth_x' }),
+    ).rejects.toThrow(/invalid JSON/);
   });
 });

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -313,3 +313,154 @@ export async function mintUserSignerJwtForExternalUser(input: {
     scope: token.scope?.trim() || scope,
   };
 }
+
+/**
+ * Non-secret connection params + a `pmth_…` API key needed to perform the new
+ * single-call signer-session exchange documented at
+ * `POST /api/v1/apps/{clientId}/auth/api-key/signer-session`.
+ *
+ * `billingUrl` is the PymtHouse ORIGIN (e.g. `https://pymthouse.com`), NOT the
+ * `/api/v1/oidc` issuer URL — the endpoint lives under `/api/v1/apps/...`.
+ */
+export interface PymthouseApiKeyExchangeConfig {
+  billingUrl: string;
+  clientId: string;
+  apiKey: string;
+  scope?: string;
+}
+
+/** Result of the api-key → signer-session exchange (endpoint form inputs). */
+export interface ApiKeySignerSession {
+  /** Signer-session token to forward as `Authorization: Bearer …`. */
+  accessToken: string;
+  /** Remote signer DMZ base URL the provider returned (or null when omitted). */
+  signerUrl: string | null;
+  /** Seconds until the session expires (>= 1), defaulted when omitted. */
+  expiresIn: number;
+  /** Scope the session carries (defaults to the requested scope). */
+  scope: string;
+  /** Always `Bearer` for the signer DMZ. */
+  tokenType: string;
+}
+
+/**
+ * Read the signer-session token out of the exchange response envelope.
+ *
+ * Mirrors the canonical example client
+ * (`livepeer-gateway-client@30df477` `auth_exchange._signer_access_token`):
+ * accept either the nested `token.{accessToken,access_token}` envelope OR a
+ * flat top-level `{accessToken,access_token}`.
+ */
+function readSignerAccessToken(body: Record<string, unknown>): string {
+  const token = body.token;
+  if (token && typeof token === 'object' && !Array.isArray(token)) {
+    const rec = token as Record<string, unknown>;
+    for (const key of ['accessToken', 'access_token'] as const) {
+      const value = rec[key];
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+  }
+  for (const key of ['accessToken', 'access_token'] as const) {
+    const value = body[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  throw new PmtHouseError('API key signer-session response missing signer access token', {
+    status: 502,
+    code: 'invalid_token_response',
+  });
+}
+
+/** Read the optional signer DMZ URL (`signerUrl` | `signer_url`) from the envelope. */
+function readSignerUrl(body: Record<string, unknown>): string | null {
+  for (const key of ['signerUrl', 'signer_url'] as const) {
+    const value = body[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+/**
+ * Exchange a `pmth_…` API key for a signer session via the NEW PymtHouse
+ * endpoint `POST /api/v1/apps/{clientId}/auth/api-key/signer-session`.
+ *
+ * This is the contract John relocated the token-exchange to (the example client
+ * `livepeer-gateway-client@30df477` `exchange_api_key_for_signer`): a SINGLE
+ * authenticated POST that returns both the signer-session token AND the remote
+ * signer DMZ url — collapsing NaaP's older multi-step "mint user JWT → manually
+ * token-exchange" shim into one call. The API key is sent as the bearer; the
+ * `clientId` is URL-encoded into the path; the body carries the requested scope.
+ */
+export async function exchangeApiKeyForSignerSession(
+  cfg: PymthouseApiKeyExchangeConfig,
+): Promise<ApiKeySignerSession> {
+  const apiKey = cfg.apiKey.trim();
+  if (!apiKey) {
+    throw new PmtHouseError('API key signer-session exchange requires a non-empty API key', {
+      status: 400,
+      code: 'pymthouse_required',
+    });
+  }
+  const clientId = cfg.clientId.trim();
+  if (!clientId) {
+    throw new PmtHouseError('API key signer-session exchange requires a non-empty clientId', {
+      status: 400,
+      code: 'pymthouse_required',
+    });
+  }
+  const scope = cfg.scope?.trim() || SIGN_JOB_SCOPE;
+  const url =
+    `${cfg.billingUrl.replace(/\/+$/, '')}/api/v1/apps/` +
+    `${encodeURIComponent(clientId)}/auth/api-key/signer-session`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(scope ? { scope } : {}),
+    cache: 'no-store',
+    // Fail fast instead of hanging if the PymtHouse endpoint is unresponsive.
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await response.json()) as Record<string, unknown>;
+  } catch {
+    throw new PmtHouseError('API key signer-session exchange returned invalid JSON', {
+      status: 502,
+      code: 'invalid_token_response',
+    });
+  }
+
+  if (!response.ok) {
+    const description =
+      typeof body.error_description === 'string'
+        ? body.error_description
+        : typeof body.error === 'string'
+          ? body.error
+          : `API key signer-session exchange failed (${response.status})`;
+    throw new PmtHouseError(description, {
+      status: response.status,
+      code: typeof body.error === 'string' ? body.error : 'signer_session_exchange_failed',
+      details: body,
+    });
+  }
+
+  const accessToken = readSignerAccessToken(body);
+  const expiresIn =
+    typeof body.expires_in === 'number' && Number.isFinite(body.expires_in) && body.expires_in > 0
+      ? Math.floor(body.expires_in)
+      : 300;
+  const scopeOut = typeof body.scope === 'string' && body.scope.trim() ? body.scope.trim() : scope;
+
+  return {
+    accessToken,
+    signerUrl: readSignerUrl(body),
+    expiresIn: Math.max(1, expiresIn),
+    scope: scopeOut,
+    tokenType: 'Bearer',
+  };
+}

--- a/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
+++ b/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
@@ -83,3 +83,32 @@ export function readApiKeyExchangeConfig() {
     publicClientId,
   };
 }
+
+/**
+ * Config for the NEW single-call signer-session exchange
+ * (`POST /api/v1/apps/{clientId}/auth/api-key/signer-session`).
+ *
+ * Sourced from the OPTIONAL `PYMTHOUSE_API_KEY` (`pmth_…`) plus the existing
+ * `PYMTHOUSE_PUBLIC_CLIENT_ID` and `PYMTHOUSE_ISSUER_URL`. Returns `null` when
+ * any of these is missing — which is the DEFAULT posture (the env var is unset),
+ * so callers fall back to today's per-user mint path with zero regression. The
+ * `billingUrl` is the issuer ORIGIN (the endpoint lives under `/api/v1/apps`,
+ * not the `/api/v1/oidc` issuer path). The API key value is never logged.
+ */
+export function readApiKeySignerSessionConfig(): {
+  billingUrl: string;
+  clientId: string;
+  apiKey: string;
+} | null {
+  const issuerUrl = normalizeHttpUrl(process.env.PYMTHOUSE_ISSUER_URL?.trim() ?? '');
+  const clientId = process.env.PYMTHOUSE_PUBLIC_CLIENT_ID?.trim();
+  const apiKey = process.env.PYMTHOUSE_API_KEY?.trim();
+  if (!issuerUrl || !clientId || !apiKey) {
+    return null;
+  }
+  return {
+    billingUrl: issuerOriginFromIssuerUrl(issuerUrl),
+    clientId,
+    apiKey,
+  };
+}

--- a/e2e-evidence/api-key-signer-session-probe.txt
+++ b/e2e-evidence/api-key-signer-session-probe.txt
@@ -1,0 +1,18 @@
+# Safe prod probe — POST /api/v1/apps/{clientId}/auth/api-key/signer-session
+# Date: 2026-06-30. No real credentials sent; confirms deployment only.
+# clientId = app_973064a2c025a2cc01ab8df6 (public, non-secret prod app id)
+
+=== POST (no auth, empty body) ===
+HTTP 401
+{"error":"invalid_request","error_description":"Authorization Bearer API key is required","correlation_id":"0407640a-57ac-4adb-89f3-9a16edba7eb2"}
+
+=== POST (bogus bearer "pmth_invalid_probe_only") ===
+HTTP 401
+{"error":"invalid_client","error_description":"invalid or revoked API key","correlation_id":"c7e561f5-251b-4152-a90a-c211628e2e25"}
+
+=== GET (method check) ===
+HTTP 405
+
+# Verdict: endpoint is DEPLOYED (401/405, not 404). Auth model = Authorization: Bearer <pmth_ api key>
+# (matches livepeer-gateway-client@30df477 exchange_api_key_for_signer). Error envelope uses
+# {error, error_description, correlation_id} — handled by exchangeApiKeyForSignerSession parsing.


### PR DESCRIPTION
## Summary

PymtHouse (John) relocated the signer **token-exchange** to a single authenticated endpoint and **removed the HTTP ingest route**. This adopts the new contract in NaaP, gated behind existing flags, with **zero regression when the flags/env are OFF**.

**New contract (authoritative reference: [`livepeer-gateway-client@30df477`](https://github.com/pymthouse/livepeer-gateway-client/commit/30df47797d72764d3d8f7195b3b9417c7c1e7451) `exchange_api_key_for_signer`):**
- `POST {issuerOrigin}/api/v1/apps/{clientId}/auth/api-key/signer-session`
- Auth: `Authorization: Bearer <pmth_… API key>`; `clientId` URL-encoded in the path; body `{ "scope": "sign:job" }`.
- Response envelope: `{ "token": { "accessToken": "<jwt>" }, "signerUrl": "<dmz>" }` (also accepts flat `accessToken` / `signer_url`). Returns the signer token **and** the DMZ url in one call — collapsing NaaP's old "mint user JWT → manual token-exchange" steps.

**Safe prod probe (no real credentials):** endpoint is **deployed** —
`POST` no-auth → `401 invalid_request "Authorization Bearer API key is required"`; bogus bearer → `401 invalid_client "invalid or revoked API key"`; `GET` → `405`. Evidence in `e2e-evidence/api-key-signer-session-probe.txt`.

## Changes
- `apps/web-next/src/lib/pymthouse-client.ts`: add `exchangeApiKeyForSignerSession()` + `PymthouseApiKeyExchangeConfig`/`ApiKeySignerSession` types. Faithful to the example client: Bearer api-key, scope body, URL-encoded clientId, nested+flat response parsing, 15s timeout, `{error,error_description}` surfacing.
- `apps/web-next/src/lib/pymthouse-signer-exchange-config.ts`: add `readApiKeySignerSessionConfig()` reading the **optional** `PYMTHOUSE_API_KEY` (+ existing `PYMTHOUSE_PUBLIC_CLIENT_ID` / `PYMTHOUSE_ISSUER_URL`). Unset by default → `null` → legacy path.
- `apps/web-next/src/lib/billing/pymthouse-adapter.ts`: `resolveSignerEndpoint` prefers the new single-call exchange when an `apiKeyExchange` option is injected or `PYMTHOUSE_API_KEY` is set; otherwise runs the legacy `getSignerRouting()` + user-JWT mint path byte-for-byte. Still gated behind the existing **`per_key_remote_signer`** flag at the `/keys/validate` front door.
- Unit tests for the exchange (8 cases) and both adapter branches (4 cases).

## Shim / ingest notes
- **Shim NOT removed (deliberate).** The opaque `mintSignerSession` shim (`exchangeUserJwtForOpaqueSignerSessionWith`) produces an **opaque** `pmth_…` session for the **default flag-OFF** path; the new endpoint returns a **JWT** and authenticates with an **app-level `pmth_` key (no `externalUserId`)**. Removing the shim would change the default token type and drop per-user attribution — a regression. See "Open question for John" below.
- **Ingest dependency confirmed gone.** NaaP makes no outbound call to `/internal/ingest/signed-ticket` (the only `ingest` references are NaaP's own inbound `/api/v1/metrics/ingest` BPP endpoint + usage libs). Usage stays on the pull path (`usage_pull`, `GET /apps/{clientId}/usage`).

## Verification
- `vitest run` (web-next): **1263 passed, 1 skipped** (127 files).
- `next lint` on changed files: clean.
- `tsc --noEmit`: **no new errors** (13 pre-existing errors on `main`, none in touched files).

## Open question for John (per-user attribution)
The `/auth/api-key/signer-session` endpoint authenticates with a `pmth_` **API key** and takes **no `externalUserId`** — so identity/usage attribute at the **key** level. NaaP is multi-tenant (per-NaaP-user `externalUserId`). For a **single-key demo** this PR works as-is (set `PYMTHOUSE_API_KEY` + `PYMTHOUSE_PUBLIC_CLIENT_ID`, flip `per_key_remote_signer`). For **multi-tenant**, please confirm either (a) per-account `pmth_` keys, or (b) the M2M `client_credentials` + `external_user_id` variant (the example client's `exchange_client_secret_for_signer`) is the intended per-user path. Also: the returned `token.accessToken` is documented/used as a JWT — please confirm it carries the DMZ webhook claims (`aud`=issuer, `scope ⊇ sign:job`, `sub`).

## Remaining finish-line steps (owner)
Per `PYMTHOUSE-PREREQS-FOR-JOHN.md`: (1) `BPP_VALIDATE_V2=1` on the prod app; (2) deploy a USD-priced canary orchestrator + SDK node and share its URL; (3) rebuild the signer image with go-livepeer #3966 + #3967; (4) provide the demo `pmth_` API key (or confirm the per-user mechanism above) + the prod M2M secret. No prod flags were flipped and nothing was merged to main here.

## Test plan
- [ ] Review the exchange request/response parsing vs `livepeer-gateway-client@30df477`.
- [ ] Confirm default-OFF posture: with `PYMTHOUSE_API_KEY` unset and `per_key_remote_signer` OFF, `/keys/validate` is byte-identical to today.
- [ ] (Owner) Provide a demo `pmth_` key + flip flags, then run a real signed generation.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin page to view and manage team-level feature flag overrides.
  * Added a new admin section for feature flags with team search and override controls.
  * Feature flag behavior is now team-aware across several team and billing flows.

* **Bug Fixes**
  * Improved consistency so team-specific settings no longer leak across teams.
  * Hidden endpoints now return a consistent not-found response when disabled, reducing probing signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->