### PR TITLE
feat(pymthouse): builder-sdk 0.6.0 and RFC 8693 API key exchange

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.5.0",
+    "@pymthouse/builder-sdk": "file:../../../builder-sdk",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "file:../../../builder-sdk",
+    "@pymthouse/builder-sdk": "0.6.0",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.test.ts
@@ -65,11 +65,11 @@ beforeEach(() => {
     m2mClientSecret: 'secret_test',
   });
   createPymthouseApiKey.mockResolvedValue({
-    apiKey: 'app_testclient.pmth_composite_key_secret',
+    apiKey: 'app_3b386c81a1db1169fd2c3986_pmth_composite_key_secret',
     row: {
       id: 'key-1',
       label: 'naap-validate-signer',
-      prefix: 'app_test',
+      prefix: 'app_3b38',
       suffix: 'cret',
       status: 'active',
       createdAt: '2026-01-01T00:00:00.000Z',
@@ -163,7 +163,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, composi
   const TOKEN = { accessToken: 'pmth_abc123', tokenType: 'Bearer', expiresIn: 3600, scope: 'sign:job' };
   const CTX = { externalUserId: 'acct_user_42' };
 
-  it('mints a composite app.pmth_ key and forwards it as the Bearer', async () => {
+  it('mints a composite app_<24hex>_ key and forwards it as the Bearer', async () => {
     getSignerRouting.mockResolvedValue({
       clientId: 'app_x',
       routing: { signerApiUrl: 'https://api.pymthouse.com', remoteDmzUrl: null, jwksUri: 'j', identityMode: 'jwt', meteringMode: 'platform_ingest' },
@@ -181,7 +181,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (per-key remote signer, composi
     });
     expect(ep).toEqual({
       url: 'https://signer-dmz.pymthouse.com',
-      headers: { Authorization: 'Bearer app_testclient.pmth_composite_key_secret' },
+      headers: { Authorization: 'Bearer app_3b386c81a1db1169fd2c3986_pmth_composite_key_secret' },
     });
     expect(mintUserSignerJwtForExternalUser).not.toHaveBeenCalled();
   });
@@ -349,11 +349,12 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
         deprecatedHostedFacade: { description: '', signerApiUrl: null },
       },
     });
+    const compositeKey = 'app_3b386c81a1db1169fd2c3986_pmth_composite_secret';
     const a = new PymthouseAdapter({
       apiKeyExchange: {
         billingUrl: 'https://pymthouse.com',
-        clientId: 'app_x',
-        apiKey: 'app_x.pmth_composite_secret',
+        clientId: 'app_3b386c81a1db1169fd2c3986',
+        apiKey: compositeKey,
       },
     });
 
@@ -362,7 +363,7 @@ describe('PymthouseAdapter.resolveSignerEndpoint (NEW api-key signer-session exc
     expect(exchangeApiKeyForSignerSession).not.toHaveBeenCalled();
     expect(ep).toEqual({
       url: 'https://signer-dmz.pymthouse.com',
-      headers: { Authorization: 'Bearer app_x.pmth_composite_secret' },
+      headers: { Authorization: `Bearer ${compositeKey}` },
     });
   });
 

--- a/apps/web-next/src/lib/billing/pymthouse-adapter.ts
+++ b/apps/web-next/src/lib/billing/pymthouse-adapter.ts
@@ -11,7 +11,7 @@
 import 'server-only';
 
 import { isPymthouseConfigured } from '@pymthouse/builder-sdk/config';
-import { assertDirectSignerBaseUrl } from '@pymthouse/builder-sdk/signer/server';
+import { assertDirectSignerBaseUrl, isCompositeApiKey } from '@pymthouse/builder-sdk/signer/server';
 
 import type { MeScopeUsagePayload, PmtHouseClient, UsageApiResponse } from '@pymthouse/builder-sdk';
 
@@ -67,8 +67,8 @@ export interface PymthouseAdapterOptions {
    */
   signerExchange?: PymthouseSignerExchangeConfig;
   /**
-   * Optional config for the NEW single-call signer-session exchange
-   * (`POST /api/v1/apps/{clientId}/auth/api-key/signer-session`). When present,
+   * Optional config for the app-scoped RFC 8693 API-key → signer JWT exchange
+   * (`POST /api/v1/apps/{clientId}/oidc/token`). When present,
    * {@link PymthouseAdapter.resolveSignerEndpoint} prefers it over the legacy
    * `getSignerRouting()` + user-JWT mint. Omitted by default; the global-env
    * adapter resolves it lazily from `PYMTHOUSE_API_KEY` (unset ⇒ legacy path).
@@ -295,13 +295,11 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     _session: SignerSessionToken,
     context?: { externalUserId: string },
   ): Promise<SignerSessionEndpoint> {
-    // NEW contract: a single authenticated POST to
-    // `/api/v1/apps/{clientId}/auth/api-key/signer-session` returns BOTH the
-    // remote signer DMZ url AND the bearer in one call (replacing the legacy
-    // `getSignerRouting()` + user-JWT mint below). Preferred when an explicit
-    // `apiKeyExchange` was injected (per-instance) OR — for the GLOBAL-env
-    // adapter only — `PYMTHOUSE_API_KEY` is set. Unset by default ⇒ this branch
-    // is skipped and the legacy path runs byte-for-byte (zero regression).
+    // Preferred path: API-key config (`apiKeyExchange` or global `PYMTHOUSE_API_KEY`).
+    // Composite keys go to the DMZ as Bearer (identity webhook exchanges them).
+    // Bare `pmth_*` keys use RFC 8693 `POST …/apps/{clientId}/oidc/token` for a
+    // short-lived signer JWT + `signer_url`. Unset by default ⇒ legacy
+    // `getSignerRouting()` + mint path below (zero regression).
     //
     // The global `PYMTHOUSE_API_KEY` env is NOT consulted for a per-instance
     // adapter (one with an injected `clientOverride`): that key belongs to the
@@ -310,20 +308,20 @@ export class PymthouseAdapter implements BillingProviderAdapter {
     // isolation. A per-instance adapter therefore uses the new path only when
     // its own `apiKeyExchange` is injected, else the legacy per-instance mint.
     //
-    // NOTE: this endpoint is authenticated by the `pmth_…` key itself and takes
+    // NOTE: this endpoint is authenticated by the API key itself and takes
     // no `externalUserId`, so identity/usage attribution is at the KEY level,
     // not per NaaP user.
     const apiKeyCfg =
       this.apiKeyExchange ?? (this.clientOverride ? undefined : readApiKeySignerSessionConfig());
     if (apiKeyCfg) {
       const apiKey = apiKeyCfg.apiKey.trim();
-      // PR #210 composite keys (`app_XXX.pmth_YYY`) authenticate the DMZ
-      // directly — no signer-session exchange hop. ONLY this path needs
+      // Composite keys (`app_<24hex>_<secret>`) authenticate the DMZ directly —
+      // the clearinghouse identity webhook exchanges them. ONLY this path needs
       // `getSignerRouting()` to discover the DMZ url. A bare `pmth_…` key gets
       // its url from `exchangeApiKeyForSignerSession()` below and must NOT be
       // gated on signer routing (which it never needed) — doing so regressed
       // bare-key callers with a spurious "no remote signer DMZ url" throw.
-      if (apiKey.includes('.pmth_')) {
+      if (isCompositeApiKey(apiKey)) {
         const url = this.resolveDmzUrl(await this.client().getSignerRouting());
         return {
           url,
@@ -350,7 +348,7 @@ export class PymthouseAdapter implements BillingProviderAdapter {
       throw new Error('resolveSignerEndpoint requires externalUserId to mint the signer bearer');
     }
 
-    // PR #210: DMZ expects composite `app_XXX.pmth_YYY` bearer, not user JWT.
+    // DMZ accepts composite `app_<24hex>_<secret>` Bearer (identity webhook).
     // NOTE (follow-up): this legacy fallback mints a fresh long-lived key per
     // resolution. It is only reached when neither an injected `apiKeyExchange`
     // nor a global `PYMTHOUSE_API_KEY` composite key is configured (prod uses

--- a/apps/web-next/src/lib/pymthouse-client.test.ts
+++ b/apps/web-next/src/lib/pymthouse-client.test.ts
@@ -133,7 +133,7 @@ describe('mintUserSignerJwtForExternalUser (Builder user-token JWT for the remot
   });
 });
 
-describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/auth/api-key/signer-session)', () => {
+describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/oidc/token)', () => {
   function mockFetch(
     response: { ok?: boolean; status?: number; json: () => Promise<unknown> },
   ): ReturnType<typeof vi.fn> {
@@ -150,7 +150,7 @@ describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/auth/api-
     vi.unstubAllGlobals();
   });
 
-  it('POSTs the api key as Bearer with scope body and parses the nested token envelope', async () => {
+  it('POSTs RFC 8693 form body and parses the nested token envelope', async () => {
     // Canonical example-client envelope: { token: { accessToken }, signerUrl }.
     const fetchMock = mockFetch({
       json: async () => ({
@@ -169,14 +169,18 @@ describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/auth/api-
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://pymthouse.com/api/v1/apps/app_973064/auth/api-key/signer-session');
+    expect(url).toBe('https://pymthouse.com/api/v1/apps/app_973064/oidc/token');
     expect(init.method).toBe('POST');
     expect(init.headers).toMatchObject({
-      Authorization: 'Bearer pmth_test_key',
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
       Accept: 'application/json',
     });
-    expect(JSON.parse(init.body as string)).toEqual({ scope: 'sign:job' });
+    expect(init.headers).not.toHaveProperty('Authorization');
+    const form = new URLSearchParams(init.body as string);
+    expect(form.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
+    expect(form.get('subject_token')).toBe('pmth_test_key');
+    expect(form.get('subject_token_type')).toBe('urn:ietf:params:oauth:token-type:access_token');
+    expect(form.get('scope')).toBe('sign:job');
 
     expect(out).toEqual({
       accessToken: 'eyJhbGciOiJSUzI1NiJ9.signer.sig',
@@ -200,7 +204,8 @@ describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/auth/api-
     });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(init.body as string)).toEqual({ scope: 'sign:job extra' });
+    const form = new URLSearchParams(init.body as string);
+    expect(form.get('scope')).toBe('sign:job extra');
     expect(out.accessToken).toBe('flat.jwt.sig');
     expect(out.signerUrl).toBe('https://dmz.example');
     // No expires_in in the response → conservative default TTL.
@@ -217,7 +222,7 @@ describe('exchangeApiKeyForSignerSession (POST /api/v1/apps/{clientId}/auth/api-
     });
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toBe(
-      'https://pymthouse.com/api/v1/apps/app%2Fwith%20space/auth/api-key/signer-session',
+      'https://pymthouse.com/api/v1/apps/app%2Fwith%20space/oidc/token',
     );
   });
 

--- a/apps/web-next/src/lib/pymthouse-client.ts
+++ b/apps/web-next/src/lib/pymthouse-client.ts
@@ -315,9 +315,9 @@ export async function mintUserSignerJwtForExternalUser(input: {
 }
 
 /**
- * Non-secret connection params + a `pmth_…` API key needed to perform the new
- * single-call signer-session exchange documented at
- * `POST /api/v1/apps/{clientId}/auth/api-key/signer-session`.
+ * Non-secret connection params + a `pmth_…` / composite `app_<24hex>_<secret>`
+ * API key needed for app-scoped RFC 8693 token exchange at
+ * `POST /api/v1/apps/{clientId}/oidc/token`.
  *
  * `billingUrl` is the PymtHouse ORIGIN (e.g. `https://pymthouse.com`), NOT the
  * `/api/v1/oidc` issuer URL — the endpoint lives under `/api/v1/apps/...`.
@@ -329,9 +329,9 @@ export interface PymthouseApiKeyExchangeConfig {
   scope?: string;
 }
 
-/** Result of the api-key → signer-session exchange (endpoint form inputs). */
+/** Result of the api-key → signer JWT exchange (endpoint form inputs). */
 export interface ApiKeySignerSession {
-  /** Signer-session token to forward as `Authorization: Bearer …`. */
+  /** Signer JWT to forward as `Authorization: Bearer …`. */
   accessToken: string;
   /** Remote signer DMZ base URL the provider returned (or null when omitted). */
   signerUrl: string | null;
@@ -344,12 +344,10 @@ export interface ApiKeySignerSession {
 }
 
 /**
- * Read the signer-session token out of the exchange response envelope.
+ * Read the signer access token out of the exchange response envelope.
  *
- * Mirrors the canonical example client
- * (`livepeer-gateway-client@30df477` `auth_exchange._signer_access_token`):
- * accept either the nested `token.{accessToken,access_token}` envelope OR a
- * flat top-level `{accessToken,access_token}`.
+ * Accept either the nested `token.{accessToken,access_token}` envelope OR a
+ * flat top-level `{accessToken,access_token}` (RFC 8693 OIDC response).
  */
 function readSignerAccessToken(body: Record<string, unknown>): string {
   const token = body.token;
@@ -364,7 +362,7 @@ function readSignerAccessToken(body: Record<string, unknown>): string {
     const value = body[key];
     if (typeof value === 'string' && value.trim()) return value.trim();
   }
-  throw new PmtHouseError('API key signer-session response missing signer access token', {
+  throw new PmtHouseError('API key token exchange response missing signer access token', {
     status: 502,
     code: 'invalid_token_response',
   });
@@ -380,29 +378,26 @@ function readSignerUrl(body: Record<string, unknown>): string | null {
 }
 
 /**
- * Exchange a `pmth_…` API key for a signer session via the NEW PymtHouse
- * endpoint `POST /api/v1/apps/{clientId}/auth/api-key/signer-session`.
+ * Exchange a bare `pmth_…` or composite `app_<24hex>_<secret>` API key for a
+ * short-lived signer JWT via app-scoped RFC 8693 token exchange
+ * (`POST /api/v1/apps/{clientId}/oidc/token`).
  *
- * This is the contract John relocated the token-exchange to (the example client
- * `livepeer-gateway-client@30df477` `exchange_api_key_for_signer`): a SINGLE
- * authenticated POST that returns both the signer-session token AND the remote
- * signer DMZ url — collapsing NaaP's older multi-step "mint user JWT → manually
- * token-exchange" shim into one call. The API key is sent as the bearer; the
- * `clientId` is URL-encoded into the path; the body carries the requested scope.
+ * Dashboard parity: `subject_token` is the full API key string; the path already
+ * supplies `{clientId}`. Replaces the removed `/auth/api-key/signer-session` route.
  */
 export async function exchangeApiKeyForSignerSession(
   cfg: PymthouseApiKeyExchangeConfig,
 ): Promise<ApiKeySignerSession> {
   const apiKey = cfg.apiKey.trim();
   if (!apiKey) {
-    throw new PmtHouseError('API key signer-session exchange requires a non-empty API key', {
+    throw new PmtHouseError('API key token exchange requires a non-empty API key', {
       status: 400,
       code: 'pymthouse_required',
     });
   }
   const clientId = cfg.clientId.trim();
   if (!clientId) {
-    throw new PmtHouseError('API key signer-session exchange requires a non-empty clientId', {
+    throw new PmtHouseError('API key token exchange requires a non-empty clientId', {
       status: 400,
       code: 'pymthouse_required',
     });
@@ -410,16 +405,24 @@ export async function exchangeApiKeyForSignerSession(
   const scope = cfg.scope?.trim() || SIGN_JOB_SCOPE;
   const url =
     `${cfg.billingUrl.replace(/\/+$/, '')}/api/v1/apps/` +
-    `${encodeURIComponent(clientId)}/auth/api-key/signer-session`;
+    `${encodeURIComponent(clientId)}/oidc/token`;
+
+  const form = new URLSearchParams({
+    grant_type: TOKEN_EXCHANGE_GRANT,
+    subject_token: apiKey,
+    subject_token_type: SUBJECT_ACCESS_TOKEN_TYPE,
+  });
+  if (scope) {
+    form.set('scope', scope);
+  }
 
   const response = await fetch(url, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
       Accept: 'application/json',
     },
-    body: JSON.stringify(scope ? { scope } : {}),
+    body: form.toString(),
     cache: 'no-store',
     // Fail fast instead of hanging if the PymtHouse endpoint is unresponsive.
     signal: AbortSignal.timeout(15_000),
@@ -429,7 +432,7 @@ export async function exchangeApiKeyForSignerSession(
   try {
     body = (await response.json()) as Record<string, unknown>;
   } catch {
-    throw new PmtHouseError('API key signer-session exchange returned invalid JSON', {
+    throw new PmtHouseError('API key token exchange returned invalid JSON', {
       status: 502,
       code: 'invalid_token_response',
     });
@@ -441,7 +444,7 @@ export async function exchangeApiKeyForSignerSession(
         ? body.error_description
         : typeof body.error === 'string'
           ? body.error
-          : `API key signer-session exchange failed (${response.status})`;
+          : `API key token exchange failed (${response.status})`;
     throw new PmtHouseError(description, {
       status: response.status,
       code: typeof body.error === 'string' ? body.error : 'signer_session_exchange_failed',

--- a/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
+++ b/apps/web-next/src/lib/pymthouse-signer-exchange-config.ts
@@ -85,15 +85,16 @@ export function readApiKeyExchangeConfig() {
 }
 
 /**
- * Config for the NEW single-call signer-session exchange
- * (`POST /api/v1/apps/{clientId}/auth/api-key/signer-session`).
+ * Config for the app-scoped RFC 8693 API-key → signer JWT exchange
+ * (`POST /api/v1/apps/{clientId}/oidc/token`).
  *
- * Sourced from the OPTIONAL `PYMTHOUSE_API_KEY` (composite `app_XXX.pmth_YYY` or bare
- * `pmth_…`) plus the existing `PYMTHOUSE_PUBLIC_CLIENT_ID` and `PYMTHOUSE_ISSUER_URL`.
- * any of these is missing — which is the DEFAULT posture (the env var is unset),
- * so callers fall back to today's per-user mint path with zero regression. The
- * `billingUrl` is the issuer ORIGIN (the endpoint lives under `/api/v1/apps`,
- * not the `/api/v1/oidc` issuer path). The API key value is never logged.
+ * Sourced from the OPTIONAL `PYMTHOUSE_API_KEY` (composite `app_<24hex>_<secret>`
+ * or bare `pmth_…`) plus the existing `PYMTHOUSE_PUBLIC_CLIENT_ID` and
+ * `PYMTHOUSE_ISSUER_URL`. Returns null when any of these is missing — which is
+ * the DEFAULT posture (the env var is unset), so callers fall back to today's
+ * per-user mint path with zero regression. The `billingUrl` is the issuer ORIGIN
+ * (the endpoint lives under `/api/v1/apps`, not the `/api/v1/oidc` issuer path).
+ * The API key value is never logged.
  */
 export function readApiKeySignerSessionConfig(): {
   billingUrl: string;

--- a/docs/pymthouse-integration.md
+++ b/docs/pymthouse-integration.md
@@ -4,7 +4,7 @@ Official Builder API contract: [PymtHouse `docs/builder-api.md`](https://github.
 
 Server-to-server calls use the published npm package [`@pymthouse/builder-sdk`](https://www.npmjs.com/package/@pymthouse/builder-sdk) (source: [pymthouse/builder-sdk](https://github.com/pymthouse/builder-sdk)), wrapped in [apps/web-next/src/lib/pymthouse-client.ts](apps/web-next/src/lib/pymthouse-client.ts) with `import "server-only"` so M2M secrets never ship to the browser.
 
-**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **`0.6.0`** (local `file:` link to the builder-sdk checkout until published) in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root (or `./bin/start.sh`, which syncs when `package-lock.json` changes), and re-verify billing/OIDC routes after any upgrade.
+**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **`0.6.0`** in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root (or `./bin/start.sh`, which syncs when `package-lock.json` changes), and re-verify billing/OIDC routes after any upgrade.
 
 ## Plan-builder data (PymtHouse → NaaP)
 

--- a/docs/pymthouse-integration.md
+++ b/docs/pymthouse-integration.md
@@ -4,7 +4,7 @@ Official Builder API contract: [PymtHouse `docs/builder-api.md`](https://github.
 
 Server-to-server calls use the published npm package [`@pymthouse/builder-sdk`](https://www.npmjs.com/package/@pymthouse/builder-sdk) (source: [pymthouse/builder-sdk](https://github.com/pymthouse/builder-sdk)), wrapped in [apps/web-next/src/lib/pymthouse-client.ts](apps/web-next/src/lib/pymthouse-client.ts) with `import "server-only"` so M2M secrets never ship to the browser.
 
-**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **exact `0.5.0`** from the npm registry in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root (or `./bin/start.sh`, which syncs when `package-lock.json` changes), and re-verify billing/OIDC routes after any upgrade.
+**Dependency pin:** NaaP pins `@pymthouse/builder-sdk` at **`0.6.0`** (local `file:` link to the builder-sdk checkout until published) in [apps/web-next/package.json](../apps/web-next/package.json) (and matching pins in the developer-api plugin packages). Review [builder-sdk releases](https://github.com/pymthouse/builder-sdk/releases) before bumping, run `npm install` at the repo root (or `./bin/start.sh`, which syncs when `package-lock.json` changes), and re-verify billing/OIDC routes after any upgrade.
 
 ## Plan-builder data (PymtHouse → NaaP)
 
@@ -49,17 +49,17 @@ NaaP server                                              PymtHouse
 - **Confidential M2M** (`m2m_…`) credentials are **`PYMTHOUSE_M2M_CLIENT_ID`** + **`PYMTHOUSE_M2M_CLIENT_SECRET`**. A single OIDC client cannot be both public (device flow) and confidential; PymtHouse provisions two clients per developer app when you enable **Backend device helper** in Auth & Scopes.
 - **End-user scope** is only **`sign:job`** on the token request.
 - The M2M client must allow **`users:read`**, **`users:write`**, **`users:token`**, and **`sign:job`** in its allowed scopes (defaults for the backend helper).
-- Short-lived Builder-minted user JWTs are **not** surfaced as NaaP developer API keys for the Create API Key flow. That flow mints long-lived **`pmth_*`** API keys via the Builder Apps **`…/users/{externalUserId}/keys`** route (Dashboard parity). Opaque signer sessions (~90 days) remain available via **`POST /api/v1/billing/pymthouse/token`** only.
+- Short-lived Builder-minted user JWTs are **not** surfaced as NaaP developer API keys for the Create API Key flow. That flow mints long-lived presented API keys via the Builder Apps **`…/users/{externalUserId}/keys`** route (Dashboard parity). Newly issued keys are composite **`app_<24hex>_<secret>`** (usually `app_…_pmth_…`); bare **`pmth_*`** remains valid as `subject_token` when `{clientId}` is already in the exchange path. Opaque signer sessions (~90 days) remain available via **`POST /api/v1/billing/pymthouse/token`** only.
 
 ### NaaP endpoints
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| `POST` | `/api/v1/auth/providers/pymthouse/start` | First-time link from the **Create API Key** UI. Returns `{ access_token, token_type, expires_in, scope, login_session_id, auth_url: null, poll_after_ms: 0 }` where `access_token` is a long-lived **`pmth_*`** API key (Builder Apps user key). |
+| `POST` | `/api/v1/auth/providers/pymthouse/start` | First-time link from the **Create API Key** UI. Returns `{ access_token, token_type, expires_in, scope, login_session_id, auth_url: null, poll_after_ms: 0 }` where `access_token` is a long-lived presented API key (`app_<24hex>_<secret>` or bare `pmth_*`). |
 | `POST` | `/api/v1/billing/pymthouse/token` | Mint-on-demand opaque signer session. Returns `{ access_token, token_type, expires_in, scope }` where `access_token` is an opaque **`pmth_…`** signer session (~90 days). Auth: NaaP session + CSRF. Rate limited per user. Internally mints a short-lived JWT then RFC 8693 token-exchanges with the M2M client. |
 | `GET` | `/api/v1/billing/pymthouse/usage` | Session BFF over PymtHouse **Usage API** (see below). Auth: NaaP session cookie / bearer. `Cache-Control: no-store`. |
 | `GET` | `/api/v1/billing/pymthouse/config` | Public integration settings for the Developer API UI (`signerUrl` from `PYMTHOUSE_SIGNER_URL`). Auth: NaaP session cookie / bearer. |
-| `POST` | `/api/pymthouse/keys/exchange` | Public exchange: PymtHouse **`pmth_*`** API key → short-lived signer JWT. No NaaP session. Uses `@pymthouse/builder-sdk/signer/server` `createApiKeyExchangeHandler`. Same contract as Dashboard. |
+| `POST` | `/api/pymthouse/keys/exchange` | Public exchange: PymtHouse API key (`app_*_*` or bare `pmth_*`) → short-lived signer JWT via app-scoped RFC 8693 `POST …/apps/{clientId}/oidc/token`. No NaaP session. Uses `@pymthouse/builder-sdk/signer/server` `createApiKeyExchangeHandler`. Same contract as Dashboard. |
 | `POST` | `/api/signer/device/exchange` | Public exchange: device token → signer session. No NaaP session. Uses `createDeviceExchangeHandler`. Complements the browser device-approve step below. |
 
 ### Developer API manager SDK token
@@ -73,7 +73,7 @@ That SDK token is **base64-encoded JSON**, not a JWT. It bundles signer and disc
   "signer": "https://pymthouse-preview.up.railway.app",
   "discovery": "https://naap.example.com/api/v1/orchestrator-leaderboard/plans/{planId}/python-gateway",
   "signer_headers": {
-    "Authorization": "Bearer pmth_..."
+    "Authorization": "Bearer app_<24hex>_pmth_..."
   },
   "discovery_headers": {
     "Authorization": "Bearer gw_..."
@@ -81,7 +81,7 @@ That SDK token is **base64-encoded JSON**, not a JWT. It bundles signer and disc
 }
 ```
 
-- `signer_headers.Authorization` carries the long-lived **`pmth_*`** API key (same value as the billing key in the success dialog). **livepeer-python-gateway** detects `pmth_*` in `signer_headers`, infers the NaaP billing origin from the `discovery` URL host, and exchanges via **`POST /api/pymthouse/keys/exchange`** before calling the signer DMZ (same outcome as `--billing-url` + `--api-key`).
+- `signer_headers.Authorization` carries the long-lived presented API key (same value as the billing key in the success dialog — composite `app_<24hex>_<secret>` or bare `pmth_*`). **livepeer-python-gateway** may exchange via **`POST /api/pymthouse/keys/exchange`** before calling the signer DMZ; alternatively the remote-signer identity webhook accepts the full composite as Bearer and performs the same RFC 8693 exchange. Bare `pmth_*` alone is insufficient for webhook routing without client-id context.
 - `discovery_headers.Authorization` uses a separate NaaP service-gateway key (`gw_…`) minted during the same dialog via `/api/v1/gw/admin/keys`.
 - The `signer` field comes from **`PYMTHOUSE_SIGNER_URL`** when set (via `GET /api/v1/billing/pymthouse/config`), otherwise `{issuerOrigin}/api/signer`. Exchange may override the effective signer URL with the value returned from the exchange response.
 - If the user selects a saved discovery plan, the token points at `/api/v1/orchestrator-leaderboard/plans/{planId}/python-gateway`; otherwise it points at `/api/v1/orchestrator-leaderboard/python-gateway` for default model-based discovery (append `?billingProvider=pymthouse` for PymtHouse default discovery).
@@ -154,9 +154,9 @@ Legacy **`naap/link-user`**, **`naap-service`** seed-only flows, and **`gateway`
 - `PYMTHOUSE_PUBLIC_CLIENT_ID` is the public **`app_...`** id; `PYMTHOUSE_M2M_CLIENT_ID` is the confidential **`m2m_...`** id.
 - `PYMTHOUSE_M2M_CLIENT_SECRET` matches the M2M client’s secret.
 - NaaP logs show `[billing-auth:pymthouse] Linked user …` (no browser popup).
-- **Create API Key** (`/api/v1/auth/providers/pymthouse/start`) returns a long-lived **`pmth_*`** user API key (exchangeable via `/api/pymthouse/keys/exchange`).
+- **Create API Key** (`/api/v1/auth/providers/pymthouse/start`) returns a long-lived presented API key (`app_<24hex>_<secret>` or bare `pmth_*`, exchangeable via `/api/pymthouse/keys/exchange`).
 - **`POST /api/v1/billing/pymthouse/token`** still returns an opaque signer session (~90 days) for session/BFF use; implementation uses [`pymthouse-client.ts`](../apps/web-next/src/lib/pymthouse-client.ts) `mintSignerSessionForExternalUser` (omits token-exchange `resource` so PymtHouse selects gateway opaque-session exchange).
-- python-gateway `--token` with `signer_headers` carrying **`pmth_*`** logs `API-key signer exchange at {discovery-origin}` and receives a signer JWT + `signerUrl` from the exchange response.
+- python-gateway `--token` with `signer_headers` carrying a presented API key exchanges via `/api/pymthouse/keys/exchange` (or the identity webhook accepts a composite Bearer) and receives a signer JWT + `signerUrl` from the exchange response.
 
 ## Device login (RFC 8628) — Option B (NaaP-side approval)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,27 +58,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "../builder-sdk": {
-      "name": "@pymthouse/builder-sdk",
-      "version": "0.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.18.0",
-        "@types/node": "^22.10.0",
-        "eslint": "^9.18.0",
-        "prettier": "^3.4.2",
-        "tsup": "^8.3.5",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^8.20.0",
-        "vitest": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "apps/web-next": {
       "name": "@naap/web-next",
       "version": "0.0.1",
@@ -93,7 +72,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "file:../../../builder-sdk",
+        "@pymthouse/builder-sdk": "0.6.0",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -8730,8 +8709,16 @@
       }
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "resolved": "../builder-sdk",
-      "link": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.0.tgz",
+      "integrity": "sha512-31tgdkJCri/z+377YfZmeL8BHtMuiUPD7z1+xq78w+kuqSELSr1u7sA6PYgN37UQxj4DkiswozC19WUbIwVgpg==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -24343,6 +24330,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -31923,7 +31919,7 @@
         "@naap/database": "*",
         "@naap/plugin-server-sdk": "*",
         "@naap/types": "*",
-        "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
+        "@pymthouse/builder-sdk": "0.6.0",
         "cors": "^2.8.6",
         "dotenv": "^16.6.1",
         "express": "^4.21.0",
@@ -31970,7 +31966,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
+        "@pymthouse/builder-sdk": "0.6.0",
         "framer-motion": "^12.0.0",
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "../builder-sdk": {
+      "name": "@pymthouse/builder-sdk",
+      "version": "0.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.18.0",
+        "@types/node": "^22.10.0",
+        "eslint": "^9.18.0",
+        "prettier": "^3.4.2",
+        "tsup": "^8.3.5",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.20.0",
+        "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "apps/web-next": {
       "name": "@naap/web-next",
       "version": "0.0.1",
@@ -72,7 +93,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.5.0",
+        "@pymthouse/builder-sdk": "file:../../../builder-sdk",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -8709,16 +8730,8 @@
       }
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.5.0.tgz",
-      "integrity": "sha512-Kn1bca6s5IybGlDhtQzz6kS+5tQUZhoLk8McAmK6YDItFCm2app1Yg6hMjEkb3lv+2f8bSpjkYb9p7qr7YASJw==",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
+      "resolved": "../builder-sdk",
+      "link": true
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -24330,15 +24343,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/oauth4webapi": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
-      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -31919,7 +31923,7 @@
         "@naap/database": "*",
         "@naap/plugin-server-sdk": "*",
         "@naap/types": "*",
-        "@pymthouse/builder-sdk": "0.5.0",
+        "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
         "cors": "^2.8.6",
         "dotenv": "^16.6.1",
         "express": "^4.21.0",
@@ -31966,7 +31970,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.5.0",
+        "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
         "framer-motion": "^12.0.0",
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",

--- a/plugins/developer-api/backend/package.json
+++ b/plugins/developer-api/backend/package.json
@@ -12,7 +12,7 @@
     "@naap/database": "*",
     "@naap/plugin-server-sdk": "*",
     "@naap/types": "*",
-    "@pymthouse/builder-sdk": "0.5.0",
+    "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
     "cors": "^2.8.6",
     "dotenv": "^16.6.1",
     "express": "^4.21.0",

--- a/plugins/developer-api/backend/package.json
+++ b/plugins/developer-api/backend/package.json
@@ -12,7 +12,7 @@
     "@naap/database": "*",
     "@naap/plugin-server-sdk": "*",
     "@naap/types": "*",
-    "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
+    "@pymthouse/builder-sdk": "0.6.0",
     "cors": "^2.8.6",
     "dotenv": "^16.6.1",
     "express": "^4.21.0",

--- a/plugins/developer-api/frontend/package.json
+++ b/plugins/developer-api/frontend/package.json
@@ -17,7 +17,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.5.0",
+    "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
     "framer-motion": "^12.0.0",
     "lucide-react": "^0.575.0",
     "react": "^19.0.0",

--- a/plugins/developer-api/frontend/package.json
+++ b/plugins/developer-api/frontend/package.json
@@ -17,7 +17,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "file:../../../../builder-sdk",
+    "@pymthouse/builder-sdk": "0.6.0",
     "framer-motion": "^12.0.0",
     "lucide-react": "^0.575.0",
     "react": "^19.0.0",

--- a/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
+++ b/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
@@ -2063,7 +2063,9 @@ result = [...result].sort((a, b) => {
                 )}
                 {isPymthousePresentedApiKey(createdRawKey) && (
                   <p className="text-text-secondary mt-1">
-                    Long-lived until revoked. Present this key to the remote signer (composite Bearer) or exchange it for a short-lived signer JWT before streaming.
+                    {isCompositeApiKey(createdRawKey.trim())
+                      ? 'Long-lived until revoked. Present this key to the remote signer as Bearer, or exchange it for a short-lived signer JWT before streaming.'
+                      : 'Long-lived until revoked. Exchange this key for a short-lived signer JWT (e.g. via /api/pymthouse/keys/exchange) before calling the remote signer.'}
                   </p>
                 )}
               </div>

--- a/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
+++ b/plugins/developer-api/frontend/src/pages/DeveloperView.tsx
@@ -24,7 +24,14 @@ ChevronUp,
 } from 'lucide-react';
 import { Card, Badge, Modal, Tooltip } from '@naap/ui';
 import type { NetworkModel } from '@naap/plugin-sdk';
+import { isCompositeApiKey } from '@pymthouse/builder-sdk';
 import { SubscriptionsPanel } from './SubscriptionsPanel';
+
+/** Presented PymtHouse billing key: composite `app_<24hex>_<secret>` or bare `pmth_*`. */
+function isPymthousePresentedApiKey(key: string): boolean {
+  const trimmed = key.trim();
+  return isCompositeApiKey(trimmed) || (trimmed.startsWith('pmth_') && !trimmed.startsWith('pmth_cs_'));
+}
 
 const PIPELINE_COLOR: Record<string, string> = {
   'text-to-image':           '#f59e0b',
@@ -986,10 +993,11 @@ result = [...result].sort((a, b) => {
       const directAccessToken = startData.data?.access_token || startData.access_token;
       const loginSessionId = startData.data?.login_session_id || startData.login_session_id;
 
-      // Server-to-server providers (e.g. PymtHouse) return a long-lived pmth_* API key
-      // as `access_token` directly. Browser-redirect providers (e.g. Daydream)
-      // hand back only a `login_session_id`; the popup opens a same-origin NaaP
-      // redirector that resolves the provider authorization URL server-side, so no
+      // Server-to-server providers (e.g. PymtHouse) return a long-lived API key
+      // (`app_<24hex>_<secret>` or bare `pmth_*`) as `access_token` directly.
+      // Browser-redirect providers (e.g. Daydream) hand back only a
+      // `login_session_id`; the popup opens a same-origin NaaP redirector that
+      // resolves the provider authorization URL server-side, so no
       // remote-controlled URL is ever passed into window.open.
       let providerApiKey: string | null = directAccessToken || null;
 
@@ -1930,7 +1938,8 @@ result = [...result].sort((a, b) => {
                           <code className="text-slate-300">GET …/manifest</code>
                           ); capabilities outside that list return no orchestrators. Discovery uses a new{' '}
                           <code className="text-slate-300">gw_…</code> gateway key; the signer uses your billing provider
-                          <code className="text-slate-300"> pmth_*</code> key (the SDK exchanges it for a signer JWT at runtime).
+                          <code className="text-slate-300"> app_*_*</code> (or bare <code className="text-slate-300">pmth_*</code>) key
+                          (the SDK exchanges it for a signer JWT at runtime, or the identity webhook accepts the composite Bearer).
                         </>
                       ) : (
                         <>
@@ -2041,7 +2050,7 @@ result = [...result].sort((a, b) => {
                 <p className="text-text-secondary mt-0.5">
                   {createdKeyWarning || 'This is the only time your API key will be shown. Copy it now and store it in a safe place.'}
                 </p>
-                {createdKeyExpiresAt && !createdRawKey.startsWith('pmth_') && (
+                {createdKeyExpiresAt && !isPymthousePresentedApiKey(createdRawKey) && (
                   <p className="text-amber-200 mt-1">
                     {`Expires at ${new Date(createdKeyExpiresAt).toLocaleString('en-US', {
                       month: 'short',
@@ -2052,9 +2061,9 @@ result = [...result].sort((a, b) => {
                     })}.`}
                   </p>
                 )}
-                {createdRawKey.startsWith('pmth_') && (
+                {isPymthousePresentedApiKey(createdRawKey) && (
                   <p className="text-text-secondary mt-1">
-                    Long-lived until revoked. The SDK exchanges this key for a short-lived signer session before streaming.
+                    Long-lived until revoked. Present this key to the remote signer (composite Bearer) or exchange it for a short-lived signer JWT before streaming.
                   </p>
                 )}
               </div>
@@ -2065,7 +2074,8 @@ result = [...result].sort((a, b) => {
                 <p className="text-xs text-text-secondary">
                   Base64 JSON for python-gateway <code className="text-slate-300">--token</code> flag — signer, discovery,
                   and header configuration. For PymtHouse, <code className="text-slate-300">signer_headers</code> carries
-                  your <code className="text-slate-300">pmth_*</code> key; the SDK exchanges it for a signer JWT before streaming.
+                  your <code className="text-slate-300">app_*_*</code> (or bare <code className="text-slate-300">pmth_*</code>) key;
+                  the SDK exchanges it for a signer JWT before streaming (or the identity webhook accepts the composite Bearer).
                 </p>
                 <div className="flex items-start gap-2">
                   <code className="max-h-40 flex-1 overflow-y-auto break-all rounded-lg border border-white/10 bg-bg-tertiary px-3 py-2 font-mono text-xs text-accent-emerald select-all">


### PR DESCRIPTION
## Summary
- Bump `@pymthouse/builder-sdk` to the published builder-sdk 0.6.0 contract.
- Switch API-key → signer exchange to the app-scoped RFC 8693 endpoint (`POST /api/v1/apps/{clientId}/oidc/token`), replacing the old signer-session path.
- Treat composite `app_<24hex>_pmth_…` keys as DMZ Bearer credentials; update adapter/client tests and PymtHouse docs accordingly.

## Test plan
- [ ] Confirm CI installs resolve `@pymthouse/builder-sdk`
- [ ] Run `pymthouse-adapter` / `pymthouse-client` unit tests.
- [ ] Exercise Get API Key / validate signer path with a composite key and with OIDC token exchange.
- [ ] Smoke developer-api UI key creation against preview PymtHouse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated PymtHouse billing authentication to support app-scoped API key exchanges using the RFC 8693 token-exchange flow.
  - Added support for both composite `app_*_*` and legacy `pmth_*` presented API keys.
  - Improved signer routing and authorization handling for composite keys.
  - Updated Developer API screens with clearer guidance for creating, presenting, and exchanging PymtHouse keys.

- **Documentation**
  - Revised integration guidance, endpoint details, key formats, routing expectations, and verification steps.
  - Updated examples and SDK references for the latest PymtHouse integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->