### PR TITLE
feat(mcp-oauth): NaaP login bridge for Scenario A (/login?mcp_oauth=1)

### DIFF
--- a/apps/web-next/src/app/(auth)/login/login-form.tsx
+++ b/apps/web-next/src/app/(auth)/login/login-form.tsx
@@ -86,6 +86,7 @@ export default function LoginForm() {
         searchParams.get('callbackUrl') ||
         searchParams.get('redirect') ||
         '/dashboard';
+      // Relative same-origin paths only (includes /api/v1/auth/mcp/complete).
       const safeRedirect =
         raw.startsWith('/') && !raw.startsWith('//') ? raw : '/dashboard';
       router.replace(safeRedirect);

--- a/apps/web-next/src/app/api/v1/auth/callback/[provider]/route.ts
+++ b/apps/web-next/src/app/api/v1/auth/callback/[provider]/route.ts
@@ -9,6 +9,10 @@ import {
   NAAP_PMTH_DEVICE_APPROVAL_COOKIE,
   tryParseDeviceApprovalCookie,
 } from '@/lib/pymthouse-device-initiate';
+import {
+  NAAP_MCP_OAUTH_PENDING_COOKIE,
+  tryParseMcpOauthPendingCookie,
+} from '@/lib/mcp-oauth-login-bridge';
 
 interface RouteParams {
   params: Promise<{ provider: string }>;
@@ -50,9 +54,14 @@ export async function GET(request: NextRequest, { params }: RouteParams): Promis
     const deviceApproval = await tryParseDeviceApprovalCookie(
       request.cookies.get(NAAP_PMTH_DEVICE_APPROVAL_COOKIE)?.value,
     );
+    const mcpPending = await tryParseMcpOauthPendingCookie(
+      request.cookies.get(NAAP_MCP_OAUTH_PENDING_COOKIE)?.value,
+    );
     const redirectUrl = deviceApproval
       ? new URL('/oidc/device-approved', request.url)
-      : new URL('/dashboard', request.url);
+      : mcpPending
+        ? new URL('/api/v1/auth/mcp/complete', request.url)
+        : new URL('/dashboard', request.url);
 
     const response = NextResponse.redirect(redirectUrl);
 

--- a/apps/web-next/src/app/api/v1/auth/mcp/complete/route.ts
+++ b/apps/web-next/src/app/api/v1/auth/mcp/complete/route.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /api/v1/auth/mcp/complete
+ *
+ * Authenticated completion of the Storyboard MCP OAuth login bridge.
+ * Reads the pending cookie set from `/login?mcp_oauth=1`, then redirects to
+ * the allow-listed Storyboard callback with identity (never a composite).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { validateSessionWithExpiry } from '@/lib/api/auth';
+import { getAuthToken } from '@/lib/api/response';
+import {
+  NAAP_MCP_OAUTH_PENDING_COOKIE,
+  buildMcpOauthCallbackUrl,
+  tryParseMcpOauthPendingCookie,
+} from '@/lib/mcp-oauth-login-bridge';
+
+function clearPending(res: NextResponse): NextResponse {
+  res.cookies.set(NAAP_MCP_OAUTH_PENDING_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 0,
+    path: '/',
+  });
+  return res;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const token = getAuthToken(request);
+  if (!token) {
+    const login = new URL('/login', request.url);
+    login.searchParams.set('error', 'mcp_oauth_login_required');
+    return NextResponse.redirect(login);
+  }
+
+  const session = await validateSessionWithExpiry(token);
+  if (!session) {
+    const login = new URL('/login', request.url);
+    login.searchParams.set('error', 'mcp_oauth_login_required');
+    return clearPending(NextResponse.redirect(login));
+  }
+
+  const pending = await tryParseMcpOauthPendingCookie(
+    request.cookies.get(NAAP_MCP_OAUTH_PENDING_COOKIE)?.value,
+  );
+  if (!pending) {
+    return clearPending(NextResponse.redirect(new URL('/dashboard', request.url)));
+  }
+
+  try {
+    const target = await buildMcpOauthCallbackUrl({
+      pending,
+      externalUserId: session.user.id,
+      email: session.user.email,
+    });
+    return clearPending(NextResponse.redirect(target));
+  } catch (err) {
+    console.error('[mcp-oauth-complete] failed to build callback', err);
+    const login = new URL('/login', request.url);
+    login.searchParams.set('error', 'mcp_oauth_failed');
+    return clearPending(NextResponse.redirect(login));
+  }
+}

--- a/apps/web-next/src/app/api/v1/auth/mcp/identity/route.ts
+++ b/apps/web-next/src/app/api/v1/auth/mcp/identity/route.ts
@@ -1,0 +1,40 @@
+/**
+ * POST /api/v1/auth/mcp/identity
+ *
+ * Exchange a short-lived signed MCP identity code (from the login-bridge
+ * callback) for `{ externalUserId, email }`. Used by Storyboard's naap
+ * BillingProvider when the callback does not already carry external_user_id.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { consumeMcpOauthIdentityCode } from '@/lib/mcp-oauth-login-bridge';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: { code?: unknown };
+  try {
+    body = (await request.json()) as { code?: unknown };
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  if (!code) {
+    return NextResponse.json({ error: 'code_required' }, { status: 400 });
+  }
+
+  const identity = await consumeMcpOauthIdentityCode(code);
+  if (!identity) {
+    return NextResponse.json({ error: 'invalid_or_expired_code' }, { status: 401 });
+  }
+
+  const res = NextResponse.json({
+    externalUserId: identity.externalUserId,
+    email: identity.email,
+  });
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}

--- a/apps/web-next/src/lib/mcp-oauth-login-bridge.test.ts
+++ b/apps/web-next/src/lib/mcp-oauth-login-bridge.test.ts
@@ -1,0 +1,89 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildMcpOauthCallbackUrl,
+  consumeMcpOauthIdentityCode,
+  encodeMcpOauthPendingCookie,
+  isAllowedMcpOauthRedirectUri,
+  mintMcpOauthIdentityCode,
+  tryParseMcpOauthPendingCookie,
+} from '@/lib/mcp-oauth-login-bridge';
+
+const ORIGIN = 'https://storyboard.example';
+const CALLBACK = `${ORIGIN}/api/mcp/oauth/callback`;
+
+describe('mcp-oauth-login-bridge', () => {
+  const prev: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of [
+      'MCP_INTERNAL_MINT_ALLOWLIST',
+      'MCP_OAUTH_REDIRECT_ALLOWLIST',
+      'MCP_OAUTH_BRIDGE_SECRET',
+      'NEXTAUTH_SECRET',
+      'MCP_INTERNAL_MINT_SECRET',
+    ]) {
+      prev[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.MCP_INTERNAL_MINT_ALLOWLIST = ORIGIN;
+    process.env.NEXTAUTH_SECRET = 'test-bridge-secret-for-hmac';
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('allowlists Storyboard callback derived from mint allowlist origins', () => {
+    expect(isAllowedMcpOauthRedirectUri(CALLBACK)).toBe(true);
+    expect(isAllowedMcpOauthRedirectUri(`${ORIGIN}/evil`)).toBe(false);
+    expect(isAllowedMcpOauthRedirectUri(`${CALLBACK}?x=1`)).toBe(false);
+  });
+
+  it('round-trips pending cookie and builds callback with identity + code', async () => {
+    const cookie = await encodeMcpOauthPendingCookie({
+      state: 'st_abc',
+      redirectUri: CALLBACK,
+    });
+    const pending = await tryParseMcpOauthPendingCookie(cookie);
+    expect(pending?.state).toBe('st_abc');
+    expect(pending?.redirectUri).toBe(CALLBACK);
+
+    const url = new URL(
+      await buildMcpOauthCallbackUrl({
+        pending: pending!,
+        externalUserId: 'user-42',
+        email: 'a@b.c',
+      }),
+    );
+    expect(url.origin + url.pathname).toBe(CALLBACK);
+    expect(url.searchParams.get('state')).toBe('st_abc');
+    expect(url.searchParams.get('external_user_id')).toBe('user-42');
+    expect(url.searchParams.get('email')).toBe('a@b.c');
+    const code = url.searchParams.get('code');
+    expect(code).toMatch(/^mcp_id_/);
+    await expect(consumeMcpOauthIdentityCode(code!)).resolves.toEqual({
+      externalUserId: 'user-42',
+      email: 'a@b.c',
+    });
+  });
+
+  it('rejects pending cookie when redirect is not allowlisted', async () => {
+    await expect(
+      encodeMcpOauthPendingCookie({
+        state: 'st',
+        redirectUri: 'https://evil.example/callback',
+      }),
+    ).rejects.toThrow(/redirect_not_allowed/);
+  });
+
+  it('rejects forged identity codes', async () => {
+    const code = await mintMcpOauthIdentityCode({ externalUserId: 'u1' });
+    await expect(consumeMcpOauthIdentityCode(code.replace(/.$/, 'x'))).resolves.toBeNull();
+  });
+});

--- a/apps/web-next/src/lib/mcp-oauth-login-bridge.ts
+++ b/apps/web-next/src/lib/mcp-oauth-login-bridge.ts
@@ -1,0 +1,272 @@
+/**
+ * MCP OAuth Scenario A login bridge (Storyboard → NaaP `/login?mcp_oauth=1`).
+ *
+ * After Google/GitHub (or password) sign-in, NaaP redirects back to Storyboard's
+ * broker callback with the NaaP user id. Redirect URIs must be allow-listed
+ * (derived from MCP_OAUTH_REDIRECT_ALLOWLIST and/or MCP_INTERNAL_MINT_ALLOWLIST
+ * origins + `/api/mcp/oauth/callback`). Absent allow-list config, the bridge
+ * is inert.
+ *
+ * Cookie signing uses Web Crypto so this module is safe to import from Edge
+ * middleware (same pattern as pymthouse-device-initiate).
+ */
+
+export const NAAP_MCP_OAUTH_PENDING_COOKIE = 'naap_mcp_oauth_pending';
+
+const PENDING_TTL_MS = 10 * 60 * 1000;
+const IDENTITY_CODE_TTL_MS = 5 * 60 * 1000;
+const CALLBACK_PATH = '/api/mcp/oauth/callback';
+
+export interface McpOauthPending {
+  state: string;
+  redirectUri: string;
+  exp: number;
+}
+
+export interface McpOauthIdentityPayload {
+  externalUserId: string;
+  email?: string;
+  exp: number;
+  nonce: string;
+}
+
+function cookieSecret(): string | null {
+  const secret =
+    process.env.MCP_OAUTH_BRIDGE_SECRET?.trim() ||
+    process.env.NEXTAUTH_SECRET?.trim() ||
+    process.env.MCP_INTERNAL_MINT_SECRET?.trim() ||
+    null;
+  return secret && secret.length > 0 ? secret : null;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  const base64 =
+    typeof btoa === 'function'
+      ? btoa(binary)
+      : Buffer.from(binary, 'binary').toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlToBytes(value: string): Uint8Array | null {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  try {
+    const binary =
+      typeof atob === 'function'
+        ? atob(padded)
+        : Buffer.from(padded, 'base64').toString('binary');
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+async function importHmacKey(secret: string, usages: KeyUsage[]): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    usages,
+  );
+}
+
+async function signPayload(serializedPayload: string, secret: string): Promise<string> {
+  const key = await importHmacKey(secret, ['sign']);
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(serializedPayload),
+  );
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+async function verifyPayload(
+  serializedPayload: string,
+  providedSignatureBytes: Uint8Array,
+  secret: string,
+): Promise<boolean> {
+  const key = await importHmacKey(secret, ['verify']);
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    new Uint8Array(providedSignatureBytes),
+    new TextEncoder().encode(serializedPayload),
+  );
+}
+
+function randomNonceHex(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Build the set of exact redirect_uri values permitted for the MCP bridge. */
+export function mcpOauthRedirectAllowlist(
+  env: NodeJS.ProcessEnv = process.env,
+): Set<string> {
+  const out = new Set<string>();
+  const explicit = env.MCP_OAUTH_REDIRECT_ALLOWLIST?.trim();
+  if (explicit) {
+    for (const part of explicit.split(',')) {
+      const u = part.trim();
+      if (u) out.add(u);
+    }
+  }
+  const mintOrigins = env.MCP_INTERNAL_MINT_ALLOWLIST?.trim();
+  if (mintOrigins) {
+    for (const part of mintOrigins.split(',')) {
+      const origin = part.trim().replace(/\/+$/, '');
+      if (!origin) continue;
+      try {
+        const base = new URL(origin);
+        out.add(new URL(CALLBACK_PATH, base.origin).toString());
+      } catch {
+        /* skip malformed */
+      }
+    }
+  }
+  return out;
+}
+
+export function isAllowedMcpOauthRedirectUri(
+  redirectUri: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const allow = mcpOauthRedirectAllowlist(env);
+  if (allow.size === 0) return false;
+  try {
+    const u = new URL(redirectUri);
+    if (u.username || u.password || u.hash) return false;
+    return allow.has(u.toString());
+  } catch {
+    return false;
+  }
+}
+
+export async function encodeMcpOauthPendingCookie(
+  pending: Omit<McpOauthPending, 'exp'>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  const secret = cookieSecret();
+  if (!secret) {
+    throw new Error('mcp_oauth_bridge_secret_missing');
+  }
+  if (!isAllowedMcpOauthRedirectUri(pending.redirectUri, env)) {
+    throw new Error('mcp_oauth_redirect_not_allowed');
+  }
+  if (!pending.state || pending.state.length > 512) {
+    throw new Error('mcp_oauth_state_invalid');
+  }
+  const body: McpOauthPending = {
+    state: pending.state,
+    redirectUri: pending.redirectUri,
+    exp: Date.now() + PENDING_TTL_MS,
+  };
+  const serializedPayload = bytesToBase64Url(new TextEncoder().encode(JSON.stringify(body)));
+  const signature = await signPayload(serializedPayload, secret);
+  return `${serializedPayload}.${signature}`;
+}
+
+export async function tryParseMcpOauthPendingCookie(
+  raw: string | undefined,
+): Promise<McpOauthPending | null> {
+  if (!raw || raw.length > 8192) return null;
+  const secret = cookieSecret();
+  if (!secret) return null;
+  const sep = raw.lastIndexOf('.');
+  if (sep <= 0) return null;
+  const serializedPayload = raw.slice(0, sep);
+  const providedSignature = raw.slice(sep + 1);
+  const providedBytes = base64UrlToBytes(providedSignature);
+  if (!providedBytes) return null;
+  const valid = await verifyPayload(serializedPayload, providedBytes, secret);
+  if (!valid) return null;
+  try {
+    const payloadBytes = base64UrlToBytes(serializedPayload);
+    if (!payloadBytes) return null;
+    const parsed = JSON.parse(new TextDecoder().decode(payloadBytes)) as McpOauthPending;
+    if (!parsed?.state || !parsed?.redirectUri || typeof parsed.exp !== 'number') return null;
+    if (Date.now() > parsed.exp) return null;
+    if (!isAllowedMcpOauthRedirectUri(parsed.redirectUri)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function mintMcpOauthIdentityCode(
+  identity: Omit<McpOauthIdentityPayload, 'exp' | 'nonce'>,
+): Promise<string> {
+  const secret = cookieSecret();
+  if (!secret) {
+    throw new Error('mcp_oauth_bridge_secret_missing');
+  }
+  const body: McpOauthIdentityPayload = {
+    externalUserId: identity.externalUserId,
+    email: identity.email,
+    exp: Date.now() + IDENTITY_CODE_TTL_MS,
+    nonce: randomNonceHex(),
+  };
+  const serializedPayload = bytesToBase64Url(new TextEncoder().encode(JSON.stringify(body)));
+  const signature = await signPayload(serializedPayload, secret);
+  return `mcp_id_${serializedPayload}.${signature}`;
+}
+
+export async function consumeMcpOauthIdentityCode(
+  code: string,
+): Promise<{ externalUserId: string; email?: string } | null> {
+  if (!code.startsWith('mcp_id_')) return null;
+  const secret = cookieSecret();
+  if (!secret) return null;
+  const raw = code.slice('mcp_id_'.length);
+  const sep = raw.lastIndexOf('.');
+  if (sep <= 0) return null;
+  const serializedPayload = raw.slice(0, sep);
+  const providedSignature = raw.slice(sep + 1);
+  const providedBytes = base64UrlToBytes(providedSignature);
+  if (!providedBytes) return null;
+  const valid = await verifyPayload(serializedPayload, providedBytes, secret);
+  if (!valid) return null;
+  try {
+    const payloadBytes = base64UrlToBytes(serializedPayload);
+    if (!payloadBytes) return null;
+    const parsed = JSON.parse(
+      new TextDecoder().decode(payloadBytes),
+    ) as McpOauthIdentityPayload;
+    if (!parsed?.externalUserId || typeof parsed.exp !== 'number') return null;
+    if (Date.now() > parsed.exp) return null;
+    return {
+      externalUserId: String(parsed.externalUserId),
+      email: parsed.email ? String(parsed.email) : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Build the Storyboard callback URL with identity (never includes mint secrets). */
+export async function buildMcpOauthCallbackUrl(opts: {
+  pending: McpOauthPending;
+  externalUserId: string;
+  email?: string | null;
+}): Promise<string> {
+  const dest = new URL(opts.pending.redirectUri);
+  dest.searchParams.set('state', opts.pending.state);
+  dest.searchParams.set('external_user_id', opts.externalUserId);
+  if (opts.email) dest.searchParams.set('email', opts.email);
+  const code = await mintMcpOauthIdentityCode({
+    externalUserId: opts.externalUserId,
+    email: opts.email ?? undefined,
+  });
+  dest.searchParams.set('code', code);
+  return dest.toString();
+}

--- a/apps/web-next/src/middleware.ts
+++ b/apps/web-next/src/middleware.ts
@@ -8,6 +8,12 @@ import {
   extractDeviceApprovalTupleFromTargetLink,
   validatePymthouseDeviceInitiateQuery,
 } from '@/lib/pymthouse-device-initiate';
+import {
+  NAAP_MCP_OAUTH_PENDING_COOKIE,
+  encodeMcpOauthPendingCookie,
+  isAllowedMcpOauthRedirectUri,
+  tryParseMcpOauthPendingCookie,
+} from '@/lib/mcp-oauth-login-bridge';
 
 // Plugin route mapping: path prefix → plugin name (camelCase DB name).
 // Maps custom route prefixes to their plugin so the middleware can rewrite
@@ -161,6 +167,57 @@ export async function middleware(request: NextRequest) {
   // Get the auth token from cookies
   const token = request.cookies.get('naap_auth_token')?.value;
 
+  // Storyboard MCP OAuth bridge: /login?mcp_oauth=1&state=&redirect_uri=
+  if (pathname === '/login' && request.method === 'GET') {
+    const mcpOauth = request.nextUrl.searchParams.get('mcp_oauth');
+    if (mcpOauth === '1') {
+      const state = request.nextUrl.searchParams.get('state')?.trim() ?? '';
+      const redirectUri = request.nextUrl.searchParams.get('redirect_uri')?.trim() ?? '';
+      if (!state || !redirectUri || !isAllowedMcpOauthRedirectUri(redirectUri)) {
+        const u = new URL('/login', request.url);
+        u.searchParams.set('error', 'mcp_oauth_invalid');
+        const res = NextResponse.redirect(u);
+        res.headers.set('x-request-id', requestId);
+        res.headers.set('x-trace-id', traceId);
+        return res;
+      }
+      let pendingCookie: string;
+      try {
+        pendingCookie = await encodeMcpOauthPendingCookie({ state, redirectUri });
+      } catch (err) {
+        console.error('[middleware] Failed to encode MCP OAuth pending cookie', err);
+        const u = new URL('/login', request.url);
+        u.searchParams.set('error', 'mcp_oauth_invalid');
+        const res = NextResponse.redirect(u);
+        res.headers.set('x-request-id', requestId);
+        res.headers.set('x-trace-id', traceId);
+        return res;
+      }
+      const pendingOpts = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax' as const,
+        maxAge: 600,
+        path: '/',
+      };
+      if (token) {
+        const complete = new URL('/api/v1/auth/mcp/complete', request.url);
+        const res = NextResponse.redirect(complete);
+        res.cookies.set(NAAP_MCP_OAUTH_PENDING_COOKIE, pendingCookie, pendingOpts);
+        res.headers.set('x-request-id', requestId);
+        res.headers.set('x-trace-id', traceId);
+        return res;
+      }
+      const clean = new URL('/login', request.url);
+      clean.searchParams.set('callbackUrl', '/api/v1/auth/mcp/complete');
+      const res = NextResponse.redirect(clean);
+      res.cookies.set(NAAP_MCP_OAUTH_PENDING_COOKIE, pendingCookie, pendingOpts);
+      res.headers.set('x-request-id', requestId);
+      res.headers.set('x-trace-id', traceId);
+      return res;
+    }
+  }
+
   // PymtHouse OIDC device-flow third-party initiate → NAAP login → /oidc/device-approved (server approve)
   if (pathname === '/login' && request.method === 'GET') {
     const iss = request.nextUrl.searchParams.get('iss');
@@ -298,6 +355,11 @@ export async function middleware(request: NextRequest) {
     if (token) {
       const devicePending = request.cookies.get(NAAP_PMTH_DEVICE_APPROVAL_COOKIE)?.value;
       const allowLoginForDeviceReturn = pathname === '/login' && Boolean(devicePending);
+      const mcpPendingRaw = request.cookies.get(NAAP_MCP_OAUTH_PENDING_COOKIE)?.value;
+      const mcpPending = await tryParseMcpOauthPendingCookie(mcpPendingRaw);
+      if (pathname === '/login' && mcpPending) {
+        return NextResponse.redirect(new URL('/api/v1/auth/mcp/complete', request.url));
+      }
       if (!allowLoginForDeviceReturn) {
         return NextResponse.redirect(new URL('/dashboard', request.url));
       }


### PR DESCRIPTION
## Summary
- Add `/login?mcp_oauth=1&state=&redirect_uri=` bridge used by Storyboard PR-10 `naap` provider.
- After Google/GitHub (or password) sign-in, redirect to allow-listed Storyboard `/api/mcp/oauth/callback` with `external_user_id` (+ signed `code` for optional `/api/v1/auth/mcp/identity` exchange).
- Redirect allow-list from `MCP_OAUTH_REDIRECT_ALLOWLIST` and/or `MCP_INTERNAL_MINT_ALLOWLIST` origins + `/api/mcp/oauth/callback`. Absent allow-list ⇒ bridge inert (error redirect).
- Does **not** flip any OAuth flag; mint still requires Preview env (ops).

## Self-review
- [x] no secrets in commits (placeholders / env only)
- [x] open-redirect prevented (exact allow-list match)
- [x] Edge-safe Web Crypto cookie signing (middleware-importable)
- [x] unit tests for allow-list + cookie/code round-trip
- [x] composite never appears in redirect

## Test plan
- [x] `vitest` `mcp-oauth-login-bridge.test.ts` (4 tests)
- [ ] Preview: set mint allow-list + `NEXTAUTH_SECRET` (or `MCP_OAUTH_BRIDGE_SECRET`); hit `/login?mcp_oauth=1&state=st&redirect_uri=<storyboard-callback>` → sign in → land on Storyboard callback with `external_user_id`
- [ ] Confirm prod mint still 404 without secrets; `MCP_OAUTH_ENABLED` stays unset on Storyboard prod


Made with [Cursor](https://cursor.com)