### PR TITLE
feat(leaderboard): seed Daydream-BYOC and pymthouse-LR public discovery plans

### DIFF
--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/plans/[id]/python-gateway/route.test.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/plans/[id]/python-gateway/route.test.ts
@@ -17,9 +17,27 @@ vi.mock('@/lib/orchestrator-leaderboard/discovery-order', () => ({
   tieredShuffleDiscoveryAddresses: (addresses: string[]) => [...addresses],
 }));
 
+vi.mock('@/lib/orchestrator-leaderboard/query', () => ({
+  fetchLeaderboard: vi.fn(),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/signer-bundle-config', () => ({
+  getSignerBundle: vi.fn(),
+}));
+
+vi.mock('@/lib/orchestrator-leaderboard/signer-bundle-discovery', () => ({
+  buildSignerBundleDiscovery: vi.fn(),
+}));
+
+vi.mock('@/lib/pymthouse-manifest', () => ({
+  ensurePymthouseManifestFresh: vi.fn(async () => ({ revisionChanged: false })),
+}));
+
 import { authorize } from '@/lib/gateway/authorize';
 import { getPlan } from '@/lib/orchestrator-leaderboard/plans';
 import { evaluateAndCache } from '@/lib/orchestrator-leaderboard/refresh';
+import { getSignerBundle } from '@/lib/orchestrator-leaderboard/signer-bundle-config';
+import { buildSignerBundleDiscovery } from '@/lib/orchestrator-leaderboard/signer-bundle-discovery';
 
 describe('GET /api/v1/orchestrator-leaderboard/plans/:id/python-gateway', () => {
   beforeEach(() => {
@@ -98,5 +116,62 @@ describe('GET /api/v1/orchestrator-leaderboard/plans/:id/python-gateway', () => 
     const req = new NextRequest('http://localhost/api/v1/orchestrator-leaderboard/plans/plan-1/python-gateway');
     const res = await GET(req, { params: Promise.resolve({ id: 'plan-1' }) });
     expect(res.status).toBe(401);
+  });
+
+  it('serves signer-bundle shortlist for naap-default-daydream-byoc plans', async () => {
+    (getPlan as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'plan-byoc',
+      billingPlanId: 'naap-default-daydream-byoc',
+      billingProviderSlug: 'daydream',
+      name: 'Daydream Signer · BYOC / Tool',
+      description: null,
+      teamId: null,
+      ownerUserId: 'user-1',
+      capabilities: ['flux-dev'],
+      topN: 100,
+      slaWeights: null,
+      slaMinScore: null,
+      sortBy: null,
+      filters: null,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    (getSignerBundle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      slug: 'daydream-byoc',
+      enabled: true,
+      billingProviderSlug: 'daydream',
+      categories: ['byoc', 'tool'],
+      topN: 100,
+    });
+    (buildSignerBundleDiscovery as ReturnType<typeof vi.fn>).mockResolvedValue({
+      addresses: [
+        'https://byoc-staging-1.daydream.monster:8935',
+        'https://tool-staging-1.daydream.monster:8935',
+      ],
+      meta: {
+        fromCache: true,
+        cacheAgeMs: 0,
+        staticFleetInjected: 2,
+        categoriesQueried: ['byoc', 'tool'],
+        capabilitiesQueried: 2,
+      },
+    });
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(
+      'http://localhost/api/v1/orchestrator-leaderboard/plans/plan-byoc/python-gateway',
+      { headers: { Authorization: 'Bearer gw_test' } },
+    );
+    const res = await GET(req, { params: Promise.resolve({ id: 'plan-byoc' }) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Discovery-Mode')).toBe('signer-bundle-plan');
+    expect(res.headers.get('X-Discovery-Bundle')).toBe('daydream-byoc');
+    expect(evaluateAndCache).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual([
+      { address: 'https://byoc-staging-1.daydream.monster:8935' },
+      { address: 'https://tool-staging-1.daydream.monster:8935' },
+    ]);
   });
 });

--- a/apps/web-next/src/app/api/v1/orchestrator-leaderboard/plans/[id]/python-gateway/route.ts
+++ b/apps/web-next/src/app/api/v1/orchestrator-leaderboard/plans/[id]/python-gateway/route.ts
@@ -5,6 +5,10 @@
  * `[{ "address": "<orchUri>" }, ...]`
  *
  * Auth: same as plan results (NaaP `gw_…` gateway API key or NaaP session token).
+ *
+ * Signer-bundle public plans (`naap-default-daydream-byoc`,
+ * `naap-default-pymthouse-live-runner`) reuse the signer-bundle shortlist
+ * builder (static-fleet aware) so they match `/bundles/{slug}/python-gateway`.
  */
 
 export const runtime = 'nodejs';
@@ -12,15 +16,25 @@ export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { authorize } from '@/lib/gateway/authorize';
+import { getAuthToken } from '@/lib/api/response';
 import { DISCOVERY_RESPONSE_CACHE_CONTROL } from '@/lib/orchestrator-leaderboard/discovery-constants';
 import { getPlan } from '@/lib/orchestrator-leaderboard/plans';
 import { evaluateAndCache } from '@/lib/orchestrator-leaderboard/refresh';
 import { tieredShuffleDiscoveryAddresses } from '@/lib/orchestrator-leaderboard/discovery-order';
 import { resolvePlanCapabilitiesForProvider } from '@/lib/orchestrator-leaderboard/provider-restrictions';
+import { fetchLeaderboard } from '@/lib/orchestrator-leaderboard/query';
+import { getSignerBundle } from '@/lib/orchestrator-leaderboard/signer-bundle-config';
+import {
+  buildSignerBundleDiscovery,
+  type CapabilityFetchResult,
+} from '@/lib/orchestrator-leaderboard/signer-bundle-discovery';
+import { signerBundleSlugForPlanBillingId } from '@/lib/orchestrator-leaderboard/signer-bundle-plan-ids';
 import {
   type BillingProviderSlug,
   BillingProviderSlugSchema,
+  type DiscoveryPlan,
 } from '@/lib/orchestrator-leaderboard/types';
+import { ensurePymthouseManifestFresh } from '@/lib/pymthouse-manifest';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -78,6 +92,11 @@ export async function GET(
     });
   }
 
+  const bundleSlug = signerBundleSlugForPlanBillingId(plan.billingPlanId);
+  if (bundleSlug) {
+    return serveSignerBundlePlan(request, plan, bundleSlug);
+  }
+
   const allowedCaps = resolvePlanCapabilitiesForProvider(plan);
   if (allowedCaps.length === 0) {
     return NextResponse.json([], {
@@ -120,6 +139,73 @@ export async function GET(
     });
   } catch (err) {
     console.error('[plans/python-gateway] evaluateAndCache failed:', err);
+    return new NextResponse('Internal server error', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}
+
+async function serveSignerBundlePlan(
+  request: NextRequest,
+  plan: DiscoveryPlan,
+  bundleSlug: NonNullable<ReturnType<typeof signerBundleSlugForPlanBillingId>>,
+): Promise<Response> {
+  const bundle = await getSignerBundle(bundleSlug);
+  if (!bundle || !bundle.enabled) {
+    return new NextResponse('Not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  if (bundle.billingProviderSlug === 'pymthouse') {
+    try {
+      await ensurePymthouseManifestFresh();
+    } catch (err) {
+      console.warn('[plans/python-gateway] pymthouse manifest refresh failed', err);
+    }
+  }
+
+  const authToken = getAuthToken(request) || '';
+  const cookieHeader = request.headers.get('cookie');
+  const fetchCapabilityAddresses = async (
+    leaderboardCap: string,
+  ): Promise<CapabilityFetchResult> => {
+    const result = await fetchLeaderboard(leaderboardCap, authToken, request.url, cookieHeader);
+    const addresses: string[] = [];
+    for (const row of result.rows) {
+      const address = row.orch_uri?.trim();
+      if (address) addresses.push(address);
+    }
+    return { addresses, fromCache: result.fromCache, cachedAt: result.cachedAt };
+  };
+
+  try {
+    const { addresses, meta } = await buildSignerBundleDiscovery({
+      bundle,
+      fetchCapabilityAddresses,
+      topN: plan.topN ?? bundle.topN,
+    });
+
+    return NextResponse.json(
+      addresses.map((address) => ({ address })),
+      {
+        headers: {
+          'Cache-Control': DISCOVERY_RESPONSE_CACHE_CONTROL,
+          'X-Cache': meta.fromCache ? 'HIT' : 'MISS',
+          'X-Cache-Age': String(meta.cacheAgeMs),
+          'X-Discovery-Bundle': bundleSlug,
+          'X-Discovery-Mode': 'signer-bundle-plan',
+        },
+      },
+    );
+  } catch (err) {
+    console.error('[plans/python-gateway] signer-bundle plan failed', {
+      billingPlanId: plan.billingPlanId,
+      bundleSlug,
+      err,
+    });
     return new NextResponse('Internal server error', {
       status: 500,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },

--- a/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-plan-ids.test.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/__tests__/signer-bundle-plan-ids.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SIGNER_BUNDLE_PLAN_BILLING_IDS,
+  signerBundleSlugForPlanBillingId,
+} from '../signer-bundle-plan-ids';
+
+describe('signerBundleSlugForPlanBillingId', () => {
+  it('maps seeded public plan billing ids onto bundle slugs', () => {
+    expect(signerBundleSlugForPlanBillingId('naap-default-daydream-byoc')).toBe(
+      'daydream-byoc',
+    );
+    expect(
+      signerBundleSlugForPlanBillingId('naap-default-pymthouse-live-runner'),
+    ).toBe('pymthouse-live-runner');
+  });
+
+  it('returns null for unrelated plans', () => {
+    expect(signerBundleSlugForPlanBillingId('naap-default-max-avail')).toBeNull();
+    expect(signerBundleSlugForPlanBillingId('custom-plan')).toBeNull();
+  });
+
+  it('exposes exactly the two signer-bundle plan ids', () => {
+    expect(Object.keys(SIGNER_BUNDLE_PLAN_BILLING_IDS).sort()).toEqual([
+      'naap-default-daydream-byoc',
+      'naap-default-pymthouse-live-runner',
+    ]);
+  });
+});

--- a/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-plan-ids.ts
+++ b/apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-plan-ids.ts
@@ -1,0 +1,20 @@
+/**
+ * Maps public DiscoveryPlan.billingPlanId values (seeded by
+ * bin/seed-discovery-plans.ts) onto signer-bundle slugs so
+ * /plans/{id}/python-gateway can serve the same shortlist as
+ * /bundles/{slug}/python-gateway.
+ */
+
+import type { SignerBundleSlug } from './signer-bundle-types';
+
+/** Seeded billingPlanId → signer bundle slug. */
+export const SIGNER_BUNDLE_PLAN_BILLING_IDS: Record<string, SignerBundleSlug> = {
+  'naap-default-daydream-byoc': 'daydream-byoc',
+  'naap-default-pymthouse-live-runner': 'pymthouse-live-runner',
+};
+
+export function signerBundleSlugForPlanBillingId(
+  billingPlanId: string,
+): SignerBundleSlug | null {
+  return SIGNER_BUNDLE_PLAN_BILLING_IDS[billingPlanId] ?? null;
+}

--- a/apps/web-next/tests/leaderboard-posture.spec.ts
+++ b/apps/web-next/tests/leaderboard-posture.spec.ts
@@ -37,19 +37,21 @@ test.describe('Leaderboard Posture — API (live) @pre-release', () => {
     expect(body.success).toBe(true);
 
     const plans = body.data?.plans ?? [];
-    expect(plans.length).toBeGreaterThanOrEqual(4);
+    expect(plans.length).toBeGreaterThanOrEqual(6);
 
     const publicPlans = plans.filter(
       (p: { visibility?: string; billingPlanId?: string }) =>
         p.visibility === 'public' || p.billingPlanId?.startsWith('naap-default-'),
     );
-    expect(publicPlans.length).toBeGreaterThanOrEqual(4);
+    expect(publicPlans.length).toBeGreaterThanOrEqual(6);
 
     const expectedSlugs = [
       'naap-default-high-perf-video',
       'naap-default-budget-image',
       'naap-default-balanced-stream',
       'naap-default-max-avail',
+      'naap-default-daydream-byoc',
+      'naap-default-pymthouse-live-runner',
     ];
     for (const slug of expectedSlugs) {
       const match = publicPlans.find(

--- a/bin/seed-discovery-plans.ts
+++ b/bin/seed-discovery-plans.ts
@@ -23,11 +23,64 @@ interface DefaultPlanTemplate {
   description: string;
   capabilities: string[];
   topN: number;
+  /** Defaults to pymthouse when omitted (legacy templates). */
+  billingProviderSlug?: 'daydream' | 'pymthouse';
   slaWeights?: Record<string, number>;
   slaMinScore?: number;
   sortBy?: string;
   filters?: Record<string, number>;
 }
+
+/** Keep in sync with STORYBOARD_DEFAULT_PLAN / SIGNER_BUNDLE_DEFAULTS. */
+const DAYDREAM_BYOC_CAPS = [
+  'nano-banana',
+  'recraft-v4',
+  'flux-schnell',
+  'flux-dev',
+  'ltx-t2v',
+  'ltx-i2v',
+  'kontext-edit',
+  'bg-remove',
+  'topaz-upscale',
+  'chatterbox-tts',
+  'gemini-image',
+  'gemini-text',
+  'ffmpeg-concat',
+  'ffmpeg-trim',
+  'ffmpeg-overlay',
+  'ffmpeg-export',
+  'ffmpeg-audio-mix',
+  'ffmpeg-loop',
+  'ffmpeg-burn-subtitles',
+  'ffmpeg-grid',
+  'ffmpeg-mux',
+  'pillow-resize',
+  'pillow-watermark',
+  'pillow-format',
+  'pillow-palette',
+  'pillow-grid',
+  'obscura-extract-text',
+  'obscura-extract-markdown',
+  'obscura-extract-links',
+  'hyperframes-caption',
+  'hyperframes-lower-third',
+  'hyperframes-render',
+  'yolo-detect',
+  'yolo-segment',
+  'cad-render',
+  'cad-validate',
+];
+
+const PYMTHOUSE_LR_CAPS = [
+  'flux-dev',
+  'flux-schnell',
+  'gpt-image',
+  'kontext-edit',
+  'pixverse-i2v',
+  'seedance-mini-i2v',
+  'veo-t2v',
+  'chatterbox-tts',
+];
 
 const DEFAULT_PLAN_TEMPLATES: DefaultPlanTemplate[] = [
   {
@@ -68,6 +121,28 @@ const DEFAULT_PLAN_TEMPLATES: DefaultPlanTemplate[] = [
     capabilities: ['noop', 'streamdiffusion', 'streamdiffusion-sdxl', 'streamdiffusion-sdxl-v2v'],
     topN: 50,
     sortBy: 'avail',
+  },
+  {
+    slug: 'daydream-byoc',
+    name: 'Daydream Signer · BYOC / Tool',
+    description:
+      'Orchestrators for the Daydream remote-signer path (BYOC + tool hosts). ' +
+      'Same shortlist as /bundles/daydream-byoc/python-gateway — set DISCOVERY_URL to this plan’s python-gateway URL.',
+    capabilities: DAYDREAM_BYOC_CAPS,
+    topN: 100,
+    billingProviderSlug: 'daydream',
+    sortBy: 'slaScore',
+  },
+  {
+    slug: 'pymthouse-live-runner',
+    name: 'pymthouse Signer · Live Runner',
+    description:
+      'Orchestrators for the pymthouse per-key remote-signer path (Live Runner hosts). ' +
+      'Same shortlist as /bundles/pymthouse-live-runner/python-gateway — set DISCOVERY_URL to this plan’s python-gateway URL.',
+    capabilities: PYMTHOUSE_LR_CAPS,
+    topN: 100,
+    billingProviderSlug: 'pymthouse',
+    sortBy: 'slaScore',
   },
 ];
 
@@ -139,7 +214,7 @@ async function main() {
       await prisma.discoveryPlan.create({
         data: {
           billingPlanId,
-          billingProviderSlug: 'pymthouse',
+          billingProviderSlug: tpl.billingProviderSlug ?? 'pymthouse',
           name: tpl.name,
           description: tpl.description,
           visibility: 'public',
@@ -158,7 +233,36 @@ async function main() {
       created++;
     }
 
-    console.log(`[seed-plans] Done — created: ${created}, skipped: ${skipped}, total: ${existingPlans.length + created}`);
+    // Keep signer-bundle plans in sync if they already exist (capabilities /
+    // provider / description may evolve with STORYBOARD_DEFAULT_PLAN).
+    let updated = 0;
+    for (const tpl of DEFAULT_PLAN_TEMPLATES) {
+      if (tpl.slug !== 'daydream-byoc' && tpl.slug !== 'pymthouse-live-runner') {
+        continue;
+      }
+      const billingPlanId = defaultPlanId(tpl.slug);
+      if (!existingIds.has(billingPlanId)) continue;
+      await prisma.discoveryPlan.update({
+        where: { billingPlanId },
+        data: {
+          name: tpl.name,
+          description: tpl.description,
+          billingProviderSlug: tpl.billingProviderSlug ?? 'pymthouse',
+          capabilities: tpl.capabilities,
+          topN: tpl.topN,
+          sortBy: tpl.sortBy ?? undefined,
+          enabled: true,
+          visibility: 'public',
+        },
+      });
+      console.log(`[seed-plans] Updated: ${tpl.name} (${billingPlanId})`);
+      updated++;
+    }
+
+    console.log(
+      `[seed-plans] Done — created: ${created}, skipped: ${skipped}, updated: ${updated}, ` +
+        `total: ${existingPlans.length + created}`,
+    );
   } finally {
     await prisma.$disconnect();
   }

--- a/plugins/orchestrator-leaderboard/docs/data-sources.md
+++ b/plugins/orchestrator-leaderboard/docs/data-sources.md
@@ -165,6 +165,10 @@ unchanged.
 Point an SDK node's `DISCOVERY_URL` at the matching bundle when ready; no
 Storyboard/pymthouse code changes are required for the NaaP-only MVP.
 
+**Config guides:**
+- Human / ops HTML: [`signer-bundle-infra-guide.html`](./signer-bundle-infra-guide.html)
+- Agent markdown: [`signer-bundle-infra-guide.md`](./signer-bundle-infra-guide.md)
+
 ---
 
 ## Audit log

--- a/plugins/orchestrator-leaderboard/docs/for-ai.md
+++ b/plugins/orchestrator-leaderboard/docs/for-ai.md
@@ -76,6 +76,12 @@ Base path: `/api/v1/orchestrator-leaderboard`. Full host comes from the user
 | `GET`    | `/sources`                    | JWT or `gw_`            | List data source priority & status.             |
 | `PUT`    | `/sources`                    | JWT (`system:admin`)    | Reorder / enable / disable data sources.        |
 | `GET`    | `/audits`                     | JWT or `gw_`            | Recent refresh audit log.                       |
+| `GET`    | `/bundles/daydream-byoc/python-gateway` | JWT or `gw_` | Daydream signer → BYOC/tool orch shortlist. **Flag:** `SIGNER_BUNDLE_DISCOVERY_ENABLED`. |
+| `GET`    | `/bundles/pymthouse-live-runner/python-gateway` | JWT or `gw_` | pymthouse signer → Live Runner orch shortlist. Same flag. |
+| `GET/PUT`| `/bundles/config`             | JWT (`system:admin`)    | Read/update signer-bundle overrides.            |
+
+**Signer-plane wiring (ops):** [`signer-bundle-infra-guide.md`](./signer-bundle-infra-guide.md)
+(HTML: [`signer-bundle-infra-guide.html`](./signer-bundle-infra-guide.html)).
 
 ---
 

--- a/plugins/orchestrator-leaderboard/docs/how-to-guide.md
+++ b/plugins/orchestrator-leaderboard/docs/how-to-guide.md
@@ -17,6 +17,10 @@ The full machine-readable contract lives in
 [`./api-reference.md`](./api-reference.md). This document is the *integration
 playbook*.
 
+**Daydream vs pymthouse signer planes** (point `DISCOVERY_URL` at a bundle
+endpoint): see [`signer-bundle-infra-guide.html`](./signer-bundle-infra-guide.html)
+or the agent copy [`signer-bundle-infra-guide.md`](./signer-bundle-infra-guide.md).
+
 ---
 
 ## 1. Concepts in 30 seconds

--- a/plugins/orchestrator-leaderboard/docs/signer-bundle-infra-guide.html
+++ b/plugins/orchestrator-leaderboard/docs/signer-bundle-infra-guide.html
@@ -1,0 +1,586 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Signer Bundle Discovery — Infra Config Guide</title>
+  <style>
+    :root {
+      --bg: #0f1419;
+      --bg-elev: #171d25;
+      --bg-code: #0b1015;
+      --ink: #e8eef5;
+      --muted: #9aa8b8;
+      --line: #2a3542;
+      --accent: #3d9b8f;
+      --accent-2: #c4a35a;
+      --daydream: #5b9fd4;
+      --pymthouse: #d47a5b;
+      --ok: #6bcf8e;
+      --warn: #e0b35a;
+      --danger: #e07a7a;
+      --radius: 10px;
+      --font: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
+      --mono: "IBM Plex Mono", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: var(--font);
+      color: var(--ink);
+      background:
+        radial-gradient(1200px 600px at 10% -10%, #1a2a33 0%, transparent 55%),
+        radial-gradient(900px 500px at 100% 0%, #2a2218 0%, transparent 50%),
+        var(--bg);
+      line-height: 1.55;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .wrap {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 2.5rem 1.25rem 4rem;
+    }
+
+    header.hero {
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 1.75rem;
+      margin-bottom: 2rem;
+    }
+    header.hero .kicker {
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 0.5rem;
+    }
+    header.hero h1 {
+      font-size: clamp(1.6rem, 3vw, 2.15rem);
+      font-weight: 650;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.75rem;
+      line-height: 1.2;
+    }
+    header.hero p.lead {
+      margin: 0;
+      color: var(--muted);
+      max-width: 54ch;
+      font-size: 1.05rem;
+    }
+
+    nav.toc {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1rem;
+      margin: 1.25rem 0 0;
+      font-size: 0.9rem;
+    }
+    nav.toc a { color: var(--muted); }
+    nav.toc a:hover { color: var(--ink); }
+
+    h2 {
+      font-size: 1.25rem;
+      margin: 2.25rem 0 0.85rem;
+      letter-spacing: -0.015em;
+    }
+    h3 {
+      font-size: 1.02rem;
+      margin: 1.5rem 0 0.6rem;
+      color: var(--ink);
+    }
+    p { margin: 0 0 0.9rem; color: var(--ink); }
+    p.muted, .muted { color: var(--muted); }
+    ul, ol { margin: 0 0 1rem; padding-left: 1.2rem; color: var(--ink); }
+    li { margin: 0.3rem 0; }
+    li::marker { color: var(--muted); }
+
+    .grid-2 {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+    @media (max-width: 720px) {
+      .grid-2 { grid-template-columns: 1fr; }
+    }
+
+    .plane {
+      background: var(--bg-elev);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 1.1rem 1.15rem 1.2rem;
+      position: relative;
+      overflow: hidden;
+    }
+    .plane::before {
+      content: "";
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 3px;
+    }
+    .plane.daydream::before { background: var(--daydream); }
+    .plane.pymthouse::before { background: var(--pymthouse); }
+    .plane h3 { margin-top: 0; display: flex; align-items: center; gap: 0.5rem; }
+    .badge {
+      display: inline-block;
+      font-size: 0.68rem;
+      font-weight: 650;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 0.2rem 0.45rem;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      color: var(--muted);
+    }
+    .plane.daydream .badge { color: var(--daydream); border-color: color-mix(in srgb, var(--daydream) 45%, var(--line)); }
+    .plane.pymthouse .badge { color: var(--pymthouse); border-color: color-mix(in srgb, var(--pymthouse) 45%, var(--line)); }
+    .plane .url {
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      word-break: break-all;
+      color: var(--accent-2);
+      margin: 0.6rem 0 0.8rem;
+    }
+    .plane .orchs {
+      font-size: 0.88rem;
+      color: var(--muted);
+      margin: 0;
+    }
+    .plane .orchs code {
+      color: var(--ink);
+      font-family: var(--mono);
+      font-size: 0.8rem;
+    }
+
+    .callout {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 0.9rem 1rem;
+      background: color-mix(in srgb, var(--bg-elev) 80%, transparent);
+      margin: 1rem 0;
+    }
+    .callout.ok { border-color: color-mix(in srgb, var(--ok) 40%, var(--line)); }
+    .callout.warn { border-color: color-mix(in srgb, var(--warn) 45%, var(--line)); }
+    .callout strong { color: var(--ink); }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+      margin: 0.75rem 0 1.25rem;
+    }
+    th, td {
+      text-align: left;
+      padding: 0.55rem 0.65rem;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+    }
+    th { color: var(--muted); font-weight: 550; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    td code { font-family: var(--mono); font-size: 0.8rem; color: var(--accent-2); }
+
+    .codeblock {
+      position: relative;
+      background: var(--bg-code);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      margin: 0.6rem 0 1.1rem;
+      overflow: hidden;
+    }
+    .codeblock .bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.4rem 0.7rem;
+      border-bottom: 1px solid var(--line);
+      font-size: 0.72rem;
+      color: var(--muted);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .codeblock pre {
+      margin: 0;
+      padding: 0.9rem 1rem;
+      overflow-x: auto;
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: #d7e2ee;
+    }
+    .codeblock button.copy {
+      appearance: none;
+      border: 1px solid var(--line);
+      background: var(--bg-elev);
+      color: var(--ink);
+      font: inherit;
+      font-size: 0.72rem;
+      padding: 0.25rem 0.55rem;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    .codeblock button.copy:hover { border-color: var(--accent); color: var(--accent); }
+    .codeblock button.copy.copied { color: var(--ok); border-color: var(--ok); }
+
+    .steps {
+      counter-reset: step;
+      list-style: none;
+      padding: 0;
+    }
+    .steps li {
+      counter-increment: step;
+      position: relative;
+      padding: 0.85rem 0 0.85rem 2.6rem;
+      border-bottom: 1px solid var(--line);
+    }
+    .steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 0;
+      top: 0.9rem;
+      width: 1.7rem;
+      height: 1.7rem;
+      border-radius: 50%;
+      background: var(--bg-elev);
+      border: 1px solid var(--line);
+      display: grid;
+      place-items: center;
+      font-size: 0.78rem;
+      font-weight: 650;
+      color: var(--accent);
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+
+    .flow {
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      background: var(--bg-code);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 1rem;
+      white-space: pre;
+      overflow-x: auto;
+      color: #c5d3e0;
+      margin: 0.75rem 0 1.25rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="hero">
+      <p class="kicker">Orchestrator Leaderboard · NaaP</p>
+      <h1>Signer Bundle Discovery — Infra Config</h1>
+      <p class="lead">
+        Point each remote signer at the matching discovery plan (or bundle alias).
+        Daydream → BYOC/tool orchs. pymthouse → Live Runner orchs.
+        Same <code>[{ "address" }]</code> contract — choose the URL, not a matrix of flags.
+        Plans appear at <code>/orchestrator-leaderboard/plans</code> like any other public plan.
+      </p>
+      <nav class="toc" aria-label="Sections">
+        <a href="#model">Model</a>
+        <a href="#naap">NaaP flag</a>
+        <a href="#daydream">Daydream path</a>
+        <a href="#pymthouse">pymthouse path</a>
+        <a href="#verify">Verify</a>
+        <a href="#admin">Admin overrides</a>
+        <a href="#troubleshoot">Troubleshoot</a>
+      </nav>
+    </header>
+
+    <section id="model">
+      <h2>1. The model (one sentence)</h2>
+      <p>
+        <strong>Discovery URL selects the orchestrator plane.</strong>
+        The signer stack you already run decides payment; these endpoints only answer
+        “which orch URIs should I dial?”
+      </p>
+
+      <div class="grid-2">
+        <article class="plane daydream">
+          <h3><span class="badge">Daydream</span> BYOC plane</h3>
+          <p class="url">Plan <strong>naap-default-daydream-byoc</strong><br />…/plans/{id}/python-gateway</p>
+          <p class="url" style="margin-top:0.35rem;opacity:0.85">alias …/bundles/<strong>daydream-byoc</strong>/python-gateway</p>
+          <p class="orchs">
+            Returns BYOC + tool hosts, e.g.<br />
+            <code>byoc-staging-1.daydream.monster:8935</code><br />
+            <code>tool-staging-1.daydream.monster:8935</code>
+          </p>
+        </article>
+        <article class="plane pymthouse">
+          <h3><span class="badge">pymthouse</span> Live Runner plane</h3>
+          <p class="url">Plan <strong>naap-default-pymthouse-live-runner</strong><br />…/plans/{id}/python-gateway</p>
+          <p class="url" style="margin-top:0.35rem;opacity:0.85">alias …/bundles/<strong>pymthouse-live-runner</strong>/python-gateway</p>
+          <p class="orchs">
+            Returns Live Runner hosts, e.g.<br />
+            <code>liverunner-staging-1.daydream.monster:8935</code>
+          </p>
+        </article>
+      </div>
+
+      <pre class="flow">SDK / gateway node
+  │  DISCOVERY_URL = one of the two endpoints below
+  ▼
+NaaP  GET /bundles/{slug}/python-gateway
+  │  Bearer gw_…   +  SIGNER_BUNDLE_DISCOVERY_ENABLED=1
+  ▼
+[{ "address": "https://…" }]  →  dial orch  →  sign via your remote signer</pre>
+
+      <div class="callout ok">
+        <strong>Keep it simple:</strong> do not mix planes.
+        Daydream signer → <code>daydream-byoc</code>.
+        pymthouse signer → <code>pymthouse-live-runner</code>.
+      </div>
+    </section>
+
+    <section id="naap">
+      <h2>2. Enable on NaaP (once)</h2>
+      <p class="muted">Default is OFF (404). Turn on for the environment that should serve these bundles.</p>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Vercel / host env</span><button type="button" class="copy">Copy</button></div>
+        <pre>SIGNER_BUNDLE_DISCOVERY_ENABLED=true</pre>
+      </div>
+
+      <table>
+        <thead>
+          <tr><th>Item</th><th>Value</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Auth</td>
+            <td><code>Authorization: Bearer gw_…</code> (Service Gateway API key)</td>
+          </tr>
+          <tr>
+            <td>Base path</td>
+            <td><code>/api/v1/orchestrator-leaderboard/bundles</code></td>
+          </tr>
+          <tr>
+            <td>Response</td>
+            <td>Bare JSON array <code>[{ "address": "&lt;orchUri&gt;" }]</code></td>
+          </tr>
+          <tr>
+            <td>Headers</td>
+            <td><code>X-Discovery-Bundle</code>, <code>X-Discovery-Mode: signer-bundle</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="daydream">
+      <h2>3. Configure Daydream signer → BYOC</h2>
+      <ol class="steps">
+        <li>
+          <strong>On the SDK / gateway node</strong> that uses the Daydream remote signer,
+          set <code>DISCOVERY_URL</code> to the
+          <code>naap-default-daydream-byoc</code> plan’s python-gateway URL
+          (visible in the Plans UI).
+        </li>
+        <li>
+          Redeploy / restart the node so it picks up the env.
+        </li>
+        <li>
+          Smoke-test with the same <code>gw_</code> key the node will use.
+        </li>
+      </ol>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Node env — Daydream path (plan URL)</span><button type="button" class="copy">Copy</button></div>
+        <pre>NAAP_API_URL=https://app.naap.io
+NAAP_API_KEY=gw_xxxxxxxx
+
+# Resolve plan id from billingPlanId=naap-default-daydream-byoc (UI: /orchestrator-leaderboard/plans)
+PLAN_ID=PLAN_ID_HERE
+DISCOVERY_URL=${NAAP_API_URL}/api/v1/orchestrator-leaderboard/plans/${PLAN_ID}/python-gateway
+
+# Alias (requires SIGNER_BUNDLE_DISCOVERY_ENABLED=true):
+# DISCOVERY_URL=${NAAP_API_URL}/api/v1/orchestrator-leaderboard/bundles/daydream-byoc/python-gateway</pre>
+      </div>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Smoke test</span><button type="button" class="copy">Copy</button></div>
+        <pre>curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$DISCOVERY_URL" | jq .
+
+# Expect addresses including:
+#   https://byoc-staging-1.daydream.monster:8935
+#   https://tool-staging-1.daydream.monster:8935
+# Header: X-Discovery-Bundle: daydream-byoc</pre>
+      </div>
+    </section>
+
+    <section id="pymthouse">
+      <h2>4. Configure pymthouse signer → Live Runner</h2>
+      <ol class="steps">
+        <li>
+          On the SDK / gateway node that uses the <strong>pymthouse per-key DMZ signer</strong>
+          (<code>SIGNER_FROM_VALIDATE</code> / validate endpoint form), set
+          <code>DISCOVERY_URL</code> to the Live Runner <strong>plan</strong> python-gateway URL
+          (<code>naap-default-pymthouse-live-runner</code>).
+        </li>
+        <li>Redeploy / restart.</li>
+        <li>Smoke-test; confirm LR host, not BYOC host.</li>
+      </ol>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Node env — pymthouse path (plan URL)</span><button type="button" class="copy">Copy</button></div>
+        <pre>NAAP_API_URL=https://app.naap.io
+NAAP_API_KEY=gw_xxxxxxxx
+
+PLAN_ID=PLAN_ID_HERE
+DISCOVERY_URL=${NAAP_API_URL}/api/v1/orchestrator-leaderboard/plans/${PLAN_ID}/python-gateway
+
+# Alias (requires SIGNER_BUNDLE_DISCOVERY_ENABLED=true):
+# DISCOVERY_URL=${NAAP_API_URL}/api/v1/orchestrator-leaderboard/bundles/pymthouse-live-runner/python-gateway</pre>
+      </div>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Smoke test</span><button type="button" class="copy">Copy</button></div>
+        <pre>curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$DISCOVERY_URL" | jq .
+
+# Expect addresses including:
+#   https://liverunner-staging-1.daydream.monster:8935
+# Must NOT include byoc-staging-1 / tool-staging-1
+# Header: X-Discovery-Bundle: pymthouse-live-runner</pre>
+      </div>
+    </section>
+
+    <section id="verify">
+      <h2>5. Verify isolation</h2>
+      <p class="muted">Both endpoints should return non-overlapping address sets.</p>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Cross-check</span><button type="button" class="copy">Copy</button></div>
+        <pre>BASE="$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles"
+AUTH="Authorization: Bearer $NAAP_API_KEY"
+
+DAY=$(curl -sS -H "$AUTH" "$BASE/daydream-byoc/python-gateway")
+LR=$(curl -sS -H "$AUTH" "$BASE/pymthouse-live-runner/python-gateway")
+
+echo "Daydream-BYOC:" && echo "$DAY" | jq -r '.[].address'
+echo "pymthouse-LR:"  && echo "$LR"  | jq -r '.[].address'
+
+echo "Overlap count (expect 0):"
+comm -12 \
+  <(echo "$DAY" | jq -r '.[].address' | sort) \
+  <(echo "$LR"  | jq -r '.[].address' | sort) | wc -l</pre>
+      </div>
+    </section>
+
+    <section id="admin">
+      <h2>6. Optional — admin overrides</h2>
+      <p>
+        Defaults come from the committed staging baseline. To change categories,
+        static fleet URLs, or <code>topN</code> without redeploying code:
+      </p>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>List bundles (admin)</span><button type="button" class="copy">Copy</button></div>
+        <pre>curl -sS -H "Authorization: Bearer $NAAP_ADMIN_JWT" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/config" | jq .</pre>
+      </div>
+
+      <div class="codeblock" data-copy>
+        <div class="bar"><span>Override LR static fleet / topN</span><button type="button" class="copy">Copy</button></div>
+        <pre>curl -sS -X PUT \
+  -H "Authorization: Bearer $NAAP_ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "bundles": [{
+      "slug": "pymthouse-live-runner",
+      "enabled": true,
+      "topN": 50,
+      "categoryStaticOrchestrators": {
+        "lr": ["https://liverunner-staging-1.daydream.monster:8935"]
+      }
+    }]
+  }' \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/config" | jq .</pre>
+      </div>
+
+      <div class="callout warn">
+        <strong>Ops hotfix without admin UI:</strong>
+        set <code>SIGNER_BUNDLE_OVERRIDES='{"bundles":[…]}'</code> on NaaP
+        (env wins over DB). Prefer admin PUT for durable changes.
+      </div>
+
+      <h3>Useful query params</h3>
+      <table>
+        <thead><tr><th>Param</th><th>Example</th><th>Effect</th></tr></thead>
+        <tbody>
+          <tr><td><code>caps</code></td><td><code>?caps=flux-dev</code></td><td>Filter to capability (repeatable)</td></tr>
+          <tr><td><code>topN</code></td><td><code>?topN=10</code></td><td>Cap list length</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="troubleshoot">
+      <h2>7. Troubleshoot</h2>
+      <table>
+        <thead><tr><th>Symptom</th><th>Fix</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><code>404</code></td>
+            <td>Set <code>SIGNER_BUNDLE_DISCOVERY_ENABLED=true</code> and redeploy NaaP.</td>
+          </tr>
+          <tr>
+            <td><code>401</code></td>
+            <td>Pass a valid <code>gw_</code> key or session JWT.</td>
+          </tr>
+          <tr>
+            <td>Empty <code>[]</code></td>
+            <td>Check bundle <code>enabled</code>, pymthouse manifest filter (LR bundle), and static fleet config.</td>
+          </tr>
+          <tr>
+            <td>Wrong orch plane</td>
+            <td>Node’s <code>DISCOVERY_URL</code> points at the other slug — swap it.</td>
+          </tr>
+          <tr>
+            <td>Still old discovery</td>
+            <td>Search deploy env for stale <code>DISCOVERY_URL</code> / file-based discovery JSON.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <footer>
+      Agent-oriented copy of this guide:
+      <a href="./signer-bundle-infra-guide.md">signer-bundle-infra-guide.md</a>
+      · Data sources overview:
+      <a href="./data-sources.md">data-sources.md</a>
+      · Shipped in NaaP PR
+      <a href="https://github.com/livepeer/naap/pull/453">#453</a>
+    </footer>
+  </div>
+
+  <script>
+    document.querySelectorAll(".codeblock[data-copy]").forEach((block) => {
+      const btn = block.querySelector("button.copy");
+      const pre = block.querySelector("pre");
+      if (!btn || !pre) return;
+      btn.addEventListener("click", async () => {
+        const text = pre.textContent || "";
+        try {
+          await navigator.clipboard.writeText(text);
+          btn.textContent = "Copied";
+          btn.classList.add("copied");
+          setTimeout(() => {
+            btn.textContent = "Copy";
+            btn.classList.remove("copied");
+          }, 1400);
+        } catch {
+          btn.textContent = "Select & copy";
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/plugins/orchestrator-leaderboard/docs/signer-bundle-infra-guide.md
+++ b/plugins/orchestrator-leaderboard/docs/signer-bundle-infra-guide.md
@@ -1,0 +1,219 @@
+# For AI Agents — Signer Bundle Discovery (Daydream vs pymthouse)
+
+> Audience: AI coding / ops agents configuring infra so a **Daydream remote signer**
+> or a **pymthouse remote signer** dials the correct orchestrator plane.
+>
+> Humans: open [`signer-bundle-infra-guide.html`](./signer-bundle-infra-guide.html).
+> Broader leaderboard API: [`for-ai.md`](./for-ai.md).
+
+---
+
+## TL;DR
+
+Pick the discovery URL by **signer plane**. NaaP does not auto-detect the signer.
+
+Two equivalent ways (same shortlist):
+
+1. **Public Discovery Plans** (recommended — show up at `/orchestrator-leaderboard/plans`):
+   - Daydream → plan `naap-default-daydream-byoc` → `/plans/{id}/python-gateway`
+   - pymthouse → plan `naap-default-pymthouse-live-runner` → `/plans/{id}/python-gateway`
+2. **Bundle aliases** (flag-gated):
+   - `…/bundles/daydream-byoc/python-gateway`
+   - `…/bundles/pymthouse-live-runner/python-gateway`
+
+| Signer | Plan `billingPlanId` | Bundle slug | Orchs returned |
+| --- | --- | --- | --- |
+| **Daydream** remote signer | `naap-default-daydream-byoc` | `daydream-byoc` | BYOC + tool hosts |
+| **pymthouse** remote signer | `naap-default-pymthouse-live-runner` | `pymthouse-live-runner` | Live Runner host |
+
+Plans are seeded on deploy (`bin/seed-discovery-plans.ts`) as `visibility: public`.
+
+Response shape (unchanged BPP discovery):
+
+```json
+[{ "address": "https://byoc-staging-1.daydream.monster:8935" }]
+```
+
+---
+
+## Hard rules
+
+1. **Master flag must be ON** on the NaaP deployment: `SIGNER_BUNDLE_DISCOVERY_ENABLED=true` (or `1`). Default OFF → endpoints return **404**.
+2. **Auth required** on both endpoints: `Authorization: Bearer gw_…` (or NaaP session JWT).
+3. **Do not mix planes.** Daydream signer + LR discovery (or pymthouse + BYOC discovery) is a misconfig.
+4. **Do not change** legacy routes unless asked: `/python-gateway`, `/plans/{id}/python-gateway`, `/storyboard-default/python-gateway`.
+5. **Payment type is not chosen by discovery.** Discovery only returns orch addresses. Signer hostname still drives `lv2v` vs `byoc` payment shape upstream.
+6. **Never invent new slugs.** Only `daydream-byoc` and `pymthouse-live-runner`.
+
+---
+
+## Decision tree
+
+```
+Which remote signer does this node use?
+├── Daydream (e.g. signer.daydream.live)
+│     → DISCOVERY_URL = …/bundles/daydream-byoc/python-gateway
+│     → expect addresses ⊇ byoc-staging-* / tool-staging-*
+└── pymthouse per-key DMZ signer
+      → DISCOVERY_URL = …/bundles/pymthouse-live-runner/python-gateway
+      → expect addresses ⊇ liverunner-staging-*
+```
+
+---
+
+## NaaP (platform) config
+
+### Required env (Vercel / host)
+
+```bash
+SIGNER_BUNDLE_DISCOVERY_ENABLED=true
+```
+
+### Optional env hotfix (JSON overrides, wins over DB)
+
+```bash
+SIGNER_BUNDLE_OVERRIDES='{"bundles":[{"slug":"pymthouse-live-runner","topN":50}]}'
+```
+
+### Admin API (optional — persist overrides)
+
+```bash
+# List resolved bundles (admin JWT)
+curl -sS -H "Authorization: Bearer $NAAP_ADMIN_JWT" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/config"
+
+# Patch one bundle
+curl -sS -X PUT -H "Authorization: Bearer $NAAP_ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"bundles":[{"slug":"daydream-byoc","topN":100,"enabled":true}]}' \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/config"
+```
+
+Defaults (when no override):
+
+| Slug | `billingProviderSlug` | Categories | Static fleet (staging baseline) |
+| --- | --- | --- | --- |
+| `daydream-byoc` | `daydream` | `byoc`, `tool` | `https://byoc-staging-1.daydream.monster:8935`, `https://tool-staging-1.daydream.monster:8935` |
+| `pymthouse-live-runner` | `pymthouse` | `lr` | `https://liverunner-staging-1.daydream.monster:8935` |
+
+---
+
+## Resolve plan id (once)
+
+```bash
+# List public plans; grab id for the signer plane you need
+curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/plans" \
+  | jq '.data.plans[] | select(.billingPlanId|startswith("naap-default-")) | {billingPlanId,id,name}'
+```
+
+---
+
+## Daydream signer path — copy/paste
+
+```bash
+export NAAP_API_URL=https://app.naap.io   # or your NaaP origin
+export NAAP_API_KEY=gw_xxxxxxxx
+
+# Prefer plan URL (visible in UI at /orchestrator-leaderboard/plans)
+export PLAN_ID=$(curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/plans" \
+  | jq -r '.data.plans[] | select(.billingPlanId=="naap-default-daydream-byoc") | .id')
+
+export DISCOVERY_URL="$NAAP_API_URL/api/v1/orchestrator-leaderboard/plans/$PLAN_ID/python-gateway"
+# Equivalent alias (needs SIGNER_BUNDLE_DISCOVERY_ENABLED=true):
+# export DISCOVERY_URL="$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/daydream-byoc/python-gateway"
+
+# Smoke test
+curl -sS -H "Authorization: Bearer $NAAP_API_KEY" "$DISCOVERY_URL" | jq .
+# Expect: [{ "address": "https://byoc-staging-1…" }, { "address": "https://tool-staging-1…" }, …]
+# Header: X-Discovery-Bundle: daydream-byoc
+```
+
+Wire `DISCOVERY_URL` into the SDK node / python-gateway env that talks to the **Daydream** signer. Do **not** point that node at the Live Runner plan.
+
+---
+
+## pymthouse signer path — copy/paste
+
+```bash
+export NAAP_API_URL=https://app.naap.io
+export NAAP_API_KEY=gw_xxxxxxxx
+
+export PLAN_ID=$(curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/plans" \
+  | jq -r '.data.plans[] | select(.billingPlanId=="naap-default-pymthouse-live-runner") | .id')
+
+export DISCOVERY_URL="$NAAP_API_URL/api/v1/orchestrator-leaderboard/plans/$PLAN_ID/python-gateway"
+# Equivalent alias (needs SIGNER_BUNDLE_DISCOVERY_ENABLED=true):
+# export DISCOVERY_URL="$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/pymthouse-live-runner/python-gateway"
+
+# Smoke test
+curl -sS -H "Authorization: Bearer $NAAP_API_KEY" "$DISCOVERY_URL" | jq .
+# Expect: [{ "address": "https://liverunner-staging-1…" }, …]
+# Header: X-Discovery-Bundle: pymthouse-live-runner
+```
+
+Wire this `DISCOVERY_URL` into the SDK node that uses **pymthouse** `SIGNER_FROM_VALIDATE` / per-key DMZ signer. Do **not** point that node at the Daydream BYOC plan.
+
+---
+
+## Optional query params
+
+| Param | Example | Effect |
+| --- | --- | --- |
+| `caps` | `?caps=flux-dev` or `?caps=text-to-image/flux-dev` | Filter to one capability (repeatable) |
+| `capability` / `model` | `?model=flux-dev` | Same as single `caps` |
+| `topN` | `?topN=10` | Cap list length (1..1000) |
+
+---
+
+## Verify isolation (must pass)
+
+```bash
+DAY=$(curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/daydream-byoc/python-gateway")
+LR=$(curl -sS -H "Authorization: Bearer $NAAP_API_KEY" \
+  "$NAAP_API_URL/api/v1/orchestrator-leaderboard/bundles/pymthouse-live-runner/python-gateway")
+
+echo "$DAY" | jq -e 'map(.address) | any(test("byoc|tool"))' >/dev/null
+echo "$LR"  | jq -e 'map(.address) | any(test("liverunner"))' >/dev/null
+# Cross-contamination check: no shared addresses
+comm -12 \
+  <(echo "$DAY" | jq -r '.[].address' | sort) \
+  <(echo "$LR"  | jq -r '.[].address' | sort) | wc -l   # expect 0
+```
+
+---
+
+## Failure modes (agent checklist)
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `404 Not found` | Flag OFF | Set `SIGNER_BUNDLE_DISCOVERY_ENABLED=true` and redeploy |
+| `401 Unauthorized` | Missing/invalid `gw_` / JWT | Mint Service Gateway key; pass `Authorization` |
+| `[]` empty array | Caps filtered (pymthouse manifest) or bundle `enabled:false` | Check admin config + manifest; confirm static fleet still expected |
+| Wrong orch plane | `DISCOVERY_URL` points at the other slug | Swap to the table in TL;DR |
+| Still hitting old discovery | Node env not updated | Grep for `DISCOVERY_URL` / `discovery.url` in the node deploy |
+
+---
+
+## What NOT to change
+
+- Do not edit `storyboard-default` flatten bundle for this wiring.
+- Do not add Storyboard / Livepeer Agent code for MVP — env on the SDK node is enough.
+- Do not call `/plans/refresh` or crawl `{orch}/discovery` from agents.
+
+---
+
+## Source map (repo)
+
+| Concern | Path |
+| --- | --- |
+| Types / flag | `apps/web-next/src/lib/orchestrator-leaderboard/signer-bundle-types.ts` |
+| Defaults | `…/signer-bundle-defaults.ts` |
+| Config merge (DB + env) | `…/signer-bundle-config.ts` |
+| Builder | `…/signer-bundle-discovery.ts` |
+| Route | `apps/web-next/src/app/api/v1/orchestrator-leaderboard/bundles/[slug]/python-gateway/route.ts` |
+| Admin config | `…/bundles/config/route.ts` |
+| Human HTML guide | `plugins/orchestrator-leaderboard/docs/signer-bundle-infra-guide.html` |


### PR DESCRIPTION
## Summary
- Seeds two public Discovery Plans on deploy (`naap-default-daydream-byoc`, `naap-default-pymthouse-live-runner`) so they appear at `/orchestrator-leaderboard/plans` like other defaults.
- `/plans/{id}/python-gateway` for those plans reuses the signer-bundle shortlist builder (same orchs as `/bundles/{slug}/python-gateway`, including static fleet).
- Adds HTML + agent infra guides for wiring Daydream vs pymthouse `DISCOVERY_URL`.

## Test plan
- [x] Unit tests for plan-id → bundle mapping + plan python-gateway signer path
- [ ] After deploy: confirm both plans listed at https://operator.livepeer.org/orchestrator-leaderboard/plans
- [ ] Curl each plan’s `/python-gateway` with a `gw_` key; confirm BYOC+tool vs LR isolation
- [ ] Optional: set node `DISCOVERY_URL` to the plan python-gateway URL


Made with [Cursor](https://cursor.com)