### PR TITLE
chore(deps): bump @pymthouse/builder-sdk to 0.6.1

### DIFF
--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.6.1-rc.0",
+    "@pymthouse/builder-sdk": "^0.6.1",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -37,7 +37,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.6.0",
+    "@pymthouse/builder-sdk": "0.6.1-rc.0",
     "@vercel/blob": "^2.2.0",
     "ably": "^2.18.0",
     "dompurify": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.6.0",
+        "@pymthouse/builder-sdk": "0.6.1-rc.0",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -131,6 +131,18 @@
       "version": "7.4.2",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "apps/web-next/node_modules/@pymthouse/builder-sdk": {
+      "version": "0.6.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.1-rc.0.tgz",
+      "integrity": "sha512-syp6Kmu3n/JXPPU5ptTSHk2xPzPN41DYDQny3IAFegA6lMre4Exlx/Dz3PtZVZOCaq3hW6N0Wb1eJV85FUZsDA==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth4webapi": "^3.8.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "apps/web-next/node_modules/@types/mime-types": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.6.1-rc.0",
+        "@pymthouse/builder-sdk": "^0.6.1",
         "@vercel/blob": "^2.2.0",
         "ably": "^2.18.0",
         "dompurify": "^3.3.0",
@@ -131,18 +131,6 @@
       "version": "7.4.2",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "apps/web-next/node_modules/@pymthouse/builder-sdk": {
-      "version": "0.6.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.1-rc.0.tgz",
-      "integrity": "sha512-syp6Kmu3n/JXPPU5ptTSHk2xPzPN41DYDQny3IAFegA6lMre4Exlx/Dz3PtZVZOCaq3hW6N0Wb1eJV85FUZsDA==",
-      "license": "MIT",
-      "dependencies": {
-        "oauth4webapi": "^3.8.5"
-      },
-      "engines": {
-        "node": ">=20"
-      }
     },
     "apps/web-next/node_modules/@types/mime-types": {
       "version": "3.0.1",
@@ -8721,9 +8709,9 @@
       }
     },
     "node_modules/@pymthouse/builder-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.0.tgz",
-      "integrity": "sha512-31tgdkJCri/z+377YfZmeL8BHtMuiUPD7z1+xq78w+kuqSELSr1u7sA6PYgN37UQxj4DkiswozC19WUbIwVgpg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@pymthouse/builder-sdk/-/builder-sdk-0.6.1.tgz",
+      "integrity": "sha512-ALGluRpNAdnoK0Qk1ugP7TVcTrEPtnkipeIsSx6UX6hD1MN8mtOrgZAi+dhB2VZGEM7OBdWz1YhK6V1yskialw==",
       "license": "MIT",
       "dependencies": {
         "oauth4webapi": "^3.8.5"
@@ -31931,7 +31919,7 @@
         "@naap/database": "*",
         "@naap/plugin-server-sdk": "*",
         "@naap/types": "*",
-        "@pymthouse/builder-sdk": "0.6.0",
+        "@pymthouse/builder-sdk": "^0.6.1",
         "cors": "^2.8.6",
         "dotenv": "^16.6.1",
         "express": "^4.21.0",
@@ -31978,7 +31966,7 @@
         "@naap/types": "*",
         "@naap/ui": "*",
         "@naap/utils": "*",
-        "@pymthouse/builder-sdk": "0.6.0",
+        "@pymthouse/builder-sdk": "^0.6.1",
         "framer-motion": "^12.0.0",
         "lucide-react": "^0.575.0",
         "react": "^19.0.0",

--- a/plugins/developer-api/backend/package.json
+++ b/plugins/developer-api/backend/package.json
@@ -12,7 +12,7 @@
     "@naap/database": "*",
     "@naap/plugin-server-sdk": "*",
     "@naap/types": "*",
-    "@pymthouse/builder-sdk": "0.6.0",
+    "@pymthouse/builder-sdk": "^0.6.1",
     "cors": "^2.8.6",
     "dotenv": "^16.6.1",
     "express": "^4.21.0",

--- a/plugins/developer-api/frontend/package.json
+++ b/plugins/developer-api/frontend/package.json
@@ -17,7 +17,7 @@
     "@naap/types": "*",
     "@naap/ui": "*",
     "@naap/utils": "*",
-    "@pymthouse/builder-sdk": "0.6.0",
+    "@pymthouse/builder-sdk": "^0.6.1",
     "framer-motion": "^12.0.0",
     "lucide-react": "^0.575.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

- Bump `@pymthouse/builder-sdk` from `0.6.0` to `0.6.1-rc.0` in `apps/web-next` (dependency-only change).
- The RC fixes `fetchUsageForExternalUser` to run all three usage queries (`user`, `pipeline_model`, `daily_pipeline`) scoped with `userId`, instead of starting from an app-wide `groupBy=user` scan and fanning out per end-user. On busy apps that scan intermittently 5xx'd upstream, which NaaP surfaced as a 503 on `GET /api/v1/billing/pymthouse/usage?scope=me` (prod issue for `app_98575870d7ae33589a3f0660`). Mint was unaffected.
- No NaaP code changes; the route and adapter call the same SDK method.

## Test plan

- [x] `vitest` — pymthouse usage route, adapter, and discovery-plans suites pass against the new SDK (37 tests)
- [ ] Deploy preview: sign in, load the developer Usage tab for an M2M user and confirm 200 with per-pipeline breakdown
- [ ] Confirm prod 503s on `/api/v1/billing/pymthouse/usage` stop after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the builder SDK to a newer release candidate version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->