### PR TITLE
feat(discovery): parameterized canary orchestrators in storyboard-default bundle

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/orchestrator-leaderboard/provider-restrictions', () => ({
 vi.mock('@/lib/orchestrator-leaderboard/storyboard-default-plan', () => ({
   STORYBOARD_DEFAULT_PLAN_ID: 'storyboard-default',
   isStoryboardDefaultDiscoveryEnabled: vi.fn().mockReturnValue(false),
+  resolveAllCanaryStaticOrchestrators: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock('@/lib/orchestrator-leaderboard/storyboard-default-discovery', () => ({

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/python-gateway/route.ts
@@ -28,6 +28,7 @@ import {
 } from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
 import {
   isStoryboardDefaultDiscoveryEnabled,
+  resolveAllCanaryStaticOrchestrators,
   STORYBOARD_DEFAULT_PLAN_ID,
 } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
 
@@ -103,6 +104,7 @@ async function handleStoryboardDefaultPlan(
     const { addresses, byKind, meta } = await buildStoryboardDefaultDiscovery({
       fetchCapabilityAddresses,
       billingProviderSlug,
+      canaryStaticOrchestrators: resolveAllCanaryStaticOrchestrators(),
     });
 
     console.info(

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.test.ts
@@ -11,9 +11,13 @@ vi.mock('@/lib/orchestrator-leaderboard/query', () => ({
 
 import { authorize } from '@/lib/gateway/authorize';
 import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
-import { STORYBOARD_DEFAULT_DISCOVERY_FLAG } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+import {
+  STORYBOARD_CANARY_ORCHESTRATOR_ENV,
+  STORYBOARD_DEFAULT_DISCOVERY_FLAG,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
 
 const FLAG = STORYBOARD_DEFAULT_DISCOVERY_FLAG;
+const CANARY = 'https://byoc-canary-1.daydream.monster:8935';
 
 function makeRequest(qs = '') {
   return new NextRequest(
@@ -46,11 +50,22 @@ describe('GET storyboard-default/python-gateway', () => {
     }));
   });
 
+  const prevCanary = {
+    byoc: process.env[STORYBOARD_CANARY_ORCHESTRATOR_ENV.byoc],
+    tool: process.env[STORYBOARD_CANARY_ORCHESTRATOR_ENV.tool],
+    scope: process.env[STORYBOARD_CANARY_ORCHESTRATOR_ENV.scope],
+  };
+
   afterEach(() => {
     if (prev === undefined) {
       delete process.env[FLAG];
     } else {
       process.env[FLAG] = prev;
+    }
+    for (const key of ['byoc', 'tool', 'scope'] as const) {
+      const name = STORYBOARD_CANARY_ORCHESTRATOR_ENV[key];
+      if (prevCanary[key] === undefined) delete process.env[name];
+      else process.env[name] = prevCanary[key];
     }
   });
 
@@ -83,5 +98,21 @@ describe('GET storyboard-default/python-gateway', () => {
     expect(addresses).toContain('https://orch-staging-3.daydream.monster:8935');
     expect(addresses).toContain('https://orch-staging-1.daydream.monster:8935');
     expect(addresses).toContain('https://byoc-staging-1.daydream.monster:8935');
+  });
+
+  it('surfaces the env-configured canary orchestrator across byoc + tool + scope', async () => {
+    process.env[FLAG] = 'true';
+    process.env[STORYBOARD_CANARY_ORCHESTRATOR_ENV.byoc] = CANARY;
+    process.env[STORYBOARD_CANARY_ORCHESTRATOR_ENV.tool] = CANARY;
+    process.env[STORYBOARD_CANARY_ORCHESTRATOR_ENV.scope] = CANARY;
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { address: string }[];
+    const addresses = body.map((o) => o.address);
+    expect(addresses).toContain(CANARY);
+    // De-duplicated even though configured for all three classes.
+    expect(addresses.filter((a) => a === CANARY)).toHaveLength(1);
   });
 });

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/python-gateway/route.ts
@@ -23,7 +23,10 @@ import {
   buildStoryboardDefaultDiscovery,
   type CapabilityFetchResult,
 } from '@/lib/orchestrator-leaderboard/storyboard-default-discovery';
-import { isStoryboardDefaultDiscoveryEnabled } from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
+import {
+  isStoryboardDefaultDiscoveryEnabled,
+  resolveAllCanaryStaticOrchestrators,
+} from '@/lib/orchestrator-leaderboard/storyboard-default-plan';
 import {
   isByocToolDiscoveryEnabled,
   resolveByocToolCapabilities,
@@ -74,10 +77,16 @@ export async function GET(request: NextRequest): Promise<Response> {
       ? await resolveByocToolCapabilities()
       : undefined;
 
+    // Parameterized canary seam: env-listed orchestrators (e.g. the deployed
+    // E2E-demo canary) join the static fleet per class without depending on the
+    // leaderboard dataset cron. Unset → {} → no change.
+    const canaryStaticOrchestrators = resolveAllCanaryStaticOrchestrators();
+
     const { addresses, byKind, meta } = await buildStoryboardDefaultDiscovery({
       fetchCapabilityAddresses,
       billingProviderSlug,
       categoryCapabilities,
+      canaryStaticOrchestrators,
     });
 
     const out = addresses.map((address) => ({ address }));

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-canary.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-canary.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Canary discovery seam — tests for the parameterized canary orchestrator
+ * injection and the cron-independent fail-safe added on top of the NAAP-9
+ * Storyboard Default bundle.
+ *
+ * Guarantees:
+ *  - With no canary env (the default) the bundle is byte-for-byte unchanged
+ *    (zero regression; the golden-set parity test still owns the baseline).
+ *  - When the per-class env vars are set, the canary orchestrator surfaces in
+ *    ALL THREE capability classes (scope + byoc + tool) it is configured for.
+ *  - A ClickHouse/leaderboard fetch failure degrades to the static fleet
+ *    (incl. the canary) instead of throwing — so the bundle does NOT depend on
+ *    the global leaderboard dataset cron.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildStoryboardDefaultDiscovery,
+  type CapabilityFetchResult,
+} from './storyboard-default-discovery';
+import {
+  resolveAllCanaryStaticOrchestrators,
+  resolveCanaryStaticOrchestrators,
+  STORYBOARD_CANARY_ORCHESTRATOR_ENV,
+} from './storyboard-default-plan';
+
+const CANARY = 'https://byoc-canary-1.daydream.monster:8935';
+
+/** Leaderboard mock: scope returns staging-1/2; everything else returns the BYOC host. */
+function fetchOk(): (cap: string) => Promise<CapabilityFetchResult> {
+  return async (cap: string): Promise<CapabilityFetchResult> => ({
+    addresses:
+      cap === 'scope'
+        ? [
+            'https://orch-staging-1.daydream.monster:8935',
+            'https://orch-staging-2.daydream.monster:8935',
+          ]
+        : ['https://byoc-staging-1.daydream.monster:8935'],
+    fromCache: true,
+    cachedAt: Date.now(),
+  });
+}
+
+describe('canary static-orchestrator injection', () => {
+  it('injects the canary into scope, byoc, and tool when configured for all three', async () => {
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: fetchOk(),
+      billingProviderSlug: 'daydream',
+      canaryStaticOrchestrators: { scope: [CANARY], byoc: [CANARY], tool: [CANARY] },
+    });
+
+    // Scope reports merged orchestrator addresses → canary present.
+    expect(result.byKind.scope).toContain(CANARY);
+    // The flattened payload (what python-gateway returns) contains the canary.
+    expect(result.addresses).toContain(CANARY);
+    // De-duplicated: the canary appears exactly once even though it was added
+    // to all three classes.
+    expect(result.addresses.filter((a) => a === CANARY)).toHaveLength(1);
+    // Baseline static hosts are still present.
+    expect(result.addresses).toContain('https://orch-staging-3.daydream.monster:8935');
+    expect(result.addresses).toContain('https://byoc-staging-1.daydream.monster:8935');
+  });
+
+  it('does NOT change the bundle when no canary orchestrators are supplied', async () => {
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: fetchOk(),
+      billingProviderSlug: 'daydream',
+    });
+    expect(result.addresses).not.toContain(CANARY);
+    expect(result.byKind.scope).toEqual([
+      'https://orch-staging-1.daydream.monster:8935',
+      'https://orch-staging-2.daydream.monster:8935',
+      'https://orch-staging-3.daydream.monster:8935',
+    ]);
+  });
+
+  it('does not inject the canary for a class whose capabilities are all denied', async () => {
+    // pymthouse denylist removes the daydream-only scope/byoc/tool caps, so no
+    // capability is allowed → no static fleet (and thus no canary) for any class.
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: fetchOk(),
+      billingProviderSlug: 'pymthouse',
+      canaryStaticOrchestrators: { scope: [CANARY], byoc: [CANARY], tool: [CANARY] },
+    });
+    expect(result.addresses).not.toContain(CANARY);
+  });
+});
+
+describe('cron-independent fail-safe', () => {
+  it('returns the static fleet (incl. canary) when the leaderboard fetch throws', async () => {
+    const throwingFetch = async (): Promise<CapabilityFetchResult> => {
+      throw new Error('ClickHouse query failed (503)');
+    };
+
+    const result = await buildStoryboardDefaultDiscovery({
+      fetchCapabilityAddresses: throwingFetch,
+      billingProviderSlug: 'daydream',
+      canaryStaticOrchestrators: { byoc: [CANARY], tool: [CANARY] },
+    });
+
+    // No throw, and the static fleet + canary are still served.
+    expect(result.addresses).toContain(CANARY);
+    expect(result.addresses).toContain('https://orch-staging-1.daydream.monster:8935');
+    expect(result.addresses).toContain('https://byoc-staging-1.daydream.monster:8935');
+  });
+});
+
+describe('env resolution', () => {
+  const KEYS = STORYBOARD_CANARY_ORCHESTRATOR_ENV;
+  const saved: Record<string, string | undefined> = {};
+
+  afterEach(() => {
+    for (const name of Object.values(KEYS)) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  });
+
+  function setEnv(name: string, value: string | undefined): void {
+    if (!(name in saved)) saved[name] = process.env[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+
+  it('defaults to empty when env is unset', () => {
+    setEnv(KEYS.byoc, undefined);
+    expect(resolveCanaryStaticOrchestrators('byoc')).toEqual([]);
+    expect(resolveAllCanaryStaticOrchestrators()).toEqual({});
+  });
+
+  it('parses a comma-separated list and trims blanks', () => {
+    setEnv(KEYS.byoc, ` ${CANARY} , , https://b.example:8935 `);
+    setEnv(KEYS.tool, CANARY);
+    expect(resolveCanaryStaticOrchestrators('byoc')).toEqual([
+      CANARY,
+      'https://b.example:8935',
+    ]);
+    expect(resolveAllCanaryStaticOrchestrators()).toEqual({
+      byoc: [CANARY, 'https://b.example:8935'],
+      tool: [CANARY],
+    });
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
@@ -73,6 +73,16 @@ export interface BuildStoryboardDefaultDiscoveryArgs {
    * hardcoded constants. `staticOrchestrators` always come from the plan.
    */
   categoryCapabilities?: Partial<Record<StoryboardDefaultCategoryKey, readonly string[]>>;
+  /**
+   * Extra static-fleet orchestrator URIs appended per category (e.g. a freshly
+   * deployed CANARY orchestrator surfaced via env — see
+   * `resolveAllCanaryStaticOrchestrators`). Omitted/empty → no change (zero
+   * regression / golden-set parity). These join the plan's `staticOrchestrators`
+   * and so are returned for their capability class even when ClickHouse has no
+   * warm rows yet — making the bundle independent of the leaderboard dataset
+   * cron for these addresses.
+   */
+  canaryStaticOrchestrators?: Partial<Record<StoryboardDefaultCategoryKey, readonly string[]>>;
 }
 
 /** Split a full cap path into the short leaderboard capability (after `/`). */
@@ -111,7 +121,20 @@ async function collectCategory(
     allowedCapabilities.push(raw);
 
     const leaderboardCap = leaderboardCapFromPath(raw);
-    const result = await fetchCapabilityAddresses(leaderboardCap);
+    // Fail-safe: a ClickHouse/leaderboard outage must NOT 500 the bundle. Treat
+    // a fetch error as "no warm rows" so the static fleet (incl. any canary
+    // orchestrator) is still returned — the bundle does not depend on the
+    // global leaderboard dataset cron being healthy.
+    let result: CapabilityFetchResult;
+    try {
+      result = await fetchCapabilityAddresses(leaderboardCap);
+    } catch (err) {
+      console.warn(
+        '[storyboard-default-discovery] capability fetch failed; falling back to static fleet',
+        JSON.stringify({ capability: leaderboardCap, error: err instanceof Error ? err.message : 'unknown' }),
+      );
+      result = { addresses: [], fromCache: false, cachedAt: Date.now() };
+    }
     fromCache = fromCache && result.fromCache;
     cacheAgeMs = Math.max(cacheAgeMs, Date.now() - result.cachedAt);
 
@@ -180,9 +203,13 @@ export async function buildStoryboardDefaultDiscovery(
     cacheAgeMs = Math.max(cacheAgeMs, collected.cacheAgeMs);
 
     // Respect the provider-scoped denylist: when filtering allows zero
-    // capabilities for this category, do not inject its static fleet.
+    // capabilities for this category, do not inject its static fleet (nor any
+    // canary additions — they are static-fleet members too).
+    const canaryFleet = args.canaryStaticOrchestrators?.[key] ?? [];
     const staticFleet =
-      collected.allowedCapabilities.length > 0 ? [...category.staticOrchestrators] : [];
+      collected.allowedCapabilities.length > 0
+        ? [...category.staticOrchestrators, ...canaryFleet]
+        : [];
     staticFleetInjected += staticFleetGaps(collected.discovered, staticFleet).length;
 
     const merged = mergeStaticFleet(collected.discovered, staticFleet);

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
@@ -121,3 +121,66 @@ export function isStoryboardDefaultDiscoveryEnabled(
   const raw = env[STORYBOARD_DEFAULT_DISCOVERY_FLAG]?.trim().toLowerCase();
   return raw === 'true' || raw === '1';
 }
+
+/**
+ * Per-category env vars that append EXTRA static-fleet orchestrator URIs to the
+ * Storyboard Default bundle (comma-separated). Default unset → empty → byte-for-
+ * byte-identical to today (golden-set parity preserved).
+ *
+ * Purpose: surface a freshly-deployed CANARY orchestrator in NaaP discovery
+ * WITHOUT waiting on the global leaderboard dataset cron. Because the static
+ * fleet is always merged into the bundle (and the live fetch is fail-safe — see
+ * `buildStoryboardDefaultDiscovery`), an address listed here is returned for its
+ * capability class even when ClickHouse has no warm rows for it yet. This is the
+ * "node's own DISCOVERY_URL" seam for the E2E demo.
+ *
+ * Fill in once the canary is deployed, e.g. (sdk/orch advertising byoc + tool):
+ *   STORYBOARD_CANARY_BYOC_ORCHESTRATORS=https://byoc-canary-1.daydream.monster:8935
+ *   STORYBOARD_CANARY_TOOL_ORCHESTRATORS=https://byoc-canary-1.daydream.monster:8935
+ *   STORYBOARD_CANARY_SCOPE_ORCHESTRATORS=  (leave empty unless the canary serves scope)
+ */
+export const STORYBOARD_CANARY_ORCHESTRATOR_ENV: Readonly<
+  Record<StoryboardDefaultCategoryKey, string>
+> = {
+  scope: 'STORYBOARD_CANARY_SCOPE_ORCHESTRATORS',
+  byoc: 'STORYBOARD_CANARY_BYOC_ORCHESTRATORS',
+  tool: 'STORYBOARD_CANARY_TOOL_ORCHESTRATORS',
+};
+
+/** Parse a comma/whitespace-separated env list of orchestrator URIs. */
+function parseOrchestratorList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the env-configured extra static-fleet orchestrators for one category.
+ * Returns `[]` when the env var is unset/blank (the zero-regression default).
+ */
+export function resolveCanaryStaticOrchestrators(
+  category: StoryboardDefaultCategoryKey,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  return parseOrchestratorList(env[STORYBOARD_CANARY_ORCHESTRATOR_ENV[category]]);
+}
+
+/**
+ * Resolve the env-configured canary orchestrators for every category. The
+ * result is a partial map (categories with no env override are omitted) so it
+ * can be passed straight into `buildStoryboardDefaultDiscovery`.
+ */
+export function resolveAllCanaryStaticOrchestrators(
+  env: NodeJS.ProcessEnv = process.env,
+): Partial<Record<StoryboardDefaultCategoryKey, string[]>> {
+  const out: Partial<Record<StoryboardDefaultCategoryKey, string[]>> = {};
+  for (const key of STORYBOARD_DEFAULT_CATEGORY_KEYS) {
+    const list = resolveCanaryStaticOrchestrators(key, env);
+    if (list.length > 0) {
+      out[key] = list;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Creates a **stable NaaP discovery URL** that returns the Storyboard orchestrator list spanning the three capability classes — **SCOPE + BYOC + TOOL** — and lets a freshly-deployed **canary orchestrator** be surfaced in that feed **without depending on the global leaderboard dataset cron** (the "node's own `DISCOVERY_URL`" approach for the E2E demo).

This is **additive, flag-safe, and zero-regression**: it reuses the existing NAAP-9 Storyboard Default bundle rather than inventing a parallel system.

### The discovery URL

```
GET /api/v1/orchestrator-leaderboard/storyboard-default/python-gateway
GET /api/v1/orchestrator-leaderboard/python-gateway?plan=storyboard-default
```

- Gated by env flag `STORYBOARD_DEFAULT_DISCOVERY_ENABLED` (default **OFF** → `404`, prod path unchanged).
- Auth: NaaP gateway key (`gw_…`)/master key/session, same as sibling discovery routes.
- Returns the python-gateway shape: a bare array `[{ "address": "<orchUri>" }, …]` covering scope + byoc + tool.

### What changed

- **`storyboard-default-plan.ts`** — new env vars `STORYBOARD_CANARY_{SCOPE,BYOC,TOOL}_ORCHESTRATORS` (comma-separated URIs) + resolvers. Unset/blank → `{}` → byte-for-byte identical to today (golden-set parity preserved).
- **`storyboard-default-discovery.ts`** — `canaryStaticOrchestrators` arg merged into each class's static fleet; the live leaderboard fetch is now **fail-safe** (a ClickHouse outage degrades to the static fleet instead of `500`), so the bundle no longer depends on the dataset cron being healthy.
- **python-gateway routes** — resolve the canary env and pass it through (both the dedicated `storyboard-default` route and the `?plan=storyboard-default` path).
- **Tests** — canary injection across all three classes, dedupe, provider-denylist behavior, cron-down fail-safe, and env parsing.

### Canary placeholder — fill in once the canary is deployed

```bash
# Per the simple-infra canary plan, byoc-canary-1 advertises byoc + tool caps:
STORYBOARD_CANARY_BYOC_ORCHESTRATORS=https://byoc-canary-1.daydream.monster:8935
STORYBOARD_CANARY_TOOL_ORCHESTRATORS=https://byoc-canary-1.daydream.monster:8935
STORYBOARD_CANARY_SCOPE_ORCHESTRATORS=   # leave empty unless the canary serves scope
STORYBOARD_DEFAULT_DISCOVERY_ENABLED=true
```

## Verified evidence (real route handler; only auth + ClickHouse query stubbed)

**Cron DOWN** (ClickHouse 503 for every capability) — endpoint still returns `200` with the canary present:

```
GET …/storyboard-default/python-gateway?billingProviderSlug=daydream  -> 200 (X-Discovery-Mode: storyboard-default)
[{"address":"https://orch-staging-2.daydream.monster:8935"},
 {"address":"https://orch-staging-1.daydream.monster:8935"},
 {"address":"https://orch-staging-3.daydream.monster:8935"},
 {"address":"https://byoc-canary-1.daydream.monster:8935"},
 {"address":"https://byoc-staging-1.daydream.monster:8935"}]
# log: served {scope:4, byocCaps:12, toolCaps:24, staticFleetInjected:8}
```

**Cron HEALTHY** (live rows + canary coexist):

```
[{"address":"https://orch-staging-1.daydream.monster:8935"},
 {"address":"https://orch-staging-2.daydream.monster:8935"},
 {"address":"https://byoc-canary-1.daydream.monster:8935"},
 {"address":"https://orch-staging-3.daydream.monster:8935"},
 {"address":"https://byoc-staging-1.daydream.monster:8935"}]
```

## Test plan

- [x] `npx vitest run src/lib/orchestrator-leaderboard src/app/api/v1/orchestrator-leaderboard` → **188 passed, 1 skipped**
- [x] Golden-set parity test green (no canary env → baseline unchanged)
- [x] No lint errors on changed files
- [ ] After canary deploy: set the env vars above on the demo team's NaaP env and re-run the GET to confirm `byoc-canary-1` appears.

## Demo wiring

- Canary SDK node `DISCOVERY_URL` → this endpoint (or `DISCOVERY_FROM_VALIDATE` via the per-key `discovery.url`).
- Demo team's key → Subscription → ProviderPlan → DiscoveryPlan binding unchanged; this feed is the static, cron-independent fallback the SDK node can rely on.

**Do not merge** — for review.

Made with [Cursor](https://cursor.com)