### PR TITLE
fix(pymthouse): emit composite app.pmth_ bearer for DMZ signer

### DIFF
--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -306,6 +306,40 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
     expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
   });
 
+  it('bare pmth_ key does NOT require signer routing (regression: exchange supplies its own url)', async () => {
+    // Regression guard: the bare-key exchange path must not call
+    // getSignerRouting() nor be gated on it. Even when routing would expose NO
+    // DMZ url, a bare pmth_ key still resolves via the exchange's own signerUrl.
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: '', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
+    });
+    exchangeApiKeyForSignerSession.mockResolvedValue({
+      accessToken: 'eyJhbGciOiJSUzI1NiJ9.signer.sig',
+      signerUrl: 'https://signer-dmz.pymthouse.com',
+      expiresIn: 900,
+      scope: 'sign:job',
+      tokenType: 'Bearer',
+    });
+    const a = new PymthouseAdapter({
+      apiKeyExchange: { billingUrl: 'https://pymthouse.com', clientId: 'app_x', apiKey: 'pmth_bare_key' },
+    });
+
+    const ep = await a.resolveSignerEndpoint(TOKEN, CTX);
+
+    expect(getSignerRouting).not.toHaveBeenCalled();
+    expect(exchangeApiKeyForSignerSession).toHaveBeenCalledWith({
+      billingUrl: 'https://pymthouse.com',
+      clientId: 'app_x',
+      apiKey: 'pmth_bare_key',
+    });
+    expect(ep).toEqual({
+      url: 'https://signer-dmz.pymthouse.com',
+      headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.signer.sig' },
+    });
+  });
+
   it('composite apiKeyExchange forwards the key directly (no exchange hop)', async () => {
     getSignerRouting.mockResolvedValue({
       clientId: 'app_x',

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -8,6 +8,7 @@ const getUserSubscription = vi.fn();
 const listBillingProducts = vi.fn();
 const getSignerRouting = vi.fn();
 const mintUserSignerJwtForExternalUser = vi.fn();
+const createPymthouseApiKey = vi.fn();
 const globalSignerExchangeConfig = vi.fn();
 const exchangeApiKeyForSignerSession = vi.fn();
 
@@ -22,6 +23,10 @@ vi.mock('@/lib/pymthouse-client', () => ({
   globalSignerExchangeConfig: () => globalSignerExchangeConfig(),
   mintUserSignerJwtForExternalUser: (input: unknown) => mintUserSignerJwtForExternalUser(input),
   exchangeApiKeyForSignerSession: (input: unknown) => exchangeApiKeyForSignerSession(input),
+}));
+
+vi.mock('@/lib/pymthouse-keys-bff', () => ({
+  createPymthouseApiKey: (input: unknown) => createPymthouseApiKey(input),
 }));
 
 // Default: no global PYMTHOUSE_API_KEY → legacy per-user mint path (zero
@@ -59,10 +64,17 @@ beforeEach(() => {
     m2mClientId: 'm2m_test',
     m2mClientSecret: 'secret_test',
   });
-  mintUserSignerJwtForExternalUser.mockResolvedValue({
-    jwt: 'eyJhbGciOiJSUzI1NiJ9.user-signer-jwt.sig',
-    expiresIn: 900,
-    scope: 'sign:job',
+  createPymthouseApiKey.mockResolvedValue({
+    apiKey: 'app_testclient.pmth_composite_key_secret',
+    row: {
+      id: 'key-1',
+      label: 'naap-validate-signer',
+      prefix: 'app_test',
+      suffix: 'cret',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      revokedAt: null,
+    },
   });
   adapter = new PymthouseAdapter();
 });
@@ -147,13 +159,11 @@ describe('PymthouseAdapter per-instance client (P0, zero regression)', () => {
   });
 });
 
-describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JWT)', () => {
-  // The opaque session is intentionally IGNORED for the bearer now — the DMZ
-  // webhook is OIDC/JWT-only, so we mint + forward a user-scoped signer JWT.
+describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, composite API key)', () => {
   const TOKEN = { accessToken: 'pmth_abc123', tokenType: 'Bearer', expiresIn: 3600, scope: 'sign:job' };
   const CTX = { externalUserId: 'acct_user_42' };
 
-  it('mints a user signer JWT and forwards it as the Bearer (NOT the opaque pmth_)', async () => {
+  it('mints a composite app.pmth_ key and forwards it as the Bearer', async () => {
     getSignerRouting.mockResolvedValue({
       clientId: 'app_x',
       routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
@@ -165,21 +175,18 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
 
     const ep = await adapter.resolveSignerEndpoint(TOKEN, CTX);
     expect(getSignerRouting).toHaveBeenCalledTimes(1);
-    // The JWT is minted against this adapter's client (the global-env singleton
-    // here) + the key's account id as the externalUserId.
-    expect(mintUserSignerJwtForExternalUser).toHaveBeenCalledWith({
-      client: expect.objectContaining({ getSignerRouting }),
+    expect(createPymthouseApiKey).toHaveBeenCalledWith({
       externalUserId: 'acct_user_42',
+      label: 'naap-validate-signer',
     });
     expect(ep).toEqual({
       url: 'https://signer-dmz.pymthouse.com',
-      headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.user-signer-jwt.sig' },
+      headers: { Authorization: 'Bearer app_testclient.pmth_composite_key_secret' },
     });
-    // The opaque session token must never leak into the forwarded header.
-    expect(ep.headers.Authorization).not.toContain('pmth_');
+    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
   });
 
-  it('uses the per-instance signer exchange config when one is injected', async () => {
+  it('uses the per-instance client routing when one is injected', async () => {
     const instanceClient = { getSignerRouting } as never;
     const instanceExchange = {
       issuerUrl: 'https://tenant.pymthouse.com/api/v1/oidc',
@@ -198,13 +205,10 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
     });
 
     await a.resolveSignerEndpoint(TOKEN, CTX);
-    // The mint binds to the injected per-instance client (whose app the DMZ
-    // routing was resolved against), never the global-env singleton.
-    expect(mintUserSignerJwtForExternalUser).toHaveBeenCalledWith({
-      client: instanceClient,
+    expect(createPymthouseApiKey).toHaveBeenCalledWith({
       externalUserId: 'acct_user_42',
+      label: 'naap-validate-signer',
     });
-    // The global env exchange config is NOT consulted for a per-instance adapter.
     expect(globalSignerExchangeConfig).not.toHaveBeenCalled();
   });
 
@@ -227,7 +231,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
     });
 
     await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow(/no remote signer DMZ url/);
-    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
   });
 
   it('rejects a dashboard /api/signer proxy base (must target the DMZ directly)', async () => {
@@ -238,10 +242,10 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
     });
 
     await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow();
-    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
   });
 
-  it('throws when no externalUserId is provided (cannot mint a user-scoped JWT)', async () => {
+  it('throws when no externalUserId is provided (cannot mint a composite key)', async () => {
     getSignerRouting.mockResolvedValue({
       clientId: 'app_x',
       routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
@@ -249,7 +253,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
     });
 
     await expect(adapter.resolveSignerEndpoint(TOKEN)).rejects.toThrow(/externalUserId/);
-    expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
   });
 
   it('propagates a mint error so the front door fails safe to the token bundle', async () => {
@@ -258,7 +262,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, user JW
       routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
       patterns: { directDmz: { description: '', signerApiUrl: '', webhookUrl: '' }, deprecatedHostedFacade: { description: '', signerApiUrl: null } },
     });
-    mintUserSignerJwtForExternalUser.mockRejectedValue(new Error('mint failed'));
+    createPymthouseApiKey.mockRejectedValue(new Error('mint failed'));
 
     await expect(adapter.resolveSignerEndpoint(TOKEN, CTX)).rejects.toThrow('mint failed');
   });
@@ -268,7 +272,15 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
   const TOKEN = { accessToken: 'pmth_abc123', tokenType: 'Bearer', expiresIn: 3600, scope: 'sign:job' };
   const CTX = { externalUserId: 'acct_user_42' };
 
-  it('explicit apiKeyExchange option → single-call exchange supplies url + bearer (no routing/mint)', async () => {
+  it('explicit apiKeyExchange with bare pmth_ key → exchange supplies url + bearer', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: {
+        directDmz: { description: '', signerApiUrl: 'https://signer-dmz.pymthouse.com', webhookUrl: 'https://hook' },
+        deprecatedHostedFacade: { description: '', signerApiUrl: null },
+      },
+    });
     exchangeApiKeyForSignerSession.mockResolvedValue({
       accessToken: 'eyJhbGciOiJSUzI1NiJ9.signer.sig',
       signerUrl: 'https://signer-dmz.pymthouse.com',
@@ -291,9 +303,33 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
       url: 'https://signer-dmz.pymthouse.com',
       headers: { Authorization: 'Bearer eyJhbGciOiJSUzI1NiJ9.signer.sig' },
     });
-    // The legacy routing + user-JWT mint path is bypassed entirely.
-    expect(getSignerRouting).not.toHaveBeenCalled();
     expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
+  });
+
+  it('composite apiKeyExchange forwards the key directly (no exchange hop)', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: {
+        directDmz: { description: '', signerApiUrl: 'https://signer-dmz.pymthouse.com', webhookUrl: 'https://hook' },
+        deprecatedHostedFacade: { description: '', signerApiUrl: null },
+      },
+    });
+    const a = new PymthouseAdapter({
+      apiKeyExchange: {
+        billingUrl: 'https://pymthouse.com',
+        clientId: 'app_x',
+        apiKey: 'app_x.pmth_composite_secret',
+      },
+    });
+
+    const ep = await a.resolveSignerEndpoint(TOKEN, CTX);
+
+    expect(exchangeApiKeyForSignerSession).not.toHaveBeenCalled();
+    expect(ep).toEqual({
+      url: 'https://signer-dmz.pymthouse.com',
+      headers: { Authorization: 'Bearer app_x.pmth_composite_secret' },
+    });
   });
 
   it('global PYMTHOUSE_API_KEY env config is used when no explicit option is injected', async () => {
@@ -302,6 +338,14 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
       clientId: 'app_env',
       apiKey: 'pmth_env_key',
     } as never);
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_env',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: {
+        directDmz: { description: '', signerApiUrl: 'https://signer-dmz.pymthouse.com', webhookUrl: '' },
+        deprecatedHostedFacade: { description: '', signerApiUrl: null },
+      },
+    });
     exchangeApiKeyForSignerSession.mockResolvedValue({
       accessToken: 'env.signer.jwt',
       signerUrl: 'https://signer-dmz.pymthouse.com',
@@ -318,7 +362,6 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
       apiKey: 'pmth_env_key',
     });
     expect(ep.url).toBe('https://signer-dmz.pymthouse.com');
-    expect(getSignerRouting).not.toHaveBeenCalled();
   });
 
   it('per-instance adapter (injected client) does NOT fall back to the global PYMTHOUSE_API_KEY env', async () => {
@@ -339,11 +382,19 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
     expect(readApiKeySignerSessionConfig).not.toHaveBeenCalled();
     expect(exchangeApiKeyForSignerSession).not.toHaveBeenCalled();
     expect(getSignerRouting).toHaveBeenCalledTimes(1);
-    expect(mintUserSignerJwtForExternalUser).toHaveBeenCalled();
+    expect(createPymthouseApiKey).toHaveBeenCalled();
     expect(ep.url).toBe('https://dmz.tenant.com');
   });
 
   it('throws when the exchange returns no signerUrl (front door fails safe)', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://signer-dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: {
+        directDmz: { description: '', signerApiUrl: 'https://signer-dmz.pymthouse.com', webhookUrl: '' },
+        deprecatedHostedFacade: { description: '', signerApiUrl: null },
+      },
+    });
     exchangeApiKeyForSignerSession.mockResolvedValue({
       accessToken: 'jwt', signerUrl: null, expiresIn: 900, scope: 'sign:job', tokenType: 'Bearer',
     });
@@ -354,6 +405,14 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
   });
 
   it('rejects a dashboard /api/signer proxy base returned by the exchange', async () => {
+    getSignerRouting.mockResolvedValue({
+      clientId: 'app_x',
+      routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: 'https://signer-dmz.pymthouse.com', jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
+      patterns: {
+        directDmz: { description: '', signerApiUrl: 'https://signer-dmz.pymthouse.com', webhookUrl: '' },
+        deprecatedHostedFacade: { description: '', signerApiUrl: null },
+      },
+    });
     exchangeApiKeyForSignerSession.mockResolvedValue({
       accessToken: 'jwt',
       signerUrl: 'https://dashboard.pymthouse.com/api/signer',

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -316,21 +316,15 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     const apiKeyCfg =
       this.apiKeyExchange ?? (this.clientOverride ? undefined : readApiKeySignerSessionConfig());
     if (apiKeyCfg) {
-      const routing = await this.client().getSignerRouting();
-      const url =
-        routing.patterns?.directDmz?.signerApiUrl ||
-        routing.routing?.remoteDmzUrl ||
-        routing.routing?.signerApiUrl ||
-        '';
-      if (!url) {
-        throw new Error('pymthouse signer routing returned no remote signer DMZ url');
-      }
-      assertDirectSignerBaseUrl(url);
-
       const apiKey = apiKeyCfg.apiKey.trim();
       // PR #210 composite keys (`app_XXX.pmth_YYY`) authenticate the DMZ
-      // directly — no signer-session exchange hop.
+      // directly — no signer-session exchange hop. ONLY this path needs
+      // `getSignerRouting()` to discover the DMZ url. A bare `pmth_…` key gets
+      // its url from `exchangeApiKeyForSignerSession()` below and must NOT be
+      // gated on signer routing (which it never needed) — doing so regressed
+      // bare-key callers with a spurious "no remote signer DMZ url" throw.
       if (apiKey.includes('.pmth_')) {
+        const url = this.resolveDmzUrl(await this.client().getSignerRouting());
         return {
           url,
           headers: { Authorization: `Bearer ${apiKey}` },
@@ -349,16 +343,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
       };
     }
 
-    const routing = await this.client().getSignerRouting();
-    const url =
-      routing.patterns?.directDmz?.signerApiUrl ||
-      routing.routing?.remoteDmzUrl ||
-      routing.routing?.signerApiUrl ||
-      '';
-    if (!url) {
-      throw new Error('pymthouse signer routing returned no remote signer DMZ url');
-    }
-    assertDirectSignerBaseUrl(url);
+    const url = this.resolveDmzUrl(await this.client().getSignerRouting());
 
     const externalUserId = context?.externalUserId;
     if (!externalUserId) {
@@ -366,6 +351,13 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     }
 
     // PR #210: DMZ expects composite `app_XXX.pmth_YYY` bearer, not user JWT.
+    // NOTE (follow-up): this legacy fallback mints a fresh long-lived key per
+    // resolution. It is only reached when neither an injected `apiKeyExchange`
+    // nor a global `PYMTHOUSE_API_KEY` composite key is configured (prod uses
+    // the composite fast-path above and never mints here). Key reuse/TTL/revoke
+    // is deferred: the Builder Apps API returns the full secret ONLY at creation
+    // (no list-returns-secret), so reuse needs new persistent secret storage +
+    // rotation — tracked as a follow-up rather than mixed into this PR.
     const { apiKey } = await createPymthouseApiKey({
       externalUserId,
       label: 'naap-validate-signer',
@@ -375,6 +367,28 @@ export class PymthouseAdapter implements BillingProviderAdapter {
       url,
       headers: { Authorization: `Bearer ${apiKey}` },
     };
+  }
+
+  /**
+   * Extract the direct-DMZ signer API url from a `getSignerRouting()` result and
+   * validate it. Prefers `patterns.directDmz.signerApiUrl`, then
+   * `routing.remoteDmzUrl`, then `routing.signerApiUrl`. Throws when none is
+   * present (so the front door can fail safe to the token-bundle form) and
+   * rejects dashboard `/api/signer` proxy bases via `assertDirectSignerBaseUrl`.
+   */
+  private resolveDmzUrl(
+    routing: Awaited<ReturnType<PmtHouseClient['getSignerRouting']>>,
+  ): string {
+    const url =
+      routing.patterns?.directDmz?.signerApiUrl ||
+      routing.routing?.remoteDmzUrl ||
+      routing.routing?.signerApiUrl ||
+      '';
+    if (!url) {
+      throw new Error('pymthouse signer routing returned no remote signer DMZ url');
+    }
+    assertDirectSignerBaseUrl(url);
+    return url;
   }
 
   async receiveCuratedOrchestrators(

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -20,10 +20,10 @@ import {
   getPmtHouseServerClient,
   mintOpaqueSignerSessionForExternalUser,
   mintSignerSessionForExternalUser,
-  mintUserSignerJwtForExternalUser,
   type PymthouseApiKeyExchangeConfig,
   type PymthouseSignerExchangeConfig,
 } from '@/lib/pymthouse-client';
+import { createPymthouseApiKey } from '@/lib/pymthouse-keys-bff';
 import { readApiKeySignerSessionConfig } from '@/lib/pymthouse-signer-exchange-config';
 import { isFeatureEnabled, PYMTHOUSE_BPP_VALIDATE_FLAG } from '@/lib/feature-flags';
 import { resolvePymthouseCapabilities } from './pymthouse-capabilities';
@@ -316,16 +316,35 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     const apiKeyCfg =
       this.apiKeyExchange ?? (this.clientOverride ? undefined : readApiKeySignerSessionConfig());
     if (apiKeyCfg) {
-      const session = await exchangeApiKeyForSignerSession(apiKeyCfg);
-      const url = session.signerUrl;
+      const routing = await this.client().getSignerRouting();
+      const url =
+        routing.patterns?.directDmz?.signerApiUrl ||
+        routing.routing?.remoteDmzUrl ||
+        routing.routing?.signerApiUrl ||
+        '';
       if (!url) {
+        throw new Error('pymthouse signer routing returned no remote signer DMZ url');
+      }
+      assertDirectSignerBaseUrl(url);
+
+      const apiKey = apiKeyCfg.apiKey.trim();
+      // PR #210 composite keys (`app_XXX.pmth_YYY`) authenticate the DMZ
+      // directly — no signer-session exchange hop.
+      if (apiKey.includes('.pmth_')) {
+        return {
+          url,
+          headers: { Authorization: `Bearer ${apiKey}` },
+        };
+      }
+
+      const session = await exchangeApiKeyForSignerSession(apiKeyCfg);
+      const exchangeUrl = session.signerUrl;
+      if (!exchangeUrl) {
         throw new Error('pymthouse api-key signer-session returned no signerUrl');
       }
-      // Reject dashboard `/api/signer/*` proxy bases — signing RPCs must target
-      // the remote-signer DMZ origin directly (builder-sdk 0.4.6).
-      assertDirectSignerBaseUrl(url);
+      assertDirectSignerBaseUrl(exchangeUrl);
       return {
-        url,
+        url: exchangeUrl,
         headers: { Authorization: `Bearer ${session.accessToken}` },
       };
     }
@@ -339,26 +358,22 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     if (!url) {
       throw new Error('pymthouse signer routing returned no remote signer DMZ url');
     }
-    // Reject dashboard `/api/signer/*` proxy bases — signing RPCs must target
-    // the remote-signer DMZ origin directly (builder-sdk 0.4.6).
     assertDirectSignerBaseUrl(url);
 
     const externalUserId = context?.externalUserId;
     if (!externalUserId) {
-      throw new Error('resolveSignerEndpoint requires externalUserId to mint the user signer JWT');
+      throw new Error('resolveSignerEndpoint requires externalUserId to mint the signer bearer');
     }
 
-    // Mint the Builder user-token JWT against THIS adapter's client (the
-    // per-instance client in subscription mode, else the global-env singleton),
-    // so the JWT's `client_id` matches the app whose DMZ we resolved above.
-    const { jwt } = await mintUserSignerJwtForExternalUser({
-      client: this.client(),
+    // PR #210: DMZ expects composite `app_XXX.pmth_YYY` bearer, not user JWT.
+    const { apiKey } = await createPymthouseApiKey({
       externalUserId,
+      label: 'naap-validate-signer',
     });
 
     return {
       url,
-      headers: { Authorization: `Bearer ${jwt}` },
+      headers: { Authorization: `Bearer ${apiKey}` },
     };
   }
 

--- a/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
+++ b/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
@@ -88,8 +88,8 @@ export function readApiKeyExchangeConfig() {
  * Config for the NEW single-call signer-session exchange
  * (`POST /api/v1/apps/{clientId}/auth/api-key/signer-session`).
  *
- * Sourced from the OPTIONAL `PYMTHOUSE_API_KEY` (`pmth_…`) plus the existing
- * `PYMTHOUSE_PUBLIC_CLIENT_ID` and `PYMTHOUSE_ISSUER_URL`. Returns `null` when
+ * Sourced from the OPTIONAL `PYMTHOUSE_API_KEY` (composite `app_XXX.pmth_YYY` or bare
+ * `pmth_…`) plus the existing `PYMTHOUSE_PUBLIC_CLIENT_ID` and `PYMTHOUSE_ISSUER_URL`.
  * any of these is missing — which is the DEFAULT posture (the env var is unset),
  * so callers fall back to today's per-user mint path with zero regression. The
  * `billingUrl` is the issuer ORIGIN (the endpoint lives under `/api/v1/apps`,


### PR DESCRIPTION
## Summary
- Replace legacy user-JWT forward in `resolveSignerEndpoint` with composite `app_XXX.pmth_YYY` keys (PR #210 DMZ contract).
- Forward composite `PYMTHOUSE_API_KEY` values directly to the DMZ (skip broken signer-session exchange for composite format).
- Bare `pmth_` keys still use the existing api-key signer-session exchange path.

## Test plan
- [x] `pymthouse-adapter.test.ts` (23 tests)
- [x] Prod validate: `signerSession.headers.Authorization` is `Bearer app_98575870….pmth_…` (not JWT)
- [ ] Billed generation E2E — blocked on DMZ `IncompleteRead(85,108)` (John)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved signer session handling for billing requests, including support for composite API keys and direct bearer-token forwarding when appropriate.
  * Updated fallback signer authentication to use a new API-key-based flow.

* **Bug Fixes**
  * Fixed handling of signer endpoint resolution so the correct authorization token is sent in each exchange scenario.
  * Expanded support for accepted API key formats in configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->