### PR TITLE
feat(leaderboard): configurable Daydream-BYOC and pymthouse-LR discovery bundles

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/[slug]/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/[slug]/python-gateway/route.test.ts
@@ -1,0 +1,134 @@
+import { NextRequest } from 'next/server';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/gateway/authorize', () => ({
+  authorize: vi.fn(),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/query', () => ({
+  fetchLeaderboard: vi.fn(),
+}));
+
+vi.mock('@/lib/pymthouse-manifest', () => ({
+  ensurePymthouseManifestFresh: vi.fn(async () => ({ revisionChanged: false })),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/provider-restrictions', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/orchestrator-leaderboard/provider-restrictions')
+  >('@/lib/orchestrator-leaderboard/provider-restrictions');
+  return {
+    ...actual,
+    isCapabilityAllowedForProvider: vi.fn(() => true),
+  };
+});
+
+vi.mock('@/lib/orchestrator-leaderboard/signer-bundle-config', async () => {
+  const { SIGNER_BUNDLE_DEFAULTS } = await import(
+    '@/lib/orchestrator-leaderboard/signer-bundle-defaults'
+  );
+  return {
+    getSignerBundle: vi.fn(async (slug: keyof typeof SIGNER_BUNDLE_DEFAULTS) => {
+      return SIGNER_BUNDLE_DEFAULTS[slug] ?? null;
+    }),
+  };
+});
+
+import { authorize } from '@/lib/gateway/authorize';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { SIGNER_BUNDLE_DISCOVERY_FLAG } from '@/lib/orchestrator-leaderboard/signer-bundle-types';
+
+const FLAG = SIGNER_BUNDLE_DISCOVERY_FLAG;
+
+function makeRequest(slug: string, qs = '') {
+  return new NextRequest(
+    `http://localhost/api/v1/orchestrator-leaderboard/bundles/${slug}/python-gateway${qs}`,
+    { headers: { Authorization: 'Bearer gw_test' } },
+  );
+}
+
+function makeContext(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe('GET bundles/:slug/python-gateway', () => {
+  const prev = process.env[FLAG];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (authorize as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authenticated: true,
+      teamId: 'personal:user-1',
+      callerType: 'apiKey',
+      callerId: 'user-1',
+    });
+    (fetchLeaderboard as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [],
+      fromCache: true,
+      cachedAt: Date.now(),
+    });
+  });
+
+  afterEach(() => {
+    if (prev === undefined) {
+      delete process.env[FLAG];
+    } else {
+      process.env[FLAG] = prev;
+    }
+  });
+
+  it('returns 404 when the flag is OFF (default)', async () => {
+    delete process.env[FLAG];
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest('daydream-byoc'), makeContext('daydream-byoc'));
+    expect(res.status).toBe(404);
+    expect(fetchLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for unknown slug even when flag is ON', async () => {
+    process.env[FLAG] = 'true';
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest('unknown-bundle'), makeContext('unknown-bundle'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 when unauthenticated with flag ON', async () => {
+    process.env[FLAG] = 'true';
+    (authorize as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest('daydream-byoc'), makeContext('daydream-byoc'));
+    expect(res.status).toBe(401);
+  });
+
+  it('daydream-byoc returns BYOC+tool addresses with X-Discovery-Bundle header', async () => {
+    process.env[FLAG] = 'true';
+    const { GET } = await import('./route');
+    const res = await GET(makeRequest('daydream-byoc'), makeContext('daydream-byoc'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Discovery-Bundle')).toBe('daydream-byoc');
+    expect(res.headers.get('X-Discovery-Mode')).toBe('signer-bundle');
+
+    const body = (await res.json()) as { address: string }[];
+    const addresses = body.map((o) => o.address);
+    expect(addresses).toContain('https://byoc-staging-1.daydream.monster:8935');
+    expect(addresses).toContain('https://tool-staging-1.daydream.monster:8935');
+    expect(addresses).not.toContain('https://liverunner-staging-1.daydream.monster:8935');
+  });
+
+  it('pymthouse-live-runner returns LR address and excludes BYOC hosts', async () => {
+    process.env[FLAG] = 'true';
+    const { GET } = await import('./route');
+    const res = await GET(
+      makeRequest('pymthouse-live-runner'),
+      makeContext('pymthouse-live-runner'),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Discovery-Bundle')).toBe('pymthouse-live-runner');
+
+    const body = (await res.json()) as { address: string }[];
+    const addresses = body.map((o) => o.address);
+    expect(addresses).toContain('https://liverunner-staging-1.daydream.monster:8935');
+    expect(addresses).not.toContain('https://byoc-staging-1.daydream.monster:8935');
+    expect(addresses).not.toContain('https://tool-staging-1.daydream.monster:8935');
+  });
+});

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/[slug]/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/[slug]/python-gateway/route.ts
@@ -1,0 +1,163 @@
+/**
+ * GET /api/v1/orchestrator-leaderboard/bundles/:slug/python-gateway
+ *
+ * Signer-bundle discovery — returns bare `[{ "address": "<orchUri>" }, ...]`
+ * for a configured signer plane:
+ *   - daydream-byoc          → Daydream signer + BYOC/tool orchs
+ *   - pymthouse-live-runner  → pymthouse signer + Live Runner orchs
+ *
+ * Gated by SIGNER_BUNDLE_DISCOVERY_ENABLED (default OFF). Bundle contents are
+ * admin-configurable via /bundles/config; code defaults come from
+ * STORYBOARD_DEFAULT_PLAN categories.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authorize } from '@/lib/gateway/authorize';
+import { getAuthToken } from '@/lib/api/response';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { DISCOVERY_RESPONSE_CACHE_CONTROL } from '@/lib/orchestrator-leaderboard/discovery-constants';
+import { getSignerBundle } from '@/lib/orchestrator-leaderboard/signer-bundle-config';
+import {
+  buildSignerBundleDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/signer-bundle-discovery';
+import {
+  isSignerBundleDiscoveryEnabled,
+  isSignerBundleSlug,
+  type SignerBundleSlug,
+} from '@/lib/orchestrator-leaderboard/signer-bundle-types';
+import { ensurePymthouseManifestFresh } from '@/lib/pymthouse-manifest';
+
+type RouteContext = { params: Promise<{ slug: string }> };
+
+const DEFAULT_TOP_N = 100;
+const MAX_TOP_N = 1000;
+
+function resolveTopN(url: URL, bundleDefault: number): number {
+  const raw = url.searchParams.get('topN');
+  if (!raw) return bundleDefault || DEFAULT_TOP_N;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_TOP_N) {
+    return bundleDefault || DEFAULT_TOP_N;
+  }
+  return parsed;
+}
+
+function resolveCapsFilter(url: URL): string[] | undefined {
+  const caps = url.searchParams
+    .getAll('caps')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (caps.length > 0) return [...new Set(caps)];
+
+  const single =
+    url.searchParams.get('capability')?.trim() ||
+    url.searchParams.get('model')?.trim();
+  return single ? [single] : undefined;
+}
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext,
+): Promise<Response> {
+  if (!isSignerBundleDiscoveryEnabled()) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const { slug: rawSlug } = await context.params;
+  if (!isSignerBundleSlug(rawSlug)) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+  const slug: SignerBundleSlug = rawSlug;
+
+  const auth = await authorize(request);
+  if (!auth) {
+    return new NextResponse('Unauthorized', {
+      status: 401,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const bundle = await getSignerBundle(slug);
+  if (!bundle || !bundle.enabled) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  if (bundle.billingProviderSlug === 'pymthouse') {
+    try {
+      await ensurePymthouseManifestFresh();
+    } catch (err) {
+      console.warn('[signer-bundle-discovery] pymthouse manifest refresh failed', err);
+    }
+  }
+
+  const url = new URL(request.url);
+  const topN = resolveTopN(url, bundle.topN);
+  const filterCapabilities = resolveCapsFilter(url);
+  const authToken = getAuthToken(request) || '';
+  const cookieHeader = request.headers.get('cookie');
+
+  const fetchCapabilityAddresses = async (
+    leaderboardCap: string,
+  ): Promise<CapabilityFetchResult> => {
+    const result = await fetchLeaderboard(leaderboardCap, authToken, request.url, cookieHeader);
+    const addresses: string[] = [];
+    for (const row of result.rows) {
+      const address = row.orch_uri?.trim();
+      if (address) addresses.push(address);
+    }
+    return { addresses, fromCache: result.fromCache, cachedAt: result.cachedAt };
+  };
+
+  try {
+    const { addresses, meta } = await buildSignerBundleDiscovery({
+      bundle,
+      fetchCapabilityAddresses,
+      filterCapabilities,
+      topN,
+    });
+
+    const out = addresses.map((address) => ({ address }));
+
+    console.info(
+      '[signer-bundle-discovery] served',
+      JSON.stringify({
+        slug,
+        billingProviderSlug: bundle.billingProviderSlug,
+        total: out.length,
+        categories: meta.categoriesQueried,
+        capabilitiesQueried: meta.capabilitiesQueried,
+        staticFleetInjected: meta.staticFleetInjected,
+        fromCache: meta.fromCache,
+      }),
+    );
+
+    return NextResponse.json(out, {
+      headers: {
+        'Cache-Control': DISCOVERY_RESPONSE_CACHE_CONTROL,
+        'X-Cache': meta.fromCache ? 'HIT' : 'MISS',
+        'X-Cache-Age': String(meta.cacheAgeMs),
+        'X-Discovery-Bundle': slug,
+        'X-Discovery-Mode': 'signer-bundle',
+      },
+    });
+  } catch (err) {
+    console.error('[signer-bundle-discovery] failed', { slug, err });
+    return new NextResponse('Internal server error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/config/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/config/route.ts
@@ -1,0 +1,78 @@
+/**
+ * GET  /api/v1/orchestrator-leaderboard/bundles/config — list resolved signer bundles (admin)
+ * PUT  /api/v1/orchestrator-leaderboard/bundles/config — update bundle overrides (admin)
+ *
+ * Persists overrides on the sentinel LeaderboardSource row `signer-bundle-config`.
+ */
+
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { validateSession } from '@/lib/api/auth';
+import { success, errors, getAuthToken } from '@/lib/api/response';
+import {
+  listSignerBundles,
+  updateSignerBundlesConfig,
+} from '@/lib/orchestrator-leaderboard/signer-bundle-config';
+import {
+  SIGNER_BUNDLE_DISCOVERY_FLAG,
+  SignerBundlesConfigSchema,
+  isSignerBundleDiscoveryEnabled,
+} from '@/lib/orchestrator-leaderboard/signer-bundle-types';
+
+async function requireAdmin(request: NextRequest) {
+  const token = getAuthToken(request);
+  if (!token) return { error: errors.unauthorized() as Response };
+  const user = await validateSession(token);
+  if (!user) return { error: errors.unauthorized('Invalid session') as Response };
+  if (!user.roles.includes('system:admin')) {
+    return { error: errors.forbidden('Admin permission required') as Response };
+  }
+  return { user };
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const auth = await requireAdmin(request);
+  if ('error' in auth && auth.error) return auth.error;
+
+  try {
+    const bundles = await listSignerBundles();
+    return success({
+      enabled: isSignerBundleDiscoveryEnabled(),
+      flag: SIGNER_BUNDLE_DISCOVERY_FLAG,
+      bundles,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to read bundle config';
+    return errors.internal(message);
+  }
+}
+
+export async function PUT(request: NextRequest): Promise<Response> {
+  const auth = await requireAdmin(request);
+  if ('error' in auth && auth.error) return auth.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errors.badRequest('Invalid JSON body');
+  }
+
+  const parsed = SignerBundlesConfigSchema.safeParse(body);
+  if (!parsed.success) {
+    return errors.badRequest(parsed.error.issues[0]?.message ?? 'Invalid bundle config');
+  }
+
+  try {
+    const bundles = await updateSignerBundlesConfig(parsed.data);
+    return success({
+      enabled: isSignerBundleDiscoveryEnabled(),
+      flag: SIGNER_BUNDLE_DISCOVERY_FLAG,
+      bundles,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update bundle config';
+    return errors.internal(message);
+  }
+}

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/sources/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/sources/route.ts
@@ -11,6 +11,7 @@ import { validateSession } from '@/lib/api/auth';
 import { getAuthToken } from '@/lib/api/response';
 import { SOURCE_KINDS } from '@/lib/orchestrator-leaderboard/sources';
 import type { SourceKind } from '@/lib/orchestrator-leaderboard/sources';
+import { isSignerBundleConfigSourceKind } from '@/lib/orchestrator-leaderboard/signer-bundle-config';
 import { z } from 'zod';
 
 const DEFAULT_SOURCES: { kind: SourceKind; priority: number; enabled: boolean }[] = [
@@ -67,9 +68,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   try {
     await ensureSeeded();
-    const sources = await prisma.leaderboardSource.findMany({
-      orderBy: { priority: 'asc' },
-    });
+    const sources = (
+      await prisma.leaderboardSource.findMany({
+        orderBy: { priority: 'asc' },
+      })
+    ).filter((s) => !isSignerBundleConfigSourceKind(s.kind));
 
     // Fetch connector details for each source
     const connectorSlugs = sources.map((s) => SOURCE_TO_CONNECTOR[s.kind]).filter(Boolean);

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-config.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { mergeSignerBundleForTest } from '../signer-bundle-config';
+import { SIGNER_BUNDLE_DEFAULTS } from '../signer-bundle-defaults';
+import {
+  isSignerBundleDiscoveryEnabled,
+  isSignerBundleSlug,
+  SIGNER_BUNDLE_DISCOVERY_FLAG,
+  SignerBundlesConfigSchema,
+} from '../signer-bundle-types';
+
+describe('signer-bundle-config helpers', () => {
+  it('isSignerBundleSlug accepts only known slugs', () => {
+    expect(isSignerBundleSlug('daydream-byoc')).toBe(true);
+    expect(isSignerBundleSlug('pymthouse-live-runner')).toBe(true);
+    expect(isSignerBundleSlug('storyboard-default')).toBe(false);
+  });
+
+  it('flag defaults OFF', () => {
+    const prev = process.env[SIGNER_BUNDLE_DISCOVERY_FLAG];
+    delete process.env[SIGNER_BUNDLE_DISCOVERY_FLAG];
+    expect(isSignerBundleDiscoveryEnabled()).toBe(false);
+    process.env[SIGNER_BUNDLE_DISCOVERY_FLAG] = 'true';
+    expect(isSignerBundleDiscoveryEnabled()).toBe(true);
+    process.env[SIGNER_BUNDLE_DISCOVERY_FLAG] = '1';
+    expect(isSignerBundleDiscoveryEnabled()).toBe(true);
+    if (prev === undefined) delete process.env[SIGNER_BUNDLE_DISCOVERY_FLAG];
+    else process.env[SIGNER_BUNDLE_DISCOVERY_FLAG] = prev;
+  });
+
+  it('merge preserves defaults for omitted fields', () => {
+    const merged = mergeSignerBundleForTest('daydream-byoc', {
+      slug: 'daydream-byoc',
+      topN: 5,
+    });
+    expect(merged.topN).toBe(5);
+    expect(merged.categories).toEqual(SIGNER_BUNDLE_DEFAULTS['daydream-byoc'].categories);
+    expect(merged.billingProviderSlug).toBe('daydream');
+  });
+
+  it('rejects invalid admin payload', () => {
+    const bad = SignerBundlesConfigSchema.safeParse({
+      bundles: [{ slug: 'not-a-bundle', topN: 1 }],
+    });
+    expect(bad.success).toBe(false);
+  });
+
+  it('accepts valid admin override payload', () => {
+    const ok = SignerBundlesConfigSchema.safeParse({
+      bundles: [
+        {
+          slug: 'pymthouse-live-runner',
+          categories: ['lr'],
+          categoryStaticOrchestrators: {
+            lr: ['https://liverunner-staging-1.daydream.monster:8935'],
+          },
+          topN: 50,
+        },
+      ],
+    });
+    expect(ok.success).toBe(true);
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-discovery.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-discovery.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../provider-restrictions', () => ({
+  isCapabilityAllowedForProvider: vi.fn(() => true),
+}));
+
+import { isCapabilityAllowedForProvider } from '../provider-restrictions';
+import { buildSignerBundleDiscovery } from '../signer-bundle-discovery';
+import { SIGNER_BUNDLE_DEFAULTS } from '../signer-bundle-defaults';
+import { mergeSignerBundleForTest } from '../signer-bundle-config';
+import type { CapabilityFetchResult } from '../signer-bundle-discovery';
+
+const BYOC = 'https://byoc-staging-1.daydream.monster:8935';
+const TOOL = 'https://tool-staging-1.daydream.monster:8935';
+const LR = 'https://liverunner-staging-1.daydream.monster:8935';
+
+function emptyFetch(): (cap: string) => Promise<CapabilityFetchResult> {
+  return async () => ({ addresses: [], fromCache: true, cachedAt: Date.now() });
+}
+
+function hostFetch(host: string): (cap: string) => Promise<CapabilityFetchResult> {
+  return async () => ({ addresses: [host], fromCache: false, cachedAt: Date.now() });
+}
+
+describe('buildSignerBundleDiscovery', () => {
+  beforeEach(() => {
+    vi.mocked(isCapabilityAllowedForProvider).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('daydream-byoc injects BYOC + tool static fleet when ClickHouse is empty', async () => {
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['daydream-byoc'],
+      fetchCapabilityAddresses: emptyFetch(),
+      random: () => 0,
+    });
+    expect(result.addresses).toContain(BYOC);
+    expect(result.addresses).toContain(TOOL);
+    expect(result.addresses).not.toContain(LR);
+    expect(result.meta.staticFleetInjected).toBeGreaterThan(0);
+  });
+
+  it('pymthouse-live-runner injects LR static fleet and excludes BYOC/tool hosts', async () => {
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['pymthouse-live-runner'],
+      fetchCapabilityAddresses: emptyFetch(),
+      random: () => 0,
+    });
+    expect(result.addresses).toContain(LR);
+    expect(result.addresses).not.toContain(BYOC);
+    expect(result.addresses).not.toContain(TOOL);
+  });
+
+  it('respects provider denylist — empty allowed caps → no static fleet', async () => {
+    vi.mocked(isCapabilityAllowedForProvider).mockReturnValue(false);
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['pymthouse-live-runner'],
+      fetchCapabilityAddresses: hostFetch(LR),
+      random: () => 0,
+    });
+    expect(result.addresses).toEqual([]);
+    expect(result.meta.capabilitiesQueried).toBe(0);
+  });
+
+  it('filters by caps= short name', async () => {
+    const fetch = vi.fn(hostFetch(BYOC));
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['daydream-byoc'],
+      fetchCapabilityAddresses: fetch,
+      filterCapabilities: ['flux-dev'],
+      random: () => 0,
+    });
+    expect(result.addresses).toContain(BYOC);
+    // Only flux-dev (and maybe other matching) — fetch called for flux-dev
+    const calledCaps = fetch.mock.calls.map((c) => c[0]);
+    expect(calledCaps).toContain('flux-dev');
+    expect(calledCaps).not.toContain('ffmpeg-concat');
+  });
+
+  it('disabled bundle returns empty addresses', async () => {
+    const bundle = mergeSignerBundleForTest('daydream-byoc', { slug: 'daydream-byoc', enabled: false });
+    const result = await buildSignerBundleDiscovery({
+      bundle,
+      fetchCapabilityAddresses: hostFetch(BYOC),
+    });
+    expect(result.addresses).toEqual([]);
+  });
+
+  it('admin category override can drop tool from daydream-byoc', async () => {
+    const bundle = mergeSignerBundleForTest('daydream-byoc', {
+      slug: 'daydream-byoc',
+      categories: ['byoc'],
+    });
+    const result = await buildSignerBundleDiscovery({
+      bundle,
+      fetchCapabilityAddresses: emptyFetch(),
+      random: () => 0,
+    });
+    expect(result.addresses).toContain(BYOC);
+    expect(result.addresses).not.toContain(TOOL);
+  });
+
+  it('honors topN', async () => {
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['daydream-byoc'],
+      fetchCapabilityAddresses: emptyFetch(),
+      topN: 1,
+      random: () => 0,
+    });
+    expect(result.addresses).toHaveLength(1);
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-parity.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-parity.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Parity / isolation tests for the two signer discovery bundles.
+ *
+ * Guarantees:
+ *   - daydream-byoc ⊇ { byoc-staging-1, tool-staging-1 } and never LR host
+ *   - pymthouse-live-runner ⊇ { liverunner-staging-1 } and never BYOC/tool hosts
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../provider-restrictions', () => ({
+  isCapabilityAllowedForProvider: vi.fn(() => true),
+}));
+
+import { buildSignerBundleDiscovery } from '../signer-bundle-discovery';
+import { SIGNER_BUNDLE_DEFAULTS } from '../signer-bundle-defaults';
+import { STORYBOARD_DEFAULT_PLAN } from '../storyboard-default-plan';
+
+const BYOC = 'https://byoc-staging-1.daydream.monster:8935';
+const TOOL = 'https://tool-staging-1.daydream.monster:8935';
+const LR = 'https://liverunner-staging-1.daydream.monster:8935';
+const SCOPE = 'https://orch-staging-1.daydream.monster:8935';
+
+describe('signer-bundle parity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('daydream-byoc defaults match STORYBOARD_DEFAULT_PLAN byoc+tool baselines', () => {
+    const bundle = SIGNER_BUNDLE_DEFAULTS['daydream-byoc'];
+    expect(bundle.billingProviderSlug).toBe('daydream');
+    expect(bundle.categories).toEqual(['byoc', 'tool']);
+    expect(bundle.categoryCapabilities?.byoc).toEqual([
+      ...STORYBOARD_DEFAULT_PLAN.byoc.capabilities,
+    ]);
+    expect(bundle.categoryCapabilities?.tool).toEqual([
+      ...STORYBOARD_DEFAULT_PLAN.tool.capabilities,
+    ]);
+    expect(bundle.categoryStaticOrchestrators?.byoc).toEqual([
+      ...STORYBOARD_DEFAULT_PLAN.byoc.staticOrchestrators,
+    ]);
+    expect(bundle.categoryStaticOrchestrators?.tool).toEqual([
+      ...STORYBOARD_DEFAULT_PLAN.tool.staticOrchestrators,
+    ]);
+  });
+
+  it('pymthouse-live-runner defaults match STORYBOARD_DEFAULT_PLAN lr baseline', () => {
+    const bundle = SIGNER_BUNDLE_DEFAULTS['pymthouse-live-runner'];
+    expect(bundle.billingProviderSlug).toBe('pymthouse');
+    expect(bundle.categories).toEqual(['lr']);
+    expect(bundle.categoryCapabilities?.lr).toEqual([
+      ...STORYBOARD_DEFAULT_PLAN.lr.capabilities,
+    ]);
+    expect(bundle.categoryStaticOrchestrators?.lr).toEqual([
+      ...STORYBOARD_DEFAULT_PLAN.lr.staticOrchestrators,
+    ]);
+  });
+
+  it('daydream-byoc shortlist contains BYOC+tool and excludes LR + scope', async () => {
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['daydream-byoc'],
+      fetchCapabilityAddresses: async () => ({
+        addresses: [],
+        fromCache: true,
+        cachedAt: Date.now(),
+      }),
+      random: () => 0,
+    });
+    expect(result.addresses).toEqual(expect.arrayContaining([BYOC, TOOL]));
+    expect(result.addresses).not.toContain(LR);
+    expect(result.addresses).not.toContain(SCOPE);
+  });
+
+  it('pymthouse-live-runner shortlist contains LR and excludes BYOC+tool+scope', async () => {
+    const result = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['pymthouse-live-runner'],
+      fetchCapabilityAddresses: async () => ({
+        addresses: [],
+        fromCache: true,
+        cachedAt: Date.now(),
+      }),
+      random: () => 0,
+    });
+    expect(result.addresses).toContain(LR);
+    expect(result.addresses).not.toContain(BYOC);
+    expect(result.addresses).not.toContain(TOOL);
+    expect(result.addresses).not.toContain(SCOPE);
+  });
+
+  it('no address appears in both default shortlists (cross-contamination)', async () => {
+    const daydream = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['daydream-byoc'],
+      fetchCapabilityAddresses: async () => ({
+        addresses: [],
+        fromCache: true,
+        cachedAt: Date.now(),
+      }),
+      random: () => 0,
+    });
+    const lr = await buildSignerBundleDiscovery({
+      bundle: SIGNER_BUNDLE_DEFAULTS['pymthouse-live-runner'],
+      fetchCapabilityAddresses: async () => ({
+        addresses: [],
+        fromCache: true,
+        cachedAt: Date.now(),
+      }),
+      random: () => 0,
+    });
+    const overlap = daydream.addresses.filter((a) => lr.addresses.includes(a));
+    expect(overlap).toEqual([]);
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/global-refresh.ts
@@ -10,12 +10,13 @@
 import { prisma } from '@/lib/db';
 import { Prisma } from '@naap/database';
 import type { SourceKind, NormalizedOrch, SourceStats } from './sources/types';
-import { getAdapter } from './sources';
+import { getAdapter, SOURCE_KINDS } from './sources';
 import { resolve, type ResolverConfig, type AuditEntry } from './resolver';
 import { getGlobalDatasetStats, writeGlobalDataset } from './global-dataset';
 import { getMembershipStrategy, getRefreshIntervalMs } from './config';
 import { clearPlanCache } from './refresh';
 import { syncPymthouseManifestSnapshot } from '@/lib/pymthouse-manifest';
+import { isSignerBundleConfigSourceKind } from './signer-bundle-config';
 
 // ---------------------------------------------------------------------------
 // Load resolver config from DB (LeaderboardSource table)
@@ -48,12 +49,17 @@ async function loadResolverConfig(): Promise<ResolverConfig> {
       orderBy: { priority: 'asc' },
     });
 
+    // Ignore sentinel config rows (e.g. signer-bundle-config) and unknown kinds
+    // so admin-persisted JSON never enters the refresh adapter pipeline.
+    const known = new Set<string>(SOURCE_KINDS);
     return {
-      sources: rows.map((r) => ({
-        kind: r.kind as SourceKind,
-        priority: r.priority,
-        enabled: r.enabled,
-      })),
+      sources: rows
+        .filter((r) => known.has(r.kind) && !isSignerBundleConfigSourceKind(r.kind))
+        .map((r) => ({
+          kind: r.kind as SourceKind,
+          priority: r.priority,
+          enabled: r.enabled,
+        })),
     };
   } catch {
     // DB not migrated yet — fall back to defaults

--- a/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-config.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-config.ts
@@ -1,0 +1,170 @@
+/**
+ * Signer-bundle config loader.
+ *
+ * Persistence uses a sentinel LeaderboardSource row
+ * (`kind = signer-bundle-config`, always disabled) so we stay inside the
+ * existing plugin tables — no schema migration, no cross-plugin pollution.
+ * The refresh pipeline and sources admin UI must ignore this kind.
+ */
+
+import { prisma } from '@/lib/db';
+import { Prisma } from '@naap/database';
+import { SIGNER_BUNDLE_DEFAULTS, listDefaultSignerBundles } from './signer-bundle-defaults';
+import {
+  SIGNER_BUNDLE_CONFIG_SOURCE_KIND,
+  SIGNER_BUNDLE_SLUGS,
+  SignerBundlesConfigSchema,
+  type SignerDiscoveryBundle,
+  type SignerDiscoveryBundleOverride,
+  type SignerBundleSlug,
+  type SignerBundlesConfig,
+} from './signer-bundle-types';
+
+function mergeBundle(
+  base: SignerDiscoveryBundle,
+  override?: SignerDiscoveryBundleOverride,
+): SignerDiscoveryBundle {
+  if (!override) return { ...base, categories: [...base.categories] };
+
+  return {
+    slug: base.slug,
+    name: override.name ?? base.name,
+    enabled: override.enabled ?? base.enabled,
+    billingProviderSlug: override.billingProviderSlug ?? base.billingProviderSlug,
+    categories: override.categories ? [...override.categories] : [...base.categories],
+    categoryCapabilities: override.categoryCapabilities
+      ? { ...override.categoryCapabilities }
+      : base.categoryCapabilities
+        ? { ...base.categoryCapabilities }
+        : undefined,
+    categoryStaticOrchestrators: override.categoryStaticOrchestrators
+      ? { ...override.categoryStaticOrchestrators }
+      : base.categoryStaticOrchestrators
+        ? { ...base.categoryStaticOrchestrators }
+        : undefined,
+    topN: override.topN ?? base.topN,
+  };
+}
+
+function parseStoredConfig(raw: unknown): SignerBundlesConfig {
+  const parsed = SignerBundlesConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { bundles: [] };
+  }
+  return parsed.data;
+}
+
+/**
+ * Optional env override: SIGNER_BUNDLE_OVERRIDES='{"bundles":[...]}'
+ * Applied after DB overrides (env wins for ops hotfixes).
+ */
+function envOverrides(): SignerBundlesConfig {
+  const raw = process.env.SIGNER_BUNDLE_OVERRIDES?.trim();
+  if (!raw) return { bundles: [] };
+  try {
+    return parseStoredConfig(JSON.parse(raw));
+  } catch {
+    return { bundles: [] };
+  }
+}
+
+async function readDbOverrides(): Promise<SignerBundlesConfig> {
+  try {
+    const row = await prisma.leaderboardSource.findUnique({
+      where: { kind: SIGNER_BUNDLE_CONFIG_SOURCE_KIND },
+      select: { config: true },
+    });
+    if (!row?.config) return { bundles: [] };
+    return parseStoredConfig(row.config);
+  } catch {
+    return { bundles: [] };
+  }
+}
+
+function applyOverrides(
+  defaults: SignerDiscoveryBundle[],
+  ...layers: SignerBundlesConfig[]
+): SignerDiscoveryBundle[] {
+  const bySlug = new Map<SignerBundleSlug, SignerDiscoveryBundle>();
+  for (const d of defaults) {
+    bySlug.set(d.slug, d);
+  }
+  for (const layer of layers) {
+    for (const o of layer.bundles) {
+      const base = bySlug.get(o.slug);
+      if (!base) continue;
+      bySlug.set(o.slug, mergeBundle(base, o));
+    }
+  }
+  return SIGNER_BUNDLE_SLUGS.map((slug) => bySlug.get(slug)!).filter(Boolean);
+}
+
+/** Resolve all bundles: code defaults ← DB ← env. */
+export async function listSignerBundles(): Promise<SignerDiscoveryBundle[]> {
+  const db = await readDbOverrides();
+  const env = envOverrides();
+  return applyOverrides(listDefaultSignerBundles(), db, env);
+}
+
+/** Resolve one bundle by slug; null if unknown. */
+export async function getSignerBundle(
+  slug: SignerBundleSlug,
+): Promise<SignerDiscoveryBundle | null> {
+  const all = await listSignerBundles();
+  return all.find((b) => b.slug === slug) ?? null;
+}
+
+/**
+ * Persist admin overrides. Merges provided bundle patches into the sentinel
+ * LeaderboardSource.config JSON. Always keeps the row enabled=false so the
+ * refresh pipeline never treats it as a data source.
+ */
+export async function updateSignerBundlesConfig(
+  input: SignerBundlesConfig,
+): Promise<SignerDiscoveryBundle[]> {
+  const parsed = SignerBundlesConfigSchema.parse(input);
+
+  const existing = await readDbOverrides();
+  const mergedBySlug = new Map<string, SignerDiscoveryBundleOverride>();
+  for (const b of existing.bundles) {
+    mergedBySlug.set(b.slug, b);
+  }
+  for (const b of parsed.bundles) {
+    const prev = mergedBySlug.get(b.slug);
+    mergedBySlug.set(b.slug, prev ? { ...prev, ...b } : b);
+  }
+
+  const stored: SignerBundlesConfig = {
+    bundles: [...mergedBySlug.values()],
+  };
+
+  await prisma.leaderboardSource.upsert({
+    where: { kind: SIGNER_BUNDLE_CONFIG_SOURCE_KIND },
+    update: {
+      enabled: false,
+      priority: 999,
+      config: stored as unknown as Prisma.InputJsonValue,
+    },
+    create: {
+      kind: SIGNER_BUNDLE_CONFIG_SOURCE_KIND,
+      enabled: false,
+      priority: 999,
+      config: stored as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  return listSignerBundles();
+}
+
+/** True when a LeaderboardSource.kind is the config sentinel (never a refresh adapter). */
+export function isSignerBundleConfigSourceKind(kind: string): boolean {
+  return kind === SIGNER_BUNDLE_CONFIG_SOURCE_KIND;
+}
+
+/** Exposed for tests — merge without I/O. */
+export function mergeSignerBundleForTest(
+  slug: SignerBundleSlug,
+  override?: SignerDiscoveryBundleOverride,
+): SignerDiscoveryBundle {
+  return mergeBundle(SIGNER_BUNDLE_DEFAULTS[slug], override);
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-defaults.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-defaults.ts
@@ -1,0 +1,47 @@
+/**
+ * Code defaults for signer-bundle discovery.
+ *
+ * Seeded from STORYBOARD_DEFAULT_PLAN categories so Daydream-BYOC and
+ * pymthouse-Live-Runner shortlists stay aligned with the committed staging
+ * baseline until an admin override is saved.
+ */
+
+import { STORYBOARD_DEFAULT_PLAN } from './storyboard-default-plan';
+import type { SignerDiscoveryBundle, SignerBundleSlug } from './signer-bundle-types';
+
+export const SIGNER_BUNDLE_DEFAULTS: Record<SignerBundleSlug, SignerDiscoveryBundle> = {
+  'daydream-byoc': {
+    slug: 'daydream-byoc',
+    name: 'Daydream signer + BYOC/tool orchestrators',
+    enabled: true,
+    billingProviderSlug: 'daydream',
+    categories: ['byoc', 'tool'],
+    categoryCapabilities: {
+      byoc: [...STORYBOARD_DEFAULT_PLAN.byoc.capabilities],
+      tool: [...STORYBOARD_DEFAULT_PLAN.tool.capabilities],
+    },
+    categoryStaticOrchestrators: {
+      byoc: [...STORYBOARD_DEFAULT_PLAN.byoc.staticOrchestrators],
+      tool: [...STORYBOARD_DEFAULT_PLAN.tool.staticOrchestrators],
+    },
+    topN: 100,
+  },
+  'pymthouse-live-runner': {
+    slug: 'pymthouse-live-runner',
+    name: 'pymthouse signer + Live Runner orchestrators',
+    enabled: true,
+    billingProviderSlug: 'pymthouse',
+    categories: ['lr'],
+    categoryCapabilities: {
+      lr: [...STORYBOARD_DEFAULT_PLAN.lr.capabilities],
+    },
+    categoryStaticOrchestrators: {
+      lr: [...STORYBOARD_DEFAULT_PLAN.lr.staticOrchestrators],
+    },
+    topN: 100,
+  },
+};
+
+export function listDefaultSignerBundles(): SignerDiscoveryBundle[] {
+  return Object.values(SIGNER_BUNDLE_DEFAULTS);
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-discovery.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-discovery.ts
@@ -1,0 +1,187 @@
+/**
+ * Build a plane-scoped orchestrator shortlist for a signer discovery bundle.
+ *
+ * Reuses static-fleet + tier-shuffle helpers from storyboard-default discovery
+ * without changing that path. Response is orch URIs only (python-gateway shape).
+ */
+
+import type { StoryboardDefaultCategory } from './storyboard-default-plan';
+import { mergeStaticFleet, staticFleetGaps } from './static-fleet';
+import {
+  tieredShuffleDiscoveryAddresses,
+  type RandomSource,
+} from './discovery-order';
+import { isCapabilityAllowedForProvider } from './provider-restrictions';
+import type { SignerDiscoveryBundle, SignerBundleCategory } from './signer-bundle-types';
+
+export interface CapabilityFetchResult {
+  addresses: string[];
+  fromCache: boolean;
+  cachedAt: number;
+}
+
+export type FetchCapabilityAddresses = (
+  leaderboardCap: string,
+) => Promise<CapabilityFetchResult>;
+
+export interface SignerBundleDiscoveryResult {
+  addresses: string[];
+  meta: {
+    fromCache: boolean;
+    cacheAgeMs: number;
+    staticFleetInjected: number;
+    categoriesQueried: SignerBundleCategory[];
+    capabilitiesQueried: number;
+  };
+}
+
+export interface BuildSignerBundleDiscoveryArgs {
+  bundle: SignerDiscoveryBundle;
+  fetchCapabilityAddresses: FetchCapabilityAddresses;
+  /** When set, only collect addresses for these short/full capability names. */
+  filterCapabilities?: string[];
+  topN?: number;
+  random?: RandomSource;
+}
+
+function leaderboardCapFromPath(raw: string): string {
+  const value = raw.trim();
+  const slash = value.lastIndexOf('/');
+  return slash >= 0 ? value.slice(slash + 1).trim() : value;
+}
+
+function resolveCategory(
+  bundle: SignerDiscoveryBundle,
+  key: SignerBundleCategory,
+): StoryboardDefaultCategory {
+  const capabilities = bundle.categoryCapabilities?.[key] ?? [];
+  const staticOrchestrators = bundle.categoryStaticOrchestrators?.[key] ?? [];
+  return { capabilities, staticOrchestrators };
+}
+
+function matchesFilter(rawCap: string, filter?: string[]): boolean {
+  if (!filter || filter.length === 0) return true;
+  const short = leaderboardCapFromPath(rawCap);
+  return filter.some((f) => {
+    const needle = f.trim();
+    if (!needle) return false;
+    return needle === rawCap || needle === short || leaderboardCapFromPath(needle) === short;
+  });
+}
+
+async function collectCategory(
+  category: StoryboardDefaultCategory,
+  billingProviderSlug: string,
+  fetchCapabilityAddresses: FetchCapabilityAddresses,
+  topN: number,
+  filterCapabilities?: string[],
+): Promise<{
+  discovered: string[];
+  allowedCapabilities: string[];
+  fromCache: boolean;
+  cacheAgeMs: number;
+}> {
+  const discovered: string[] = [];
+  const seen = new Set<string>();
+  const allowedCapabilities: string[] = [];
+  let fromCache = true;
+  let cacheAgeMs = 0;
+
+  for (const raw of category.capabilities) {
+    if (!matchesFilter(raw, filterCapabilities)) continue;
+    if (!isCapabilityAllowedForProvider(raw, billingProviderSlug)) continue;
+    allowedCapabilities.push(raw);
+
+    const leaderboardCap = leaderboardCapFromPath(raw);
+    const result = await fetchCapabilityAddresses(leaderboardCap);
+    fromCache = fromCache && result.fromCache;
+    cacheAgeMs = Math.max(cacheAgeMs, Date.now() - result.cachedAt);
+
+    for (const addr of result.addresses) {
+      const address = addr.trim();
+      if (!address || seen.has(address)) continue;
+      seen.add(address);
+      discovered.push(address);
+      if (discovered.length >= topN) break;
+    }
+    if (discovered.length >= topN) break;
+  }
+
+  return { discovered, allowedCapabilities, fromCache, cacheAgeMs };
+}
+
+/**
+ * Build the orchestrator address list for one signer bundle.
+ * Disabled bundles return an empty list (caller may 404 separately).
+ */
+export async function buildSignerBundleDiscovery(
+  args: BuildSignerBundleDiscoveryArgs,
+): Promise<SignerBundleDiscoveryResult> {
+  const { bundle, fetchCapabilityAddresses, filterCapabilities, random } = args;
+  const topN = args.topN ?? bundle.topN;
+
+  if (!bundle.enabled) {
+    return {
+      addresses: [],
+      meta: {
+        fromCache: true,
+        cacheAgeMs: 0,
+        staticFleetInjected: 0,
+        categoriesQueried: [],
+        capabilitiesQueried: 0,
+      },
+    };
+  }
+
+  let fromCache = true;
+  let cacheAgeMs = 0;
+  let staticFleetInjected = 0;
+  let capabilitiesQueried = 0;
+  const flattened: string[] = [];
+  const seen = new Set<string>();
+
+  for (const key of bundle.categories) {
+    const category = resolveCategory(bundle, key);
+    const collected = await collectCategory(
+      category,
+      bundle.billingProviderSlug,
+      fetchCapabilityAddresses,
+      topN,
+      filterCapabilities,
+    );
+    fromCache = fromCache && collected.fromCache;
+    cacheAgeMs = Math.max(cacheAgeMs, collected.cacheAgeMs);
+    capabilitiesQueried += collected.allowedCapabilities.length;
+
+    // Match storyboard-default: inject static fleet only when at least one
+    // provider-allowed capability was queried for this category.
+    const staticFleet =
+      collected.allowedCapabilities.length > 0 ? [...category.staticOrchestrators] : [];
+    staticFleetInjected += staticFleetGaps(collected.discovered, staticFleet).length;
+
+    const merged = mergeStaticFleet(collected.discovered, staticFleet);
+    for (const addr of merged) {
+      if (seen.has(addr)) continue;
+      seen.add(addr);
+      flattened.push(addr);
+      if (flattened.length >= topN) break;
+    }
+    if (flattened.length >= topN) break;
+  }
+
+  const addresses = tieredShuffleDiscoveryAddresses(
+    flattened.slice(0, topN),
+    random ? { random } : undefined,
+  );
+
+  return {
+    addresses,
+    meta: {
+      fromCache,
+      cacheAgeMs,
+      staticFleetInjected,
+      categoriesQueried: [...bundle.categories],
+      capabilitiesQueried,
+    },
+  };
+}

--- a/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-types.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-types.ts
@@ -1,0 +1,80 @@
+/**
+ * Signer-bundle discovery — types & validation.
+ *
+ * Two configurable python-gateway discovery endpoints return the right
+ * orchestrator shortlist for:
+ *   1) daydream-byoc          — Daydream signer + BYOC/tool orchs
+ *   2) pymthouse-live-runner  — pymthouse signer + Live Runner orchs
+ *
+ * Config lives entirely inside the orchestrator-leaderboard plugin surface.
+ */
+
+import { z } from 'zod';
+
+export const SIGNER_BUNDLE_DISCOVERY_FLAG = 'SIGNER_BUNDLE_DISCOVERY_ENABLED';
+
+/** Sentinel LeaderboardSource.kind used to persist admin overrides (not a refresh adapter). */
+export const SIGNER_BUNDLE_CONFIG_SOURCE_KIND = 'signer-bundle-config';
+
+export const SIGNER_BUNDLE_SLUGS = ['daydream-byoc', 'pymthouse-live-runner'] as const;
+export type SignerBundleSlug = (typeof SIGNER_BUNDLE_SLUGS)[number];
+
+export const SIGNER_BUNDLE_CATEGORIES = ['scope', 'byoc', 'tool', 'lr'] as const;
+export type SignerBundleCategory = (typeof SIGNER_BUNDLE_CATEGORIES)[number];
+
+const CategoryListSchema = z.array(z.enum(SIGNER_BUNDLE_CATEGORIES)).min(1).max(4);
+
+const CapabilityMapSchema = z
+  .record(z.enum(SIGNER_BUNDLE_CATEGORIES), z.array(z.string().min(1).max(128)).max(100))
+  .optional();
+
+const StaticOrchMapSchema = z
+  .record(z.enum(SIGNER_BUNDLE_CATEGORIES), z.array(z.string().url()).max(50))
+  .optional();
+
+export const SignerDiscoveryBundleSchema = z.object({
+  slug: z.enum(SIGNER_BUNDLE_SLUGS),
+  name: z.string().min(1).max(255),
+  enabled: z.boolean(),
+  billingProviderSlug: z.enum(['daydream', 'pymthouse']),
+  categories: CategoryListSchema,
+  categoryCapabilities: CapabilityMapSchema,
+  categoryStaticOrchestrators: StaticOrchMapSchema,
+  topN: z.number().int().min(1).max(1000).default(100),
+});
+
+export type SignerDiscoveryBundle = z.infer<typeof SignerDiscoveryBundleSchema>;
+
+/** Partial admin override for one bundle (merged onto code defaults). */
+export const SignerDiscoveryBundleOverrideSchema = z.object({
+  slug: z.enum(SIGNER_BUNDLE_SLUGS),
+  name: z.string().min(1).max(255).optional(),
+  enabled: z.boolean().optional(),
+  billingProviderSlug: z.enum(['daydream', 'pymthouse']).optional(),
+  categories: CategoryListSchema.optional(),
+  categoryCapabilities: CapabilityMapSchema,
+  categoryStaticOrchestrators: StaticOrchMapSchema,
+  topN: z.number().int().min(1).max(1000).optional(),
+});
+
+export type SignerDiscoveryBundleOverride = z.infer<typeof SignerDiscoveryBundleOverrideSchema>;
+
+export const SignerBundlesConfigSchema = z.object({
+  bundles: z.array(SignerDiscoveryBundleOverrideSchema).max(2),
+});
+
+export type SignerBundlesConfig = z.infer<typeof SignerBundlesConfigSchema>;
+
+export function isSignerBundleSlug(value: string): value is SignerBundleSlug {
+  return (SIGNER_BUNDLE_SLUGS as readonly string[]).includes(value);
+}
+
+/**
+ * Master switch. Default OFF — any value other than "true"/"1" keeps endpoints 404.
+ */
+export function isSignerBundleDiscoveryEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env[SIGNER_BUNDLE_DISCOVERY_FLAG]?.trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}

--- a/plugins/orchestrator-leaderboard/docs/data-sources.md
+++ b/plugins/orchestrator-leaderboard/docs/data-sources.md
@@ -136,6 +136,37 @@ fallback** merged into the tier shuffle so no known orchestrator is dropped.
 
 ---
 
+## Signer discovery bundles (Daydream-BYOC vs pymthouse-LR)
+
+Two **configurable**, plane-scoped python-gateway endpoints return the right
+orchestrator shortlist for each signer stack. Additive and flag-gated — existing
+`/python-gateway`, `/plans/{id}/python-gateway`, and `storyboard-default` are
+unchanged.
+
+| Slug | Signer stack | Default categories | Default static fleet |
+| --- | --- | --- | --- |
+| `daydream-byoc` | Daydream signer + BYOC | `byoc`, `tool` | `byoc-staging-1`, `tool-staging-1` |
+| `pymthouse-live-runner` | pymthouse remote signer | `lr` | `liverunner-staging-1` |
+
+- **Endpoints**:
+  - `GET /api/v1/orchestrator-leaderboard/bundles/daydream-byoc/python-gateway`
+  - `GET /api/v1/orchestrator-leaderboard/bundles/pymthouse-live-runner/python-gateway`
+- **Response**: bare `[{ "address": "<orchUri>" }]` (BPP discovery shape).
+- **Auth**: Bearer (`gw_…` or session JWT), same as other python-gateway routes.
+- **Master flag**: `SIGNER_BUNDLE_DISCOVERY_ENABLED` (default **OFF** → `404`).
+- **Config**: code defaults from `STORYBOARD_DEFAULT_PLAN`; admin overrides via
+  `GET/PUT /api/v1/orchestrator-leaderboard/bundles/config` (persisted on a
+  sentinel `LeaderboardSource` row `signer-bundle-config`, ignored by refresh).
+  Optional env hotfix: `SIGNER_BUNDLE_OVERRIDES='{"bundles":[...]}'`.
+- **Provider filter**: fixed per bundle (`daydream` vs `pymthouse` manifest).
+- **Isolation**: parity tests assert no cross-contamination between the two
+  shortlists (BYOC/tool hosts never appear in the LR bundle and vice versa).
+
+Point an SDK node's `DISCOVERY_URL` at the matching bundle when ready; no
+Storyboard/pymthouse code changes are required for the NaaP-only MVP.
+
+---
+
 ## Audit log
 
 Every refresh writes a `LeaderboardRefreshAudit` record to the database with:


### PR DESCRIPTION
## Summary
- Adds two flag-gated python-gateway discovery endpoints under the orchestrator-leaderboard plugin:
  - `/bundles/daydream-byoc/python-gateway` → Daydream signer + BYOC/tool orchs
  - `/bundles/pymthouse-live-runner/python-gateway` → pymthouse signer + Live Runner orchs
- Bundle contents are configurable (code defaults from `STORYBOARD_DEFAULT_PLAN`, admin overrides via `/bundles/config`, optional `SIGNER_BUNDLE_OVERRIDES` env). Master switch: `SIGNER_BUNDLE_DISCOVERY_ENABLED` (default OFF → 404).
- Scoped entirely to leaderboard surfaces (lib + API + plugin docs). No global feature-flags, no schema migration, no Storyboard/pymthouse changes. Existing discovery routes unchanged.

## Test plan
- [x] `vitest` signer-bundle unit/parity/config tests (22) — pass
- [x] Related storyboard-default / golden-set / refresh regression tests (26) — pass
- [ ] Enable `SIGNER_BUNDLE_DISCOVERY_ENABLED=1` on a canary and curl both endpoints with a `gw_` key
- [ ] Confirm daydream-byoc shortlist contains byoc/tool hosts and excludes liverunner
- [ ] Confirm pymthouse-live-runner shortlist contains liverunner and excludes byoc/tool
- [ ] Confirm flag OFF still returns 404 (no prod regression)


Made with [Cursor](https://cursor.com)