### PR TITLE
fix(serverless-proxy): accept HTTP 202 from fal training status polls

### DIFF
--- a/containers/livepeer-serverless-proxy/src/serverless_proxy/providers/fal_ai.py
+++ b/containers/livepeer-serverless-proxy/src/serverless_proxy/providers/fal_ai.py
@@ -258,7 +258,9 @@ class FalAiProvider(InferenceProvider):
                 status_url, headers=headers,
                 timeout=aiohttp.ClientTimeout(total=15),
             ) as resp:
-                if resp.status != 200:
+                # fal queue returns 202 while a training job is still running;
+                # treating 202 as failure caused every LoRA run to die ~10s in.
+                if resp.status not in (200, 202):
                     text = await resp.text()
                     return {
                         "status": "FAILED",
@@ -279,7 +281,7 @@ class FalAiProvider(InferenceProvider):
                 response_url, headers=headers,
                 timeout=aiohttp.ClientTimeout(total=15),
             ) as resp:
-                if resp.status == 200:
+                if resp.status in (200, 202):
                     result = await resp.json()
                     return {"status": "COMPLETED", **result}
         except (asyncio.TimeoutError, aiohttp.ClientError):

--- a/containers/livepeer-serverless-proxy/tests/test_training.py
+++ b/containers/livepeer-serverless-proxy/tests/test_training.py
@@ -134,6 +134,22 @@ async def test_p5_fal_train_status_passes_through_in_progress():
 
 
 @pytest.mark.asyncio
+async def test_p5_fal_train_status_accepts_http_202_in_progress():
+    """fal queue returns HTTP 202 while training runs — must not surface as FAILED."""
+    provider = FalAiProvider(api_key="test-key")
+    in_progress = FakeResponse(202, {"status": "IN_PROGRESS", "logs": []})
+    session = FakeSession(get_responses=[in_progress])
+
+    result = await provider.train_status(
+        "fal-ai/flux-lora-fast-training", "req-202", session,
+    )
+
+    assert result["status"] == "IN_PROGRESS"
+    assert "error" not in result
+    assert len(session.get_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_p5_fal_train_status_fetches_result_on_completion():
     """train_status on COMPLETED fetches the full response envelope."""
     provider = FalAiProvider(api_key="test-key")


### PR DESCRIPTION
Fixes LoRA training failing with status check returned 202. train_status accepts HTTP 200 and 202. 16/16 tests pass. Production VM patch verified.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training status checks for queued or in-progress jobs, so they are no longer treated as failures when the service returns a valid “in progress” response.
  * Better handling of result retrieval for jobs that are still completing, reducing false error states during polling.
  * Added coverage for queued job responses to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->