### PR TITLE
fix(start): sync npm deps on lockfile change and bump builder-sdk to 0.5.0

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.4.6",
+    "@pymthouse/builder-sdk": "0.5.0",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -104,16 +104,39 @@ preflight_check() {
     exit 1
   fi
 
-  # Auto-detect first run: no node_modules means fresh clone.
-  # All setup steps run inline — no separate setup.sh needed.
+  # Install or sync root dependencies when node_modules is absent, package-lock.json
+  # changed since the last install, or a declared workspace dep is missing.
+  # Covers fresh clones AND `git pull` adding new packages to an existing tree.
+  local needs_npm_install=false
+  local npm_install_reason=""
+  local was_fresh_clone=false
   if [ ! -d "$ROOT_DIR/node_modules" ]; then
-    echo ""
-    log_warn "node_modules not found — this looks like a fresh clone."
-    log_info "Running first-time setup automatically..."
-    echo ""
-    log_section "First-Time Setup"
+    needs_npm_install=true
+    was_fresh_clone=true
+    npm_install_reason="node_modules not found (fresh clone)"
+  elif [ ! -f "$ROOT_DIR/node_modules/.package-lock.json" ]; then
+    needs_npm_install=true
+    npm_install_reason="node_modules is incomplete (missing install marker)"
+  elif [ -f "$ROOT_DIR/package-lock.json" ] && \
+       [ "$ROOT_DIR/package-lock.json" -nt "$ROOT_DIR/node_modules/.package-lock.json" ]; then
+    needs_npm_install=true
+    npm_install_reason="package-lock.json changed since last install"
+  elif [ ! -d "$ROOT_DIR/node_modules/@pymthouse/builder-sdk" ]; then
+    needs_npm_install=true
+    npm_install_reason="@pymthouse/builder-sdk is missing from node_modules"
+  fi
 
-    # Step 1: Install dependencies
+  if [ "$needs_npm_install" = true ]; then
+    echo ""
+    if [ ! -d "$ROOT_DIR/node_modules" ]; then
+      log_warn "node_modules not found — this looks like a fresh clone."
+      log_info "Running first-time setup automatically..."
+    else
+      log_info "Syncing dependencies ($npm_install_reason)..."
+    fi
+    echo ""
+    log_section "Dependency Install"
+
     log_info "Installing dependencies (npm install)... This may take 1-2 minutes."
     cd "$ROOT_DIR" || { log_error "Cannot cd to project root"; exit 1; }
     npm_log="$LOG_DIR/npm-install.log"
@@ -127,13 +150,22 @@ preflight_check() {
     tail -5 "$npm_log"
     log_success "Dependencies installed"
 
-    # Step 2: Install git hooks (pre-push validation)
+  fi
+
+  # First-time git hooks (only when node_modules was just created).
+  if [ ! -d "$ROOT_DIR/.git/hooks" ] || [ ! -f "$ROOT_DIR/.git/hooks/pre-push" ]; then
     if [ -f "$SCRIPT_DIR/install-git-hooks.sh" ]; then
       bash "$SCRIPT_DIR/install-git-hooks.sh" 2>/dev/null && \
         log_success "Git hooks installed" || log_warn "Could not install git hooks"
     fi
+  fi
 
-    log_success "First-time setup complete. Continuing to start..."
+  if [ "$needs_npm_install" = true ]; then
+    if [ "$was_fresh_clone" = true ]; then
+      log_success "First-time setup complete. Continuing to start..."
+    else
+      log_success "Dependency sync complete. Continuing to start..."
+    fi
     echo ""
   fi
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -152,11 +152,14 @@ preflight_check() {
 
   fi
 
-  # First-time git hooks (only when node_modules was just created).
+  # Install git pre-push hook when absent (idempotent; independent of npm install).
   if [ ! -d "$ROOT_DIR/.git/hooks" ] || [ ! -f "$ROOT_DIR/.git/hooks/pre-push" ]; then
     if [ -f "$SCRIPT_DIR/install-git-hooks.sh" ]; then
-      bash "$SCRIPT_DIR/install-git-hooks.sh" 2>/dev/null && \
-        log_success "Git hooks installed" || log_warn "Could not install git hooks"
+      if bash "$SCRIPT_DIR/install-git-hooks.sh" 2>/dev/null; then
+        log_success "Git hooks installed"
+      else
+        log_warn "Could not install git hooks"
+      fi
     fi
   fi
 

--- a/docs/pymthouse-integration.md
+++ b/docs/pymthouse-integration.md
@@ -4,7 +4,7 @@ Official Builder API contract: [PymtHouse `docs/builder-api.md`](https://github.
 
 Server-to-server calls use the published npm package [`@pymthouse/builder-sdk`](https://www.npmjs.com/package/@pymthouse/builder-sdk) (source: [pymthouse/builder-sdk](https://github.com/pymthouse/builder-sdk)), wrapped in [apps/web-next/src/lib/pymthouse-client.ts](apps/web-next/src/lib/pymthouse-client.ts) with `import "server-only"` so M2M secrets never ship to the browser.
 
-**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **exact `0.4.3`** from the npm registry in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root, and re-verify billing/OIDC routes after any upgrade.
+**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **exact `0.5.0`** from the npm registry in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root (or `./bin/start.sh`, which syncs when `package-lock.json` changes), and re-verify billing/OIDC routes after any upgrade.
 
 ## Plan-builder data (PymtHouse → NaaP)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.4.6",
+        "@pymthouse/builder-sdk": "0.5.0",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -131,18 +131,6 @@
       "version": "7.4.2",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "apps/web-next/node_modules/@pymthouse/builder-sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
-      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
     },
     "apps/web-next/node_modules/@types/mime-types": {
       "version": "3.0.1",
@@ -8718,6 +8706,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@pymthouse/builder-sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.5.0.tgz",
+      "integrity": "sha512-Kn1bca6s5IybGlDhtQzz6kS+5tQUZhoLk8McAmK6YDItFCm2app1Yg6hMjEkb3lv+2f8bSpjkYb9p7qr7YASJw==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@remix-run/router": {
@@ -25303,7 +25303,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -31920,7 +31919,7 @@
         "@naap/database": "*",
         "@naap/plugin-server-sdk": "*",
         "@naap/types": "*",
-        "@pymthouse/builder-sdk": "0.4.6",
+        "@pymthouse/builder-sdk": "0.5.0",
         "cors": "^2.8.6",
         "dotenv": "^16.6.1",
         "express": "^4.21.0",
@@ -31933,18 +31932,6 @@
         "@types/uuid": "^10.0.0",
         "tsx": "^4.19.0",
         "typescript": "~5.9.3"
-      }
-    },
-    "plugins/developer-api/backend/node_modules/@pymthouse/builder-sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
-      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "plugins/developer-api/backend/node_modules/dotenv": {
@@ -31979,7 +31966,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.4.6",
+        "@pymthouse/builder-sdk": "0.5.0",
         "framer-motion": "^12.0.0",
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",
@@ -31999,18 +31986,6 @@
       },
       "engines": {
         "node": ">=20.19.0 || >=22.12.0"
-      }
-    },
-    "plugins/developer-api/frontend/node_modules/@pymthouse/builder-sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.4.6.tgz",
-      "integrity": "sha512-o00iwt4n+5mORHldio/NtDmr05YugFbj7x4Wi73IcybDJRfaHbGjGqde9BbdShljPeP5WgHUhREPopLjpJr7Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "plugins/lightning-client/backend": {
@@ -32475,6 +32450,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32492,6 +32468,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32509,6 +32486,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32526,6 +32504,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32543,6 +32522,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32560,6 +32540,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32577,6 +32558,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32594,6 +32576,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32611,6 +32594,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32628,6 +32612,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32645,6 +32630,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32662,6 +32648,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32679,6 +32666,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32696,6 +32684,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32713,6 +32702,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32730,6 +32720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32747,6 +32738,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32764,6 +32756,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32781,6 +32774,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32798,6 +32792,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32815,6 +32810,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32832,6 +32828,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32849,6 +32846,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32866,6 +32864,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32883,6 +32882,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32900,6 +32900,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32960,6 +32961,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -33076,6 +33078,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/plugins/developer-api/backend/package.json
+++ b/plugins/developer-api/backend/package.json
@@ -12,7 +12,7 @@
     "@naap/database": "*",
     "@naap/plugin-server-sdk": "*",
     "@naap/types": "*",
-    "@pymthouse/builder-sdk": "0.4.6",
+    "@pymthouse/builder-sdk": "0.5.0",
     "cors": "^2.8.6",
     "dotenv": "^16.6.1",
     "express": "^4.21.0",

--- a/plugins/developer-api/frontend/package.json
+++ b/plugins/developer-api/frontend/package.json
@@ -17,7 +17,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.4.6",
+    "@pymthouse/builder-sdk": "0.5.0",
     "framer-motion": "^12.0.0",
     "lucide-react": "^0.575.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- `./bin/start.sh` now re-runs `npm install` when `package-lock.json` is newer than the last install, `node_modules` is incomplete, or `@pymthouse/builder-sdk` is missing — fixing the case where an existing `node_modules` tree leaves newly declared registry deps unresolved after `git pull`.
- Pins `@pymthouse/builder-sdk` at **0.5.0** ([release notes](https://github.com/pymthouse/builder-sdk/releases/tag/v0.5.0)) across `apps/web-next` and `plugins/developer-api/*`.
- Updates `docs/pymthouse-integration.md` to reflect the new pin and install behavior.

## Root cause
`start.sh` only ran `npm install` when `node_modules/` was entirely absent. Developers who already had a partial install (or pulled after `@pymthouse/builder-sdk` was added) hit `Module not found: Can't resolve '@pymthouse/builder-sdk'` on Next.js build even when running `./bin/start.sh --all`.

## Test plan
- [x] `npm install` resolves `@pymthouse/builder-sdk@0.5.0` at repo root
- [x] `apps/web-next` pymthouse unit tests pass (`pymthouse-client.test.ts`, `pymthouse-adapter.test.ts`)
- [x] Fresh clone / stale `node_modules`: run `./bin/start.sh --all` and confirm dependency sync runs when lockfile changes
- [x] Verify billing/OIDC routes against PymtHouse after SDK bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup checks so dependency installation/sync runs reliably when the install state is stale or incomplete.
  * Refined setup messaging to clearly distinguish first-time setup from dependency sync.

* **Chores**
  * Updated the builder SDK dependency to version `0.5.0` across the app and related plugins.
  * Adjusted git hook installation to be more robust and run only when needed.

* **Documentation**
  * Updated the integration documentation to reflect the `0.5.0` dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->