### PR TITLE
feat(discovery): add Live Runner (lr) category + fix tool → tool-staging-1

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__tests__/golden-set.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/storyboard-default/__tests__/golden-set.test.ts
@@ -90,7 +90,10 @@ describe('NAAP-9 storyboard-default golden-set parity', () => {
       billingProviderSlug: 'daydream',
     });
     expect(SORT(result.byKind.scope)).toEqual(SORT(golden.scope));
-    expect(result.meta.staticFleetInjected).toBe(0);
+    // No scope drift → scope injects nothing. The tool + lr static fleets
+    // (tool-staging-1, liverunner-staging-1) are always gaps here because the
+    // mock returns byoc-staging-1 for every non-scope cap, so 2 are injected.
+    expect(result.meta.staticFleetInjected).toBe(2);
   });
 
   it('fails parity if a golden scope address is removed from both live and static fleet (catches missing)', async () => {

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-discovery.ts
@@ -44,6 +44,8 @@ export interface StoryboardDefaultByKind {
   byoc: string[];
   /** Tool CAPABILITIES included after the provider denylist. */
   tool: string[];
+  /** Live Runner CAPABILITIES included after the provider denylist. */
+  lr: string[];
 }
 
 export interface StoryboardDefaultDiscoveryResult {
@@ -158,8 +160,9 @@ export async function buildStoryboardDefaultDiscovery(
     scope: [],
     byoc: [],
     tool: [],
+    lr: [],
   };
-  const byKind: StoryboardDefaultByKind = { scope: [], byoc: [], tool: [] };
+  const byKind: StoryboardDefaultByKind = { scope: [], byoc: [], tool: [], lr: [] };
 
   for (const key of STORYBOARD_DEFAULT_CATEGORY_KEYS) {
     const baseCategory = plan[key];
@@ -207,6 +210,7 @@ export async function buildStoryboardDefaultDiscovery(
     ...scopeShuffled,
     ...perCategoryAddresses.byoc,
     ...perCategoryAddresses.tool,
+    ...perCategoryAddresses.lr,
   ];
   const addresses = tieredShuffleDiscoveryAddresses(
     flattened,

--- a/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/storyboard-default-plan.ts
@@ -39,6 +39,7 @@ export interface StoryboardDefaultPlan {
   readonly scope: StoryboardDefaultCategory;
   readonly byoc: StoryboardDefaultCategory;
   readonly tool: StoryboardDefaultCategory;
+  readonly lr: StoryboardDefaultCategory;
   readonly topN: number;
 }
 
@@ -98,17 +99,34 @@ export const STORYBOARD_DEFAULT_PLAN: StoryboardDefaultPlan = {
       'cad-render',
       'cad-validate',
     ],
-    staticOrchestrators: ['https://byoc-staging-1.daydream.monster:8935'],
+    staticOrchestrators: ['https://tool-staging-1.daydream.monster:8935'],
+  },
+  lr: {
+    // Live Runner mirrors these fal caps; dual-homed with byoc where they overlap
+    // (flux-*/kontext-edit/chatterbox-tts). The gateway's capability filter +
+    // score picks between byoc-staging-1 and liverunner-staging-1 per request.
+    capabilities: [
+      'flux-dev',
+      'flux-schnell',
+      'gpt-image',
+      'kontext-edit',
+      'pixverse-i2v',
+      'seedance-mini-i2v',
+      'veo-t2v',
+      'chatterbox-tts',
+    ],
+    staticOrchestrators: ['https://liverunner-staging-1.daydream.monster:8935'],
   },
   topN: 100,
 } as const;
 
-export type StoryboardDefaultCategoryKey = 'scope' | 'byoc' | 'tool';
+export type StoryboardDefaultCategoryKey = 'scope' | 'byoc' | 'tool' | 'lr';
 
 export const STORYBOARD_DEFAULT_CATEGORY_KEYS: readonly StoryboardDefaultCategoryKey[] = [
   'scope',
   'byoc',
   'tool',
+  'lr',
 ];
 
 /**


### PR DESCRIPTION
Makes the storyboard-default discovery (orchestrator-leaderboard plugin, `operator.livepeer.org`) advertise the **Live Runner** orchestrator, and fixes a stale **tool** address — the two config prerequisites for the SDK to route fal/tool caps across BYOC + LR + Tool transparently.

## Changes
- **`storyboard-default-plan.ts`** — new **`lr` category**: `staticOrchestrators: liverunner-staging-1.daydream.monster:8935` + the 8 mirrored fal caps (`flux-dev/schnell`, `gpt-image`, `kontext-edit`, `pixverse-i2v`, `seedance-mini-i2v`, `veo-t2v`, `chatterbox-tts`), dual-homed with `byoc` where they overlap. Extends `StoryboardDefaultCategoryKey` + `CATEGORY_KEYS`.
- **FIX `tool` → `tool-staging-1`** — `staticOrchestrators` was `byoc-staging-1`, but the SDK's `CAPABILITY_ORCH_MAP` routes 34 tool caps to `tool-staging-1`. Stale — would 503 tools once the SDK consumes NaaP discovery.
- **`storyboard-default-discovery.ts`** — `byKind.lr` + per-category / byKind init + flatten (the builder already iterates `CATEGORY_KEYS` generically).
- **golden-set test** — the no-drift `staticFleetInjected` is now `2` (tool + lr static fleets are gaps vs the mocked byoc host).

## Why it's safe
The gateway filters selection by advertised capability (verified in go-livepeer `discovery.go` `isCompatible` + `remote_discovery.go`), so adding LR/tool addresses can't cross-pollute LV2V or each other. Golden parity intact: `byKind` scope/byoc/tool, `tool.capabilities`, and scope static are unchanged; `lr` is additive; the tool address is a fallback (not golden-checked). **All 181 tests green.**

## Follow-ups (not blocking)
- `byoc-tool-discovery.ts` (NAAP-3 dynamic cap override) doesn't yet emit `lr` overrides — lr uses its static plan baseline for now (static-first, dynamic later).
- SDK side (simple-infra): repoint `DISCOVERY_URL` from the legacy `signer.daydream.live/discovery/staging.json` to this leaderboard route so the multi-kind list is actually consumed.

Part of the transparent SDK-routing effort (design: storyboard `TRANSPARENT-SDK-ROUTING-DESIGN-AND-PLAN.html`). Pairs with python-gateway #46/#47 (per-signer payment dual-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for LiveRunner capabilities in storyboard default discovery.
  * LiveRunner endpoints are now included in categorized and shuffled discovery results.
  * Added fallback routing for tool and LiveRunner capabilities when dynamic results are unavailable.

* **Tests**
  * Updated parity coverage to reflect static fleet injection for tool and LiveRunner capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->