### PR TITLE
feat(mcp-oauth): PR-09 — internal MCP mint route (test-app only)

### DIFF
--- a/apps/web-next/src/app/api/internal/mcp/mint/route.test.ts
+++ b/apps/web-next/src/app/api/internal/mcp/mint/route.test.ts
@@ -1,0 +1,138 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { MCP_BILLING_TEST_APP_ID, POST } from '@/app/api/internal/mcp/mint/route';
+
+const createPymthouseApiKey = vi.fn();
+
+vi.mock('@/lib/pymthouse-keys-bff', () => ({
+  createPymthouseApiKey: (...args: unknown[]) => createPymthouseApiKey(...args),
+}));
+
+const SECRET = 'test-mint-shared-secret';
+const ALLOWED = 'https://storyboard.daydream.monster';
+
+function req(opts: {
+  body?: unknown;
+  auth?: string | null;
+  origin?: string | null;
+  callerOrigin?: string | null;
+}): NextRequest {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  if (opts.auth !== null) {
+    headers.set('authorization', opts.auth ?? `Bearer ${SECRET}`);
+  }
+  if (opts.origin) headers.set('origin', opts.origin);
+  if (opts.callerOrigin) headers.set('x-mcp-caller-origin', opts.callerOrigin);
+  return new NextRequest('http://localhost/api/internal/mcp/mint', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(opts.body ?? { externalUserId: 'user-1', email: 'u@example.com' }),
+  });
+}
+
+describe('POST /api/internal/mcp/mint', () => {
+  const env: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of [
+      'MCP_INTERNAL_MINT_SECRET',
+      'MCP_INTERNAL_MINT_ALLOWLIST',
+      'PYMTHOUSE_PUBLIC_CLIENT_ID',
+    ]) {
+      env[k] = process.env[k];
+    }
+    process.env.MCP_INTERNAL_MINT_SECRET = SECRET;
+    process.env.MCP_INTERNAL_MINT_ALLOWLIST = ALLOWED;
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = MCP_BILLING_TEST_APP_ID;
+    vi.clearAllMocks();
+    createPymthouseApiKey.mockResolvedValue({
+      apiKey: `${MCP_BILLING_TEST_APP_ID}_pmth_deadbeef`,
+      row: {
+        id: 'k1',
+        label: 'mcp-oauth',
+        prefix: 'pmth_',
+        suffix: 'beef',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        revokedAt: null,
+      },
+    });
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(env)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('returns 404 when shared-secret config is absent', async () => {
+    delete process.env.MCP_INTERNAL_MINT_SECRET;
+    const res = await POST(req({ origin: ALLOWED }));
+    expect(res.status).toBe(404);
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when allow-list config is absent', async () => {
+    delete process.env.MCP_INTERNAL_MINT_ALLOWLIST;
+    const res = await POST(req({ origin: ALLOWED }));
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects unauthenticated callers with 401', async () => {
+    const res = await POST(req({ origin: ALLOWED, auth: 'Bearer wrong' }));
+    expect(res.status).toBe(401);
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects callers outside the origin allow-list with 403', async () => {
+    const res = await POST(req({ origin: 'https://evil.example' }));
+    expect(res.status).toBe(403);
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
+  });
+
+  it('fail-closes with 503 when PYMTHOUSE_PUBLIC_CLIENT_ID is not the test app', async () => {
+    process.env.PYMTHOUSE_PUBLIC_CLIENT_ID = 'app_live_customer_do_not_bill';
+    const res = await POST(req({ origin: ALLOWED }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('billing_app_mismatch');
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
+  });
+
+  it('mints via createPymthouseApiKey and returns only apiKey', async () => {
+    const res = await POST(req({ origin: ALLOWED }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Object.keys(body).sort()).toEqual(['apiKey']);
+    expect(body.apiKey).toBe(`${MCP_BILLING_TEST_APP_ID}_pmth_deadbeef`);
+    expect(createPymthouseApiKey).toHaveBeenCalledWith({
+      externalUserId: 'user-1',
+      email: 'u@example.com',
+      label: 'mcp-oauth',
+    });
+  });
+
+  it('accepts X-Mcp-Caller-Origin when Origin is absent (S2S)', async () => {
+    const res = await POST(req({ origin: null, callerOrigin: ALLOWED }));
+    expect(res.status).toBe(200);
+    expect(createPymthouseApiKey).toHaveBeenCalled();
+  });
+
+  it('returns 400 when externalUserId is missing', async () => {
+    const res = await POST(req({ origin: ALLOWED, body: { email: 'x@y.z' } }));
+    expect(res.status).toBe(400);
+    expect(createPymthouseApiKey).not.toHaveBeenCalled();
+  });
+
+  it('maps mint failures to 502 without leaking details', async () => {
+    createPymthouseApiKey.mockRejectedValue(new Error('upstream boom with secret xyz'));
+    const res = await POST(req({ origin: ALLOWED }));
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    expect(text).not.toMatch(/xyz|boom/i);
+  });
+});

--- a/apps/web-next/src/app/api/internal/mcp/mint/route.ts
+++ b/apps/web-next/src/app/api/internal/mcp/mint/route.ts
@@ -1,0 +1,138 @@
+/**
+ * Internal Storyboard → NaaP mint route (MCP OAuth Scenario A / PR-09).
+ *
+ * Mints a pymthouse composite for a NaaP-identified user by reusing NaaP's
+ * existing M2M env via `createPymthouseApiKey` (no second copy of M2M on
+ * Storyboard). Absent shared-secret / allow-list config ⇒ 404 (do not
+ * advertise the route). Bills only the hard-coded test app (RS-2).
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createPymthouseApiKey } from '@/lib/pymthouse-keys-bff';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/** RS-2 — only this pymthouse test app may be billed by MCP OAuth mint. */
+export const MCP_BILLING_TEST_APP_ID = 'app_98575870d7ae33589a3f0660';
+
+type MintBody = {
+  externalUserId?: unknown;
+  email?: unknown;
+  label?: unknown;
+};
+
+function readConfig(): { secret: string; allowlist: Set<string> } | null {
+  const secret = process.env.MCP_INTERNAL_MINT_SECRET?.trim();
+  const rawAllow = process.env.MCP_INTERNAL_MINT_ALLOWLIST?.trim();
+  if (!secret || !rawAllow) return null;
+  const allowlist = new Set(
+    rawAllow
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  if (allowlist.size === 0) return null;
+  return { secret, allowlist };
+}
+
+function secretsEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function extractBearer(request: NextRequest): string | null {
+  const header = request.headers.get('authorization');
+  if (!header) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return m?.[1]?.trim() || null;
+}
+
+function callerOrigin(request: NextRequest): string | null {
+  const origin = request.headers.get('origin')?.trim();
+  if (origin) return origin;
+  // Server-to-server callers may omit Origin; accept an explicit caller header.
+  const explicit = request.headers.get('x-mcp-caller-origin')?.trim();
+  return explicit || null;
+}
+
+function assertTestAppConfigured(): NextResponse | null {
+  const configured = process.env.PYMTHOUSE_PUBLIC_CLIENT_ID?.trim();
+  if (!configured || configured !== MCP_BILLING_TEST_APP_ID) {
+    // Fail closed — never mint against a live customer app.
+    return NextResponse.json(
+      { error: 'billing_app_mismatch', error_description: 'Mint is restricted to the test billing app.' },
+      { status: 503 },
+    );
+  }
+  return null;
+}
+
+/**
+ * POST /api/internal/mcp/mint
+ * Body: { externalUserId: string, email?: string, label?: string }
+ * Auth: Authorization: Bearer <MCP_INTERNAL_MINT_SECRET>
+ * Caller: Origin or X-Mcp-Caller-Origin must be in MCP_INTERNAL_MINT_ALLOWLIST
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const config = readConfig();
+  if (!config) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const bearer = extractBearer(request);
+  if (!bearer || !secretsEqual(bearer, config.secret)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const origin = callerOrigin(request);
+  if (!origin || !config.allowlist.has(origin)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  const appGuard = assertTestAppConfigured();
+  if (appGuard) return appGuard;
+
+  let body: MintBody;
+  try {
+    body = (await request.json()) as MintBody;
+  } catch {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'JSON body required' },
+      { status: 400 },
+    );
+  }
+
+  const externalUserId =
+    typeof body.externalUserId === 'string' ? body.externalUserId.trim() : '';
+  if (!externalUserId || externalUserId.length > 256) {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'externalUserId required' },
+      { status: 400 },
+    );
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim() : undefined;
+  const label = typeof body.label === 'string' ? body.label.trim() : 'mcp-oauth';
+
+  try {
+    const { apiKey } = await createPymthouseApiKey({
+      externalUserId,
+      email: email || null,
+      label: label || 'mcp-oauth',
+    });
+    // Composite returned only over this authenticated internal channel (AP-5).
+    // Never log apiKey.
+    return NextResponse.json({ apiKey }, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: 'mint_failed', error_description: 'Unable to mint credential' },
+      { status: 502 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/internal/mcp/mint` for Storyboard → NaaP server-to-server composite mint (MCP OAuth Scenario A).
- Reuses `createPymthouseApiKey` / existing NaaP M2M env; does **not** modify `pymthouse-keys-bff.ts`.
- Absent `MCP_INTERNAL_MINT_SECRET` + `MCP_INTERNAL_MINT_ALLOWLIST` ⇒ **404** (route not advertised).
- RS-2: fail-closes with 503 unless `PYMTHOUSE_PUBLIC_CLIENT_ID` is the pymthouse **test** app id.

## Env (ops — not in this PR)
| Name | Purpose |
|------|---------|
| `MCP_INTERNAL_MINT_SECRET` | Shared Bearer secret with Storyboard |
| `MCP_INTERNAL_MINT_ALLOWLIST` | Comma-separated Origins / `X-Mcp-Caller-Origin` values |
| `PYMTHOUSE_M2M_CLIENT_ID` / `PYMTHOUSE_M2M_CLIENT_SECRET` | Existing M2M (mint) |
| `PYMTHOUSE_PUBLIC_CLIENT_ID` | Must be test app `app_98575870…` |

Do **not** enable risky Storyboard OAuth flags in prod for this. Prefer Preview wiring first.

## Test plan
- [x] Unit tests: 404 absent config, 401 bad secret, 403 bad origin, 503 wrong app, 200 mint shape, S2S caller header, 502 no leak
- [ ] After OA-1 wired on NaaP Preview: mint one throwaway `externalUserId` (no secret values in comments)
- [ ] Confirm route 404s on prod until configured

## Self-review
- [x] no existing NaaP route behavior changed
- [x] composite never logged
- [x] test-app assertion present and failing-closed
- [x] reuses `createPymthouseApiKey` (which calls `readM2mAuthHeader`) — no Basic re-implementation
- [x] secret-scan clean


Made with [Cursor](https://cursor.com)